### PR TITLE
feat(card-service): implement Luhn algorithm, card type detection, an…

### DIFF
--- a/services/card-service/utils/card_number.go
+++ b/services/card-service/utils/card_number.go
@@ -1,0 +1,44 @@
+package utils
+
+import (
+	"fmt"
+	"math/rand"
+)
+
+// miiByBrand returns the Major Industry Identifier digit for the given card brand.
+var miiByBrand = map[string]string{
+	"VISA":             "4",
+	"MASTERCARD":       "5",
+	"DINACARD":         "9",
+	"AMERICAN_EXPRESS": "3",
+}
+
+// GenerateCardNumber generates a valid card number for the given brand and IIN code.
+// iinCode must be exactly 5 digits.
+// Returns 16 digits for Visa/Mastercard/DinaCard, 15 digits for AmEx.
+// The Luhn check digit is computed and appended automatically.
+// Note: uniqueness against the database is the caller's responsibility.
+func GenerateCardNumber(cardName string, iinCode string) string {
+	mii, ok := miiByBrand[cardName]
+	if !ok {
+		mii = "4" // default to Visa MII
+	}
+
+	accountSegmentLen := 9
+	if cardName == "AMERICAN_EXPRESS" {
+		accountSegmentLen = 8
+	}
+
+	accountSegment := fmt.Sprintf("%0*d", accountSegmentLen, rand.Intn(pow10(accountSegmentLen)))
+	partial := mii + iinCode + accountSegment
+	checkDigit := GenerateCheckDigit(partial)
+	return partial + checkDigit
+}
+
+func pow10(n int) int {
+	result := 1
+	for i := 0; i < n; i++ {
+		result *= 10
+	}
+	return result
+}

--- a/services/card-service/utils/card_number_test.go
+++ b/services/card-service/utils/card_number_test.go
@@ -1,0 +1,79 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateCardNumber_LuhnValid(t *testing.T) {
+	for _, brand := range []string{"VISA", "MASTERCARD", "DINACARD", "AMERICAN_EXPRESS"} {
+		n := GenerateCardNumber(brand, "00001")
+		if !ValidateCardNumber(n) {
+			t.Errorf("GenerateCardNumber(%q) = %q, fails Luhn check", brand, n)
+		}
+	}
+}
+
+func TestGenerateCardNumber_Length(t *testing.T) {
+	cases := []struct {
+		brand  string
+		length int
+	}{
+		{"VISA", 16},
+		{"MASTERCARD", 16},
+		{"DINACARD", 16},
+		{"AMERICAN_EXPRESS", 15},
+	}
+	for _, c := range cases {
+		n := GenerateCardNumber(c.brand, "00001")
+		if len(n) != c.length {
+			t.Errorf("GenerateCardNumber(%q) length = %d, want %d (number: %q)", c.brand, len(n), c.length, n)
+		}
+	}
+}
+
+func TestGenerateCardNumber_MII(t *testing.T) {
+	cases := []struct {
+		brand  string
+		prefix string
+	}{
+		{"VISA", "4"},
+		{"MASTERCARD", "5"},
+		{"DINACARD", "9"},
+		{"AMERICAN_EXPRESS", "3"},
+	}
+	for _, c := range cases {
+		n := GenerateCardNumber(c.brand, "00001")
+		if !strings.HasPrefix(n, c.prefix) {
+			t.Errorf("GenerateCardNumber(%q) = %q, want prefix %q", c.brand, n, c.prefix)
+		}
+	}
+}
+
+func TestGenerateCardNumber_BrandDetection(t *testing.T) {
+	cases := []struct {
+		brand   string
+		iinCode string // must be brand-compatible
+	}{
+		{"VISA", "00001"},   // MII "4" + IIN "00001" → prefix "400001"
+		{"AMERICAN_EXPRESS", "40001"}, // MII "3" + IIN "40001" → prefix "340001"
+	}
+	for _, c := range cases {
+		n := GenerateCardNumber(c.brand, c.iinCode)
+		got := DetectCardName(n)
+		if got != c.brand {
+			t.Errorf("DetectCardName(GenerateCardNumber(%q, %q)) = %q, want %q (number: %q)", c.brand, c.iinCode, got, c.brand, n)
+		}
+	}
+}
+
+func TestGenerateCardNumber_Uniqueness(t *testing.T) {
+	seen := make(map[string]bool)
+	for i := 0; i < 10; i++ {
+		n := GenerateCardNumber("VISA", "00001")
+		seen[n] = true
+	}
+	if len(seen) < 2 {
+		t.Error("GenerateCardNumber produced identical numbers across 10 calls")
+	}
+}

--- a/services/card-service/utils/card_type.go
+++ b/services/card-service/utils/card_type.go
@@ -1,0 +1,47 @@
+package utils
+
+import "strconv"
+
+// DetectCardName returns the card brand for the given card number.
+// Returns "VISA", "MASTERCARD", "DINACARD", "AMERICAN_EXPRESS", or "" if unrecognized.
+func DetectCardName(cardNumber string) string {
+	n := len(cardNumber)
+
+	// American Express: 15 digits, prefix 34 or 37
+	if n == 15 && len(cardNumber) >= 2 {
+		prefix2 := cardNumber[:2]
+		if prefix2 == "34" || prefix2 == "37" {
+			return "AMERICAN_EXPRESS"
+		}
+	}
+
+	if n != 16 {
+		return ""
+	}
+
+	// DinaCard: prefix 9891
+	if len(cardNumber) >= 4 && cardNumber[:4] == "9891" {
+		return "DINACARD"
+	}
+
+	// Mastercard: prefix 51–55 or 2221–2720
+	if len(cardNumber) >= 2 {
+		prefix2 := cardNumber[:2]
+		if prefix2 >= "51" && prefix2 <= "55" {
+			return "MASTERCARD"
+		}
+	}
+	if len(cardNumber) >= 4 {
+		prefix4, err := strconv.Atoi(cardNumber[:4])
+		if err == nil && prefix4 >= 2221 && prefix4 <= 2720 {
+			return "MASTERCARD"
+		}
+	}
+
+	// Visa: prefix 4
+	if cardNumber[0] == '4' {
+		return "VISA"
+	}
+
+	return ""
+}

--- a/services/card-service/utils/card_type_test.go
+++ b/services/card-service/utils/card_type_test.go
@@ -1,0 +1,28 @@
+package utils
+
+import "testing"
+
+func TestDetectCardName(t *testing.T) {
+	cases := []struct {
+		number string
+		want   string
+	}{
+		{"4111111111111111", "VISA"},
+		{"4532015112830366", "VISA"},
+		{"5105105105105100", "MASTERCARD"}, // prefix 51
+		{"5425233430109903", "MASTERCARD"}, // prefix 54
+		{"2221000000000009", "MASTERCARD"}, // prefix 2221 (lower bound)
+		{"2720000000000005", "MASTERCARD"}, // prefix 2720 (upper bound)
+		{"9891000000000001", "DINACARD"},
+		{"371449635398431", "AMERICAN_EXPRESS"},  // prefix 37, 15 digits
+		{"341234567890123", "AMERICAN_EXPRESS"},  // prefix 34, 15 digits
+		{"9999999999999999", ""},                 // unrecognized
+		{"1234567890123456", ""},                 // unrecognized prefix
+	}
+	for _, c := range cases {
+		got := DetectCardName(c.number)
+		if got != c.want {
+			t.Errorf("DetectCardName(%q) = %q, want %q", c.number, got, c.want)
+		}
+	}
+}

--- a/services/card-service/utils/luhn.go
+++ b/services/card-service/utils/luhn.go
@@ -1,0 +1,41 @@
+package utils
+
+import "fmt"
+
+// ValidateCardNumber returns true if the card number passes the Luhn check.
+func ValidateCardNumber(cardNumber string) bool {
+	sum := 0
+	double := false
+	for i := len(cardNumber) - 1; i >= 0; i-- {
+		d := int(cardNumber[i] - '0')
+		if double {
+			d *= 2
+			if d > 9 {
+				d -= 9
+			}
+		}
+		sum += d
+		double = !double
+	}
+	return sum%10 == 0
+}
+
+// GenerateCheckDigit takes the partial card number (all digits except the last)
+// and returns the single check digit that makes the full number Luhn-valid.
+func GenerateCheckDigit(partial string) string {
+	// Append a 0 placeholder and run Luhn; the check digit is (10 - sum%10) % 10.
+	sum := 0
+	double := true // the placeholder 0 is at position 0 from right, so next (partial's last) is doubled
+	for i := len(partial) - 1; i >= 0; i-- {
+		d := int(partial[i] - '0')
+		if double {
+			d *= 2
+			if d > 9 {
+				d -= 9
+			}
+		}
+		sum += d
+		double = !double
+	}
+	return fmt.Sprintf("%d", (10-sum%10)%10)
+}

--- a/services/card-service/utils/luhn_test.go
+++ b/services/card-service/utils/luhn_test.go
@@ -1,0 +1,47 @@
+package utils
+
+import (
+	"testing"
+)
+
+func TestValidateCardNumber_KnownValid(t *testing.T) {
+	valid := []string{
+		"4532015112830366", // Visa
+		"5425233430109903", // Mastercard
+		"378282246310005",  // AmEx (15 digits)
+		"6011111111111117", // Luhn-valid (any brand)
+	}
+	for _, n := range valid {
+		if !ValidateCardNumber(n) {
+			t.Errorf("ValidateCardNumber(%q) = false, want true", n)
+		}
+	}
+}
+
+func TestValidateCardNumber_Tampered(t *testing.T) {
+	// Flip last digit of each known-valid number — should fail
+	tampered := []string{
+		"4532015112830367",
+		"5425233430109904",
+		"378282246310006",
+	}
+	for _, n := range tampered {
+		if ValidateCardNumber(n) {
+			t.Errorf("ValidateCardNumber(%q) = true, want false (tampered)", n)
+		}
+	}
+}
+
+func TestGenerateCheckDigit_ProducesValidNumber(t *testing.T) {
+	partials := []string{
+		"453201511283036", // Visa partial (15 digits)
+		"542523343010990", // Mastercard partial (15 digits)
+		"37828224631000",  // AmEx partial (14 digits)
+	}
+	for _, p := range partials {
+		full := p + GenerateCheckDigit(p)
+		if !ValidateCardNumber(full) {
+			t.Errorf("partial %q + check digit = %q, but ValidateCardNumber = false", p, full)
+		}
+	}
+}


### PR DESCRIPTION
…d card number generation (#83, #84, #82)

- Luhn: ValidateCardNumber and GenerateCheckDigit utilities
- Card type: DetectCardName for Visa, Mastercard, DinaCard, AmEx
- Card number: GenerateCardNumber with MII + IIN + account segment + check digit
- Full unit test coverage for all three utilities