### PR TITLE
fix(email): translate card confirmation email to English with HTML te…

### DIFF
--- a/services/email-service/main.go
+++ b/services/email-service/main.go
@@ -115,11 +115,16 @@ func main() {
 		log.Fatalf("failed to parse account created email template: %v", err)
 	}
 
+	cardConfirmTmpl, err := template.ParseFiles("templates/card_confirmation.html")
+	if err != nil {
+		log.Fatalf("failed to parse card confirmation email template: %v", err)
+	}
+
 	go queue.Consume(consumeCh, smtpCfg, tmpl)
 	go queue.ConsumePasswordReset(resetConsumeCh, smtpCfg, resetTmpl)
 	go queue.ConsumePasswordConfirmation(confirmConsumeCh, smtpCfg, confirmTmpl)
 	go queue.ConsumeAccountCreated(accountCreatedConsumeCh, smtpCfg, accountCreatedTmpl)
-	go queue.ConsumeCardConfirmation(cardConfirmConsumeCh, smtpCfg, nil)
+	go queue.ConsumeCardConfirmation(cardConfirmConsumeCh, smtpCfg, cardConfirmTmpl)
 
 	lis, err := net.Listen("tcp", ":50053")
 	if err != nil {

--- a/services/email-service/queue/consumer.go
+++ b/services/email-service/queue/consumer.go
@@ -183,7 +183,7 @@ func ConsumeCardConfirmation(ch *amqp.Channel, cfg SMTPConfig, tmpl *template.Te
 			continue
 		}
 
-		if err := sendCardConfirmationEmail(cfg, msg); err != nil {
+		if err := sendCardConfirmationEmail(cfg, tmpl, msg); err != nil {
 			log.Printf("failed to send card confirmation email to %s: %v", msg.Email, err)
 		} else {
 			log.Printf("card confirmation email sent to %s", msg.Email)
@@ -193,16 +193,20 @@ func ConsumeCardConfirmation(ch *amqp.Channel, cfg SMTPConfig, tmpl *template.Te
 	}
 }
 
-func sendCardConfirmationEmail(cfg SMTPConfig, msg CardConfirmationMessage) error {
-	body := "<p>Poštovani " + msg.FirstName + ",</p>" +
-		"<p>Vaš kod za potvrdu zahteva za karticu je: <strong>" + msg.ConfirmationCode + "</strong></p>" +
-		"<p>Kod važi 15 minuta. Ako niste podneli ovaj zahtev, ignorišite ovu poruku.</p>"
+func sendCardConfirmationEmail(cfg SMTPConfig, tmpl *template.Template, msg CardConfirmationMessage) error {
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, map[string]string{
+		"FirstName":        msg.FirstName,
+		"ConfirmationCode": msg.ConfirmationCode,
+	}); err != nil {
+		return err
+	}
 
 	m := gomail.NewMessage()
 	m.SetHeader("From", cfg.From)
 	m.SetHeader("To", msg.Email)
-	m.SetHeader("Subject", "Potvrda zahteva za karticu — AnkaBanka")
-	m.SetBody("text/html", body)
+	m.SetHeader("Subject", "Card Request Confirmation — AnkaBanka")
+	m.SetBody("text/html", buf.String())
 
 	d := gomail.NewDialer(cfg.Host, cfg.Port, cfg.User, cfg.Password)
 	return d.DialAndSend(m)

--- a/services/email-service/templates/card_confirmation.html
+++ b/services/email-service/templates/card_confirmation.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Card Request Confirmation</title>
+</head>
+<body style="font-family: sans-serif; background: #f8f9fa; padding: 40px;">
+  <div style="max-width: 520px; margin: 0 auto; background: #fff; border-radius: 8px; padding: 40px; box-shadow: 0 2px 8px rgba(0,0,0,0.08);">
+    <h2 style="color: #4f46e5; margin-bottom: 8px;">AnkaBanka</h2>
+    <p>Dear {{.FirstName}},</p>
+    <p>Your confirmation code for the card request is:</p>
+    <div style="text-align: center; margin: 32px 0;">
+      <span style="font-size: 32px; font-weight: bold; letter-spacing: 8px; color: #4f46e5; font-family: monospace;">{{.ConfirmationCode}}</span>
+    </div>
+    <p style="color: #6b7280; font-size: 14px;">The code is valid for <strong>15 minutes</strong>. If you did not submit this request, please ignore this message.</p>
+    <p style="color: #6b7280; font-size: 14px;">Best regards,<br><strong>AnkaBanka Team</strong></p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
…mplate (#115)

- Add card_confirmation.html template matching existing email style
- Update sendCardConfirmationEmail to use template instead of inline HTML
- Wire cardConfirmTmpl in main.go (was passing nil)