### PR TITLE
Implement loan late payment email notification (#116)

### DIFF
--- a/services/email-service/handlers/grpc_server.go
+++ b/services/email-service/handlers/grpc_server.go
@@ -17,6 +17,7 @@ type Publisher interface {
 	PublishPasswordConfirmation(msg queue.PasswordConfirmationMessage) error
 	PublishAccountCreated(msg queue.AccountCreatedMessage) error
 	PublishCardConfirmation(msg queue.CardConfirmationMessage) error
+	PublishLoanLatePayment(msg queue.LoanLatePaymentMessage) error
 }
 
 type EmailServer struct {
@@ -98,4 +99,22 @@ func (s *EmailServer) SendCardConfirmationEmail(_ context.Context, req *pb.SendC
 		return nil, status.Errorf(codes.Internal, "failed to enqueue email: %v", err)
 	}
 	return &pb.SendCardConfirmationEmailResponse{}, nil
+}
+
+func (s *EmailServer) SendLoanLatePaymentEmail(_ context.Context, req *pb.SendLoanLatePaymentEmailRequest) (*pb.SendLoanLatePaymentEmailResponse, error) {
+	if _, err := mail.ParseAddress(req.Email); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid email address: %v", err)
+	}
+	err := s.Producer.PublishLoanLatePayment(queue.LoanLatePaymentMessage{
+		Email:      req.Email,
+		FirstName:  req.FirstName,
+		LoanNumber: req.LoanNumber,
+		AmountDue:  req.AmountDue,
+		Currency:   req.Currency,
+		RetryCount: req.RetryCount,
+	})
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to enqueue email: %v", err)
+	}
+	return &pb.SendLoanLatePaymentEmailResponse{}, nil
 }

--- a/services/email-service/main.go
+++ b/services/email-service/main.go
@@ -90,6 +90,12 @@ func main() {
 	}
 	defer cardConfirmConsumeCh.Close()
 
+	loanLateConsumeCh, err := conn.Channel()
+	if err != nil {
+		log.Fatalf("failed to open loan late payment consume channel: %v", err)
+	}
+	defer loanLateConsumeCh.Close()
+
 	producer, err := queue.NewProducer(publishCh)
 	if err != nil {
 		log.Fatalf("failed to create producer: %v", err)
@@ -120,11 +126,17 @@ func main() {
 		log.Fatalf("failed to parse card confirmation email template: %v", err)
 	}
 
+	loanLateTmpl, err := template.ParseFiles("templates/loan_late_payment.html")
+	if err != nil {
+		log.Fatalf("failed to parse loan late payment email template: %v", err)
+	}
+
 	go queue.Consume(consumeCh, smtpCfg, tmpl)
 	go queue.ConsumePasswordReset(resetConsumeCh, smtpCfg, resetTmpl)
 	go queue.ConsumePasswordConfirmation(confirmConsumeCh, smtpCfg, confirmTmpl)
 	go queue.ConsumeAccountCreated(accountCreatedConsumeCh, smtpCfg, accountCreatedTmpl)
 	go queue.ConsumeCardConfirmation(cardConfirmConsumeCh, smtpCfg, cardConfirmTmpl)
+	go queue.ConsumeLoanLatePayment(loanLateConsumeCh, smtpCfg, loanLateTmpl)
 
 	lis, err := net.Listen("tcp", ":50053")
 	if err != nil {

--- a/services/email-service/queue/consumer.go
+++ b/services/email-service/queue/consumer.go
@@ -3,6 +3,7 @@ package queue
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"html/template"
 	"log"
 
@@ -236,6 +237,58 @@ func ConsumePasswordConfirmation(ch *amqp.Channel, cfg SMTPConfig, tmpl *templat
 
 		d.Ack(false)
 	}
+}
+
+func ConsumeLoanLatePayment(ch *amqp.Channel, cfg SMTPConfig, tmpl *template.Template) {
+	if _, err := ch.QueueDeclare(LoanLatePaymentQueueName, true, false, false, false, nil); err != nil {
+		log.Fatalf("failed to declare loan late payment queue: %v", err)
+	}
+
+	msgs, err := ch.Consume(LoanLatePaymentQueueName, "", false, false, false, false, nil)
+	if err != nil {
+		log.Fatalf("failed to start loan late payment consumer: %v", err)
+	}
+
+	log.Println("loan late payment email consumer started, waiting for messages")
+
+	for d := range msgs {
+		var msg LoanLatePaymentMessage
+		if err := json.Unmarshal(d.Body, &msg); err != nil {
+			log.Printf("failed to decode loan late payment message: %v", err)
+			d.Ack(false)
+			continue
+		}
+
+		if err := sendLoanLatePaymentEmail(cfg, tmpl, msg); err != nil {
+			log.Printf("failed to send loan late payment email to %s: %v", msg.Email, err)
+		} else {
+			log.Printf("loan late payment email sent to %s", msg.Email)
+		}
+
+		d.Ack(false)
+	}
+}
+
+func sendLoanLatePaymentEmail(cfg SMTPConfig, tmpl *template.Template, msg LoanLatePaymentMessage) error {
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, map[string]string{
+		"FirstName":  msg.FirstName,
+		"LoanNumber": msg.LoanNumber,
+		"AmountDue":  fmt.Sprintf("%.2f", msg.AmountDue),
+		"Currency":   msg.Currency,
+		"RetryCount": fmt.Sprintf("%d", msg.RetryCount),
+	}); err != nil {
+		return err
+	}
+
+	m := gomail.NewMessage()
+	m.SetHeader("From", cfg.From)
+	m.SetHeader("To", msg.Email)
+	m.SetHeader("Subject", "Loan Payment Failed — AnkaBanka")
+	m.SetBody("text/html", buf.String())
+
+	d := gomail.NewDialer(cfg.Host, cfg.Port, cfg.User, cfg.Password)
+	return d.DialAndSend(m)
 }
 
 func sendPasswordConfirmationEmail(cfg SMTPConfig, tmpl *template.Template, msg PasswordConfirmationMessage) error {

--- a/services/email-service/queue/producer.go
+++ b/services/email-service/queue/producer.go
@@ -6,11 +6,12 @@ import (
 	amqp "github.com/rabbitmq/amqp091-go"
 )
 
-const QueueName                 = "email.activation"
-const ResetQueueName            = "email.passwordreset"
-const ConfirmQueueName          = "email.passwordconfirmation"
-const AccountCreatedQueueName   = "email.accountcreated"
-const CardConfirmationQueueName = "email.cardconfirmation"
+const QueueName                  = "email.activation"
+const ResetQueueName             = "email.passwordreset"
+const ConfirmQueueName           = "email.passwordconfirmation"
+const AccountCreatedQueueName    = "email.accountcreated"
+const CardConfirmationQueueName  = "email.cardconfirmation"
+const LoanLatePaymentQueueName   = "email.loanlate"
 
 type ActivationMessage struct {
 	Email          string `json:"email"`
@@ -43,6 +44,15 @@ type CardConfirmationMessage struct {
 	ConfirmationCode string `json:"confirmation_code"`
 }
 
+type LoanLatePaymentMessage struct {
+	Email      string  `json:"email"`
+	FirstName  string  `json:"first_name"`
+	LoanNumber string  `json:"loan_number"`
+	AmountDue  float64 `json:"amount_due"`
+	Currency   string  `json:"currency"`
+	RetryCount int32   `json:"retry_count"`
+}
+
 type Producer struct {
 	ch *amqp.Channel
 }
@@ -61,6 +71,9 @@ func NewProducer(ch *amqp.Channel) (*Producer, error) {
 		return nil, err
 	}
 	if _, err := ch.QueueDeclare(CardConfirmationQueueName, true, false, false, false, nil); err != nil {
+		return nil, err
+	}
+	if _, err := ch.QueueDeclare(LoanLatePaymentQueueName, true, false, false, false, nil); err != nil {
 		return nil, err
 	}
 	return &Producer{ch: ch}, nil
@@ -120,6 +133,18 @@ func (p *Producer) PublishCardConfirmation(msg CardConfirmationMessage) error {
 		return err
 	}
 	return p.ch.Publish("", CardConfirmationQueueName, false, false, amqp.Publishing{
+		ContentType:  "application/json",
+		DeliveryMode: amqp.Persistent,
+		Body:         body,
+	})
+}
+
+func (p *Producer) PublishLoanLatePayment(msg LoanLatePaymentMessage) error {
+	body, err := json.Marshal(msg)
+	if err != nil {
+		return err
+	}
+	return p.ch.Publish("", LoanLatePaymentQueueName, false, false, amqp.Publishing{
 		ContentType:  "application/json",
 		DeliveryMode: amqp.Persistent,
 		Body:         body,

--- a/services/email-service/templates/loan_late_payment.html
+++ b/services/email-service/templates/loan_late_payment.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Loan Payment Failed</title>
+</head>
+<body style="font-family: sans-serif; background: #f8f9fa; padding: 40px;">
+  <div style="max-width: 520px; margin: 0 auto; background: #fff; border-radius: 8px; padding: 40px; box-shadow: 0 2px 8px rgba(0,0,0,0.08);">
+    <h2 style="color: #dc2626; margin-bottom: 8px;">AnkaBanka</h2>
+    <p>Dear {{.FirstName}},</p>
+    <p>We were unable to collect the installment for your loan <strong>#{{.LoanNumber}}</strong>.</p>
+    <div style="background: #fef2f2; border: 1px solid #fecaca; border-radius: 6px; padding: 20px; margin: 24px 0;">
+      <p style="margin: 0; font-size: 16px;"><strong>Amount due:</strong> {{.AmountDue}} {{.Currency}}</p>
+      <p style="margin: 8px 0 0; color: #6b7280; font-size: 14px;">Failed attempts: {{.RetryCount}}</p>
+    </div>
+    <p>Please ensure your account has sufficient funds. We will automatically retry the payment.</p>
+    <p style="color: #dc2626; font-size: 14px;"><strong>Note:</strong> Repeated failed payments may result in a higher interest rate and potential legal action.</p>
+    <p style="color: #6b7280; font-size: 14px;">Best regards,<br><strong>AnkaBanka Team</strong></p>
+  </div>
+</body>
+</html>

--- a/services/loan-service/handlers/cron.go
+++ b/services/loan-service/handlers/cron.go
@@ -3,10 +3,14 @@ package handlers
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"log"
 	"math"
 	"math/rand/v2"
 	"time"
+
+	pb_client "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/client"
+	pb_email "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/email"
 )
 
 const maxRetries = 5
@@ -35,7 +39,7 @@ func (s *LoanServer) collectInstallments() {
 
 	// Find all loans due today (APPROVED) OR IN_DELAY with no retry in last 72h
 	rows, err := s.DB.QueryContext(ctx, `
-		SELECT id, account_number, next_installment_amount, currency, remaining_debt
+		SELECT id, loan_number, client_id, account_number, next_installment_amount, currency, remaining_debt
 		FROM loans
 		WHERE (
 		    (status = 'APPROVED' AND next_installment_date = CURRENT_DATE)
@@ -62,6 +66,8 @@ func (s *LoanServer) collectInstallments() {
 
 	var loans []struct {
 		id            int64
+		loanNumber    int64
+		clientID      int64
 		accountNumber string
 		amount        float64
 		currency      string
@@ -70,12 +76,14 @@ func (s *LoanServer) collectInstallments() {
 	for rows.Next() {
 		var l struct {
 			id            int64
+			loanNumber    int64
+			clientID      int64
 			accountNumber string
 			amount        float64
 			currency      string
 			remainingDebt float64
 		}
-		if err := rows.Scan(&l.id, &l.accountNumber, &l.amount, &l.currency, &l.remainingDebt); err != nil {
+		if err := rows.Scan(&l.id, &l.loanNumber, &l.clientID, &l.accountNumber, &l.amount, &l.currency, &l.remainingDebt); err != nil {
 			log.Printf("loan-service: daily cron scan error: %v", err)
 			continue
 		}
@@ -83,11 +91,11 @@ func (s *LoanServer) collectInstallments() {
 	}
 
 	for _, l := range loans {
-		s.processInstallment(ctx, l.id, l.accountNumber, l.amount, l.currency, l.remainingDebt)
+		s.processInstallment(ctx, l.id, l.loanNumber, l.clientID, l.accountNumber, l.amount, l.currency, l.remainingDebt)
 	}
 }
 
-func (s *LoanServer) processInstallment(ctx context.Context, loanID int64, accountNumber string, amount float64, currency string, remainingDebt float64) {
+func (s *LoanServer) processInstallment(ctx context.Context, loanID int64, loanNumber int64, clientID int64, accountNumber string, amount float64, currency string, remainingDebt float64) {
 	// Find the UNPAID or LATE installment due today or earliest overdue
 	var installmentID int64
 	var retryCount int
@@ -169,7 +177,21 @@ func (s *LoanServer) processInstallment(ctx context.Context, loanID int64, accou
 			log.Printf("loan-service: set IN_DELAY error: %v", err)
 		}
 		log.Printf("loan-service: insufficient funds for loan %d (retry %d)", loanID, newRetry)
-		// TODO: send email notification via email-service
+		if s.EmailClient != nil && s.ClientClient != nil {
+			if clientResp, err := s.ClientClient.GetClientById(ctx, &pb_client.GetClientByIdRequest{Id: clientID}); err == nil {
+				c := clientResp.Client
+				_, _ = s.EmailClient.SendLoanLatePaymentEmail(ctx, &pb_email.SendLoanLatePaymentEmailRequest{
+					Email:      c.Email,
+					FirstName:  c.FirstName,
+					LoanNumber: fmt.Sprintf("%d", loanNumber),
+					AmountDue:  amount,
+					Currency:   currency,
+					RetryCount: int32(newRetry),
+				})
+			} else {
+				log.Printf("loan-service: could not fetch client %d for late payment email: %v", clientID, err)
+			}
+		}
 	}
 }
 

--- a/services/loan-service/handlers/grpc_server.go
+++ b/services/loan-service/handlers/grpc_server.go
@@ -9,6 +9,8 @@ import (
 	"math/big"
 	"time"
 
+	pb_client "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/client"
+	pb_email "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/email"
 	pb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/loan"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -16,9 +18,11 @@ import (
 
 type LoanServer struct {
 	pb.UnimplementedLoanServiceServer
-	DB         *sql.DB // loan_db
-	AccountDB  *sql.DB // account_db
-	ExchangeDB *sql.DB // exchange_db (for currency conversion to determine rate tier)
+	DB           *sql.DB // loan_db
+	AccountDB    *sql.DB // account_db
+	ExchangeDB   *sql.DB // exchange_db (for currency conversion to determine rate tier)
+	EmailClient  pb_email.EmailServiceClient
+	ClientClient pb_client.ClientServiceClient
 }
 
 // --- GetClientLoans ---

--- a/services/loan-service/main.go
+++ b/services/loan-service/main.go
@@ -6,8 +6,11 @@ import (
 
 	loandb "github.com/RAF-SI-2025/EXBanka-4-Backend/services/loan-service/db"
 	"github.com/RAF-SI-2025/EXBanka-4-Backend/services/loan-service/handlers"
+	pb_client "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/client"
+	pb_email "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/email"
 	pb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/loan"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 const (
@@ -36,6 +39,20 @@ func main() {
 	}
 	defer exchangeDB.Close()
 
+	emailConn, err := grpc.NewClient("localhost:50053", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		log.Fatalf("failed to connect to email-service: %v", err)
+	}
+	defer emailConn.Close()
+	emailClient := pb_email.NewEmailServiceClient(emailConn)
+
+	clientConn, err := grpc.NewClient("localhost:50056", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		log.Fatalf("failed to connect to client-service: %v", err)
+	}
+	defer clientConn.Close()
+	clientClient := pb_client.NewClientServiceClient(clientConn)
+
 	lis, err := net.Listen("tcp", grpcPort)
 	if err != nil {
 		log.Fatalf("failed to listen on %s: %v", grpcPort, err)
@@ -43,9 +60,11 @@ func main() {
 
 	srv := grpc.NewServer()
 	loanServer := &handlers.LoanServer{
-		DB:         loanDB,
-		AccountDB:  accountDB,
-		ExchangeDB: exchangeDB,
+		DB:           loanDB,
+		AccountDB:    accountDB,
+		ExchangeDB:   exchangeDB,
+		EmailClient:  emailClient,
+		ClientClient: clientClient,
 	}
 	pb.RegisterLoanServiceServer(srv, loanServer)
 

--- a/shared/pb/email/email.pb.go
+++ b/shared/pb/email/email.pb.go
@@ -421,6 +421,126 @@ func (*SendCardConfirmationEmailResponse) Descriptor() ([]byte, []int) {
 	return file_email_proto_rawDescGZIP(), []int{7}
 }
 
+type SendLoanLatePaymentEmailRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Email         string                 `protobuf:"bytes,1,opt,name=email,proto3" json:"email,omitempty"`
+	FirstName     string                 `protobuf:"bytes,2,opt,name=first_name,json=firstName,proto3" json:"first_name,omitempty"`
+	LoanNumber    string                 `protobuf:"bytes,3,opt,name=loan_number,json=loanNumber,proto3" json:"loan_number,omitempty"`
+	AmountDue     float64                `protobuf:"fixed64,4,opt,name=amount_due,json=amountDue,proto3" json:"amount_due,omitempty"`
+	Currency      string                 `protobuf:"bytes,5,opt,name=currency,proto3" json:"currency,omitempty"`
+	RetryCount    int32                  `protobuf:"varint,6,opt,name=retry_count,json=retryCount,proto3" json:"retry_count,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SendLoanLatePaymentEmailRequest) Reset() {
+	*x = SendLoanLatePaymentEmailRequest{}
+	mi := &file_email_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SendLoanLatePaymentEmailRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SendLoanLatePaymentEmailRequest) ProtoMessage() {}
+
+func (x *SendLoanLatePaymentEmailRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_email_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SendLoanLatePaymentEmailRequest.ProtoReflect.Descriptor instead.
+func (*SendLoanLatePaymentEmailRequest) Descriptor() ([]byte, []int) {
+	return file_email_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *SendLoanLatePaymentEmailRequest) GetEmail() string {
+	if x != nil {
+		return x.Email
+	}
+	return ""
+}
+
+func (x *SendLoanLatePaymentEmailRequest) GetFirstName() string {
+	if x != nil {
+		return x.FirstName
+	}
+	return ""
+}
+
+func (x *SendLoanLatePaymentEmailRequest) GetLoanNumber() string {
+	if x != nil {
+		return x.LoanNumber
+	}
+	return ""
+}
+
+func (x *SendLoanLatePaymentEmailRequest) GetAmountDue() float64 {
+	if x != nil {
+		return x.AmountDue
+	}
+	return 0
+}
+
+func (x *SendLoanLatePaymentEmailRequest) GetCurrency() string {
+	if x != nil {
+		return x.Currency
+	}
+	return ""
+}
+
+func (x *SendLoanLatePaymentEmailRequest) GetRetryCount() int32 {
+	if x != nil {
+		return x.RetryCount
+	}
+	return 0
+}
+
+type SendLoanLatePaymentEmailResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SendLoanLatePaymentEmailResponse) Reset() {
+	*x = SendLoanLatePaymentEmailResponse{}
+	mi := &file_email_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SendLoanLatePaymentEmailResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SendLoanLatePaymentEmailResponse) ProtoMessage() {}
+
+func (x *SendLoanLatePaymentEmailResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_email_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SendLoanLatePaymentEmailResponse.ProtoReflect.Descriptor instead.
+func (*SendLoanLatePaymentEmailResponse) Descriptor() ([]byte, []int) {
+	return file_email_proto_rawDescGZIP(), []int{9}
+}
+
 var File_email_proto protoreflect.FileDescriptor
 
 const file_email_proto_rawDesc = "" +
@@ -452,13 +572,26 @@ const file_email_proto_rawDesc = "" +
 	"\n" +
 	"first_name\x18\x02 \x01(\tR\tfirstName\x12+\n" +
 	"\x11confirmation_code\x18\x03 \x01(\tR\x10confirmationCode\"#\n" +
-	"!SendCardConfirmationEmailResponse2\x95\x04\n" +
+	"!SendCardConfirmationEmailResponse\"\xd3\x01\n" +
+	"\x1fSendLoanLatePaymentEmailRequest\x12\x14\n" +
+	"\x05email\x18\x01 \x01(\tR\x05email\x12\x1d\n" +
+	"\n" +
+	"first_name\x18\x02 \x01(\tR\tfirstName\x12\x1f\n" +
+	"\vloan_number\x18\x03 \x01(\tR\n" +
+	"loanNumber\x12\x1d\n" +
+	"\n" +
+	"amount_due\x18\x04 \x01(\x01R\tamountDue\x12\x1a\n" +
+	"\bcurrency\x18\x05 \x01(\tR\bcurrency\x12\x1f\n" +
+	"\vretry_count\x18\x06 \x01(\x05R\n" +
+	"retryCount\"\"\n" +
+	" SendLoanLatePaymentEmailResponse2\x82\x05\n" +
 	"\fEmailService\x12\\\n" +
 	"\x13SendActivationEmail\x12!.email.SendActivationEmailRequest\x1a\".email.SendActivationEmailResponse\x12e\n" +
 	"\x16SendPasswordResetEmail\x12$.email.SendPasswordResetEmailRequest\x1a%.email.SendPasswordResetEmailResponse\x12f\n" +
 	"\x1dSendPasswordConfirmationEmail\x12!.email.SendActivationEmailRequest\x1a\".email.SendActivationEmailResponse\x12h\n" +
 	"\x17SendAccountCreatedEmail\x12%.email.SendAccountCreatedEmailRequest\x1a&.email.SendAccountCreatedEmailResponse\x12n\n" +
-	"\x19SendCardConfirmationEmail\x12'.email.SendCardConfirmationEmailRequest\x1a(.email.SendCardConfirmationEmailResponseB:Z8github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/emailb\x06proto3"
+	"\x19SendCardConfirmationEmail\x12'.email.SendCardConfirmationEmailRequest\x1a(.email.SendCardConfirmationEmailResponse\x12k\n" +
+	"\x18SendLoanLatePaymentEmail\x12&.email.SendLoanLatePaymentEmailRequest\x1a'.email.SendLoanLatePaymentEmailResponseB:Z8github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/emailb\x06proto3"
 
 var (
 	file_email_proto_rawDescOnce sync.Once
@@ -472,7 +605,7 @@ func file_email_proto_rawDescGZIP() []byte {
 	return file_email_proto_rawDescData
 }
 
-var file_email_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
+var file_email_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
 var file_email_proto_goTypes = []any{
 	(*SendActivationEmailRequest)(nil),        // 0: email.SendActivationEmailRequest
 	(*SendActivationEmailResponse)(nil),       // 1: email.SendActivationEmailResponse
@@ -482,6 +615,8 @@ var file_email_proto_goTypes = []any{
 	(*SendAccountCreatedEmailResponse)(nil),   // 5: email.SendAccountCreatedEmailResponse
 	(*SendCardConfirmationEmailRequest)(nil),  // 6: email.SendCardConfirmationEmailRequest
 	(*SendCardConfirmationEmailResponse)(nil), // 7: email.SendCardConfirmationEmailResponse
+	(*SendLoanLatePaymentEmailRequest)(nil),   // 8: email.SendLoanLatePaymentEmailRequest
+	(*SendLoanLatePaymentEmailResponse)(nil),  // 9: email.SendLoanLatePaymentEmailResponse
 }
 var file_email_proto_depIdxs = []int32{
 	0, // 0: email.EmailService.SendActivationEmail:input_type -> email.SendActivationEmailRequest
@@ -489,13 +624,15 @@ var file_email_proto_depIdxs = []int32{
 	0, // 2: email.EmailService.SendPasswordConfirmationEmail:input_type -> email.SendActivationEmailRequest
 	4, // 3: email.EmailService.SendAccountCreatedEmail:input_type -> email.SendAccountCreatedEmailRequest
 	6, // 4: email.EmailService.SendCardConfirmationEmail:input_type -> email.SendCardConfirmationEmailRequest
-	1, // 5: email.EmailService.SendActivationEmail:output_type -> email.SendActivationEmailResponse
-	3, // 6: email.EmailService.SendPasswordResetEmail:output_type -> email.SendPasswordResetEmailResponse
-	1, // 7: email.EmailService.SendPasswordConfirmationEmail:output_type -> email.SendActivationEmailResponse
-	5, // 8: email.EmailService.SendAccountCreatedEmail:output_type -> email.SendAccountCreatedEmailResponse
-	7, // 9: email.EmailService.SendCardConfirmationEmail:output_type -> email.SendCardConfirmationEmailResponse
-	5, // [5:10] is the sub-list for method output_type
-	0, // [0:5] is the sub-list for method input_type
+	8, // 5: email.EmailService.SendLoanLatePaymentEmail:input_type -> email.SendLoanLatePaymentEmailRequest
+	1, // 6: email.EmailService.SendActivationEmail:output_type -> email.SendActivationEmailResponse
+	3, // 7: email.EmailService.SendPasswordResetEmail:output_type -> email.SendPasswordResetEmailResponse
+	1, // 8: email.EmailService.SendPasswordConfirmationEmail:output_type -> email.SendActivationEmailResponse
+	5, // 9: email.EmailService.SendAccountCreatedEmail:output_type -> email.SendAccountCreatedEmailResponse
+	7, // 10: email.EmailService.SendCardConfirmationEmail:output_type -> email.SendCardConfirmationEmailResponse
+	9, // 11: email.EmailService.SendLoanLatePaymentEmail:output_type -> email.SendLoanLatePaymentEmailResponse
+	6, // [6:12] is the sub-list for method output_type
+	0, // [0:6] is the sub-list for method input_type
 	0, // [0:0] is the sub-list for extension type_name
 	0, // [0:0] is the sub-list for extension extendee
 	0, // [0:0] is the sub-list for field type_name
@@ -512,7 +649,7 @@ func file_email_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_email_proto_rawDesc), len(file_email_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   8,
+			NumMessages:   10,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/shared/pb/email/email_grpc.pb.go
+++ b/shared/pb/email/email_grpc.pb.go
@@ -24,6 +24,7 @@ const (
 	EmailService_SendPasswordConfirmationEmail_FullMethodName = "/email.EmailService/SendPasswordConfirmationEmail"
 	EmailService_SendAccountCreatedEmail_FullMethodName       = "/email.EmailService/SendAccountCreatedEmail"
 	EmailService_SendCardConfirmationEmail_FullMethodName     = "/email.EmailService/SendCardConfirmationEmail"
+	EmailService_SendLoanLatePaymentEmail_FullMethodName      = "/email.EmailService/SendLoanLatePaymentEmail"
 )
 
 // EmailServiceClient is the client API for EmailService service.
@@ -36,6 +37,7 @@ type EmailServiceClient interface {
 	SendPasswordConfirmationEmail(ctx context.Context, in *SendActivationEmailRequest, opts ...grpc.CallOption) (*SendActivationEmailResponse, error)
 	SendAccountCreatedEmail(ctx context.Context, in *SendAccountCreatedEmailRequest, opts ...grpc.CallOption) (*SendAccountCreatedEmailResponse, error)
 	SendCardConfirmationEmail(ctx context.Context, in *SendCardConfirmationEmailRequest, opts ...grpc.CallOption) (*SendCardConfirmationEmailResponse, error)
+	SendLoanLatePaymentEmail(ctx context.Context, in *SendLoanLatePaymentEmailRequest, opts ...grpc.CallOption) (*SendLoanLatePaymentEmailResponse, error)
 }
 
 type emailServiceClient struct {
@@ -96,6 +98,16 @@ func (c *emailServiceClient) SendCardConfirmationEmail(ctx context.Context, in *
 	return out, nil
 }
 
+func (c *emailServiceClient) SendLoanLatePaymentEmail(ctx context.Context, in *SendLoanLatePaymentEmailRequest, opts ...grpc.CallOption) (*SendLoanLatePaymentEmailResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SendLoanLatePaymentEmailResponse)
+	err := c.cc.Invoke(ctx, EmailService_SendLoanLatePaymentEmail_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // EmailServiceServer is the server API for EmailService service.
 // All implementations must embed UnimplementedEmailServiceServer
 // for forward compatibility.
@@ -106,6 +118,7 @@ type EmailServiceServer interface {
 	SendPasswordConfirmationEmail(context.Context, *SendActivationEmailRequest) (*SendActivationEmailResponse, error)
 	SendAccountCreatedEmail(context.Context, *SendAccountCreatedEmailRequest) (*SendAccountCreatedEmailResponse, error)
 	SendCardConfirmationEmail(context.Context, *SendCardConfirmationEmailRequest) (*SendCardConfirmationEmailResponse, error)
+	SendLoanLatePaymentEmail(context.Context, *SendLoanLatePaymentEmailRequest) (*SendLoanLatePaymentEmailResponse, error)
 	mustEmbedUnimplementedEmailServiceServer()
 }
 
@@ -130,6 +143,9 @@ func (UnimplementedEmailServiceServer) SendAccountCreatedEmail(context.Context, 
 }
 func (UnimplementedEmailServiceServer) SendCardConfirmationEmail(context.Context, *SendCardConfirmationEmailRequest) (*SendCardConfirmationEmailResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method SendCardConfirmationEmail not implemented")
+}
+func (UnimplementedEmailServiceServer) SendLoanLatePaymentEmail(context.Context, *SendLoanLatePaymentEmailRequest) (*SendLoanLatePaymentEmailResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method SendLoanLatePaymentEmail not implemented")
 }
 func (UnimplementedEmailServiceServer) mustEmbedUnimplementedEmailServiceServer() {}
 func (UnimplementedEmailServiceServer) testEmbeddedByValue()                      {}
@@ -242,6 +258,24 @@ func _EmailService_SendCardConfirmationEmail_Handler(srv interface{}, ctx contex
 	return interceptor(ctx, in, info, handler)
 }
 
+func _EmailService_SendLoanLatePaymentEmail_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SendLoanLatePaymentEmailRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(EmailServiceServer).SendLoanLatePaymentEmail(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: EmailService_SendLoanLatePaymentEmail_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(EmailServiceServer).SendLoanLatePaymentEmail(ctx, req.(*SendLoanLatePaymentEmailRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // EmailService_ServiceDesc is the grpc.ServiceDesc for EmailService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -268,6 +302,10 @@ var EmailService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "SendCardConfirmationEmail",
 			Handler:    _EmailService_SendCardConfirmationEmail_Handler,
+		},
+		{
+			MethodName: "SendLoanLatePaymentEmail",
+			Handler:    _EmailService_SendLoanLatePaymentEmail_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/shared/proto/email.proto
+++ b/shared/proto/email.proto
@@ -36,6 +36,16 @@ message SendCardConfirmationEmailRequest {
 }
 message SendCardConfirmationEmailResponse {}
 
+message SendLoanLatePaymentEmailRequest {
+  string email       = 1;
+  string first_name  = 2;
+  string loan_number = 3;
+  double amount_due  = 4;
+  string currency    = 5;
+  int32  retry_count = 6;
+}
+message SendLoanLatePaymentEmailResponse {}
+
 service EmailService {
   rpc SendActivationEmail(SendActivationEmailRequest)                 returns (SendActivationEmailResponse);
   rpc SendPasswordResetEmail(SendPasswordResetEmailRequest)           returns (SendPasswordResetEmailResponse);
@@ -43,4 +53,5 @@ service EmailService {
   rpc SendPasswordConfirmationEmail(SendActivationEmailRequest)       returns (SendActivationEmailResponse);
   rpc SendAccountCreatedEmail(SendAccountCreatedEmailRequest)         returns (SendAccountCreatedEmailResponse);
   rpc SendCardConfirmationEmail(SendCardConfirmationEmailRequest)     returns (SendCardConfirmationEmailResponse);
+  rpc SendLoanLatePaymentEmail(SendLoanLatePaymentEmailRequest)       returns (SendLoanLatePaymentEmailResponse);
 }


### PR DESCRIPTION
- Add SendLoanLatePaymentEmail gRPC method to email-service
- Wire up RabbitMQ queue, consumer, and HTML template
- Connect loan-service to email-service and client-service
- Replace cron TODO with actual email dispatch on payment failure