### PR TITLE
feat(#63): account_type is now personal/business, subtype separate

### DIFF
--- a/services/account-service/handlers/grpc_server.go
+++ b/services/account-service/handlers/grpc_server.go
@@ -167,7 +167,8 @@ func (s *AccountServer) RenameAccount(ctx context.Context, req *pb.RenameAccount
 
 func (s *AccountServer) GetAllAccounts(ctx context.Context, _ *pb.GetAllAccountsRequest) (*pb.GetAllAccountsResponse, error) {
 	rows, err := s.DB.QueryContext(ctx,
-		`SELECT id, account_number, account_name, owner_id, account_type, currency_id, available_balance
+		`SELECT id, account_number, account_name, owner_id, account_type, currency_id, available_balance,
+		        COALESCE(account_subtype, '')
 		 FROM accounts
 		 WHERE account_type != 'BANK'
 		 ORDER BY id DESC`)
@@ -184,11 +185,12 @@ func (s *AccountServer) GetAllAccounts(ctx context.Context, _ *pb.GetAllAccounts
 		accountType      string
 		currencyID       int64
 		availableBalance float64
+		accountSubtype   string
 	}
 	var accs []row
 	for rows.Next() {
 		var r row
-		if err := rows.Scan(&r.id, &r.accountNumber, &r.accountName, &r.ownerID, &r.accountType, &r.currencyID, &r.availableBalance); err != nil {
+		if err := rows.Scan(&r.id, &r.accountNumber, &r.accountName, &r.ownerID, &r.accountType, &r.currencyID, &r.availableBalance, &r.accountSubtype); err != nil {
 			return nil, status.Errorf(codes.Internal, "failed to scan account: %v", err)
 		}
 		accs = append(accs, r)
@@ -233,24 +235,21 @@ func (s *AccountServer) GetAllAccounts(ctx context.Context, _ *pb.GetAllAccounts
 			AccountType:      a.accountType,
 			CurrencyCode:     currencyMap[a.currencyID],
 			AvailableBalance: a.availableBalance,
+			AccountSubtype:   a.accountSubtype,
 		})
 	}
 	return &pb.GetAllAccountsResponse{Accounts: items}, nil
 }
 
-// accountTypeCode maps account type string to 2-digit code used in account number generation.
+// accountTypeCode maps account category to 2-digit code used in account number generation.
 func accountTypeCode(accountType string) string {
 	switch accountType {
-	case "CURRENT":
+	case "personal":
 		return "01"
-	case "SAVINGS":
-		return "02"
-	case "FOREIGN_CURRENCY":
-		return "03"
-	case "BUSINESS":
+	case "business":
 		return "04"
 	default:
-		return "00"
+		return "01"
 	}
 }
 
@@ -286,9 +285,9 @@ func (s *AccountServer) CreateAccount(ctx context.Context, req *pb.CreateAccount
 	// 4. Set expiration date 5 years from now
 	expirationDate := time.Now().AddDate(5, 0, 0).Format("2006-01-02")
 
-	// 5. Resolve company for BUSINESS accounts
+	// 5. Resolve company for business accounts
 	var companyID *int64
-	if req.AccountType == "BUSINESS" && req.CompanyData != nil && req.CompanyData.Name != "" {
+	if req.AccountType == "business" && req.CompanyData != nil && req.CompanyData.Name != "" {
 		var cid int64
 		err = s.DB.QueryRowContext(ctx,
 			`SELECT id FROM companies WHERE registration_number = $1`,

--- a/services/api-gateway/handlers/accounts.go
+++ b/services/api-gateway/handlers/accounts.go
@@ -301,6 +301,7 @@ func GetAllAccounts(accountClient pb.AccountServiceClient) gin.HandlerFunc {
 				"ownerFirstName":   a.OwnerFirstName,
 				"ownerLastName":    a.OwnerLastName,
 				"accountType":      a.AccountType,
+				"accountSubtype":   a.AccountSubtype,
 				"currencyCode":     a.CurrencyCode,
 				"availableBalance": a.AvailableBalance,
 			})

--- a/shared/pb/account/account.pb.go
+++ b/shared/pb/account/account.pb.go
@@ -1052,6 +1052,7 @@ type AccountListItem struct {
 	AccountType      string                 `protobuf:"bytes,7,opt,name=account_type,json=accountType,proto3" json:"account_type,omitempty"`
 	CurrencyCode     string                 `protobuf:"bytes,8,opt,name=currency_code,json=currencyCode,proto3" json:"currency_code,omitempty"`
 	AvailableBalance float64                `protobuf:"fixed64,9,opt,name=available_balance,json=availableBalance,proto3" json:"available_balance,omitempty"`
+	AccountSubtype   string                 `protobuf:"bytes,10,opt,name=account_subtype,json=accountSubtype,proto3" json:"account_subtype,omitempty"`
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache
 }
@@ -1147,6 +1148,13 @@ func (x *AccountListItem) GetAvailableBalance() float64 {
 		return x.AvailableBalance
 	}
 	return 0
+}
+
+func (x *AccountListItem) GetAccountSubtype() string {
+	if x != nil {
+		return x.AccountSubtype
+	}
+	return ""
 }
 
 type GetAllAccountsResponse struct {
@@ -1283,7 +1291,7 @@ const file_account_proto_rawDesc = "" +
 	"dailyLimit\x12#\n" +
 	"\rmonthly_limit\x18\x04 \x01(\x01R\fmonthlyLimit\"\x1d\n" +
 	"\x1bUpdateAccountLimitsResponse\"\x17\n" +
-	"\x15GetAllAccountsRequest\"\xcd\x02\n" +
+	"\x15GetAllAccountsRequest\"\xf6\x02\n" +
 	"\x0fAccountListItem\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\x03R\x02id\x12%\n" +
 	"\x0eaccount_number\x18\x02 \x01(\tR\raccountNumber\x12!\n" +
@@ -1293,7 +1301,9 @@ const file_account_proto_rawDesc = "" +
 	"\x0fowner_last_name\x18\x06 \x01(\tR\rownerLastName\x12!\n" +
 	"\faccount_type\x18\a \x01(\tR\vaccountType\x12#\n" +
 	"\rcurrency_code\x18\b \x01(\tR\fcurrencyCode\x12+\n" +
-	"\x11available_balance\x18\t \x01(\x01R\x10availableBalance\"N\n" +
+	"\x11available_balance\x18\t \x01(\x01R\x10availableBalance\x12'\n" +
+	"\x0faccount_subtype\x18\n" +
+	" \x01(\tR\x0eaccountSubtype\"N\n" +
 	"\x16GetAllAccountsResponse\x124\n" +
 	"\baccounts\x18\x01 \x03(\v2\x18.account.AccountListItemR\baccounts2\xfc\x03\n" +
 	"\x0eAccountService\x12N\n" +

--- a/shared/proto/account.proto
+++ b/shared/proto/account.proto
@@ -115,6 +115,7 @@ message AccountListItem {
   string account_type      = 7;
   string currency_code     = 8;
   double available_balance = 9;
+  string account_subtype   = 10;
 }
 
 message GetAllAccountsResponse {


### PR DESCRIPTION
- account_type stores 'personal' or 'business' (replaces CURRENT/SAVINGS/FOREIGN_CURRENCY/BUSINESS)
- account_subtype stores specific subtype (standard, savings, doo, foundation, etc.)
- Foreign currency determined by currency_id, not account_type
- accountTypeCode: personal->01, business->04
- GetAllAccounts now returns account_subtype in response
- Proto: AccountListItem gains account_subtype field (regenerated pb files)
- business company creation check updated from 'BUSINESS' to 'business'