### PR TITLE
feat(#78): bank internal accounts + exchange intermediary flow

### DIFF
--- a/services/account-service/db/schema.sql
+++ b/services/account-service/db/schema.sql
@@ -51,3 +51,19 @@ CREATE TABLE accounts (
     maintenance_fee     NUMERIC(20, 2) NOT NULL DEFAULT 0,
     company_id          BIGINT REFERENCES companies(id)
 );
+
+-- Bank internal accounts (issue #78) — one per supported currency, used as intermediaries
+-- in exchange transactions. owner_id = 0 identifies these as bank-owned; they are never
+-- returned to regular clients. currency_id values match the insertion order in
+-- exchange-service/db/schema.sql: 1=RSD, 2=EUR, 3=CHF, 4=USD, 5=GBP, 6=JPY, 7=CAD, 8=AUD.
+INSERT INTO accounts (account_number, account_name, owner_id, employee_id, currency_id, account_type, balance, available_balance)
+VALUES
+  ('BANK-RSD-001', 'Bank Internal RSD Account', 0, 0, 1, 'BANK', 1000000000, 1000000000),
+  ('BANK-EUR-001', 'Bank Internal EUR Account', 0, 0, 2, 'BANK', 10000000,   10000000),
+  ('BANK-CHF-001', 'Bank Internal CHF Account', 0, 0, 3, 'BANK', 10000000,   10000000),
+  ('BANK-USD-001', 'Bank Internal USD Account', 0, 0, 4, 'BANK', 10000000,   10000000),
+  ('BANK-GBP-001', 'Bank Internal GBP Account', 0, 0, 5, 'BANK', 10000000,   10000000),
+  ('BANK-JPY-001', 'Bank Internal JPY Account', 0, 0, 6, 'BANK', 1000000000, 1000000000),
+  ('BANK-CAD-001', 'Bank Internal CAD Account', 0, 0, 7, 'BANK', 10000000,   10000000),
+  ('BANK-AUD-001', 'Bank Internal AUD Account', 0, 0, 8, 'BANK', 10000000,   10000000)
+ON CONFLICT (account_number) DO NOTHING;

--- a/services/exchange-service/handlers/grpc_server.go
+++ b/services/exchange-service/handlers/grpc_server.go
@@ -257,7 +257,24 @@ func (s *ExchangeServer) ConvertAmount(ctx context.Context, req *pb.ConvertAmoun
 
 	commissionAmount := math.Round((req.Amount*commission)*100) / 100
 
-	// 7. Update account balances in account_db transaction
+	// 6b. Look up bank intermediary accounts (issue #78)
+	var bankFromAcct, bankToAcct string
+	if err := s.AccountDB.QueryRowContext(ctx,
+		`SELECT account_number FROM accounts WHERE owner_id = 0 AND account_type = 'BANK' AND currency_id = $1`,
+		fromCurrencyID,
+	).Scan(&bankFromAcct); err != nil {
+		return nil, status.Errorf(codes.Internal, "bank intermediary account not found for source currency: %v", err)
+	}
+	if err := s.AccountDB.QueryRowContext(ctx,
+		`SELECT account_number FROM accounts WHERE owner_id = 0 AND account_type = 'BANK' AND currency_id = $1`,
+		toCurrencyID,
+	).Scan(&bankToAcct); err != nil {
+		return nil, status.Errorf(codes.Internal, "bank intermediary account not found for destination currency: %v", err)
+	}
+
+	// 7. Update account balances via bank intermediary (issue #78)
+	// Step 1: user fromAccount → bank fromCurrency account
+	// Step 2: bank toCurrency account → user toAccount
 	tx, err := s.AccountDB.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to begin transaction: %v", err)
@@ -268,6 +285,16 @@ func (s *ExchangeServer) ConvertAmount(ctx context.Context, req *pb.ConvertAmoun
 		UPDATE accounts SET balance = balance - $1, available_balance = available_balance - $1
 		WHERE account_number = $2`, req.Amount, req.FromAccount); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to debit source account: %v", err)
+	}
+	if _, err = tx.ExecContext(ctx, `
+		UPDATE accounts SET balance = balance + $1, available_balance = available_balance + $1
+		WHERE account_number = $2`, req.Amount, bankFromAcct); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to credit bank source account: %v", err)
+	}
+	if _, err = tx.ExecContext(ctx, `
+		UPDATE accounts SET balance = balance - $1, available_balance = available_balance - $1
+		WHERE account_number = $2`, toAmount, bankToAcct); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to debit bank destination account: %v", err)
 	}
 	if _, err = tx.ExecContext(ctx, `
 		UPDATE accounts SET balance = balance + $1, available_balance = available_balance + $1


### PR DESCRIPTION
## Summary
- `account-service/db/schema.sql`: seed bank internal accounts for all 8 supported currencies (`owner_id=0`, `account_type='BANK'`); not visible to regular clients
- `exchange-service` `ConvertAmount`: money now routes through bank intermediary accounts instead of direct balance update — user → bank (fromCurrency), bank (toCurrency) → user

Closes #78

## Test plan
- [ ] Reset account-db and verify 8 BANK accounts are auto-seeded on startup
- [ ] Perform a conversion (e.g. RSD → GBP) — confirm user balances update correctly and BANK-RSD / BANK-GBP balances reflect the intermediary flow
- [ ] Perform a foreign-to-foreign conversion (e.g. GBP → AUD) — confirm both bank accounts are updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)