### PR TITLE
feat: GetPayments returns both incoming and outgoing payments

### DIFF
--- a/services/payment-service/handlers/grpc_server.go
+++ b/services/payment-service/handlers/grpc_server.go
@@ -293,7 +293,7 @@ func (s *PaymentServer) GetPayments(ctx context.Context, req *pb.GetPaymentsRequ
 		       payment_code, reference_number, purpose,
 		       timestamp, status
 		FROM payments
-		WHERE from_account = ANY($1)
+		WHERE (from_account = ANY($1) OR to_account = ANY($1))
 		  AND ($2 = '' OR timestamp >= $2::timestamptz)
 		  AND ($3 = '' OR timestamp <= $3::timestamptz)
 		  AND ($4 = 0 OR initial_amount >= $4)


### PR DESCRIPTION
Include payments where to_account belongs to the client so recipients can see incoming transactions in their payments list.