### PR TITLE
feat: dockerize all backend services

### DIFF
--- a/services/account-service/Dockerfile
+++ b/services/account-service/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.26-alpine AS builder
+WORKDIR /app
+COPY . .
+RUN go build -o /service ./services/account-service
+
+FROM alpine:3.20
+COPY --from=builder /service /service
+ENTRYPOINT ["/service"]

--- a/services/account-service/main.go
+++ b/services/account-service/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log"
 	"net"
+	"os"
 
 	acdb "github.com/RAF-SI-2025/EXBanka-4-Backend/services/account-service/db"
 	"github.com/RAF-SI-2025/EXBanka-4-Backend/services/account-service/handlers"
@@ -13,25 +14,25 @@ import (
 )
 
 func main() {
-	database, err := acdb.Connect("postgres://account_user:account_pass@localhost:5436/account_db?sslmode=disable")
+	database, err := acdb.Connect(os.Getenv("ACCOUNT_DB_URL"))
 	if err != nil {
 		log.Fatalf("failed to connect to account_db: %v", err)
 	}
 	defer database.Close()
 
-	clientDB, err := acdb.Connect("postgres://client_user:client_pass@localhost:5435/client_db?sslmode=disable")
+	clientDB, err := acdb.Connect(os.Getenv("CLIENT_DB_URL"))
 	if err != nil {
 		log.Fatalf("failed to connect to client_db: %v", err)
 	}
 	defer clientDB.Close()
 
-	exchangeDB, err := acdb.Connect("postgres://exchange_user:exchange_pass@localhost:5438/exchange_db?sslmode=disable")
+	exchangeDB, err := acdb.Connect(os.Getenv("EXCHANGE_DB_URL"))
 	if err != nil {
 		log.Fatalf("failed to connect to exchange_db: %v", err)
 	}
 	defer exchangeDB.Close()
 
-	emailConn, err := grpc.NewClient("localhost:50053", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	emailConn, err := grpc.NewClient(os.Getenv("EMAIL_SERVICE_ADDR"), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		log.Fatalf("failed to connect to email-service: %v", err)
 	}

--- a/services/api-gateway/Dockerfile
+++ b/services/api-gateway/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.26-alpine AS builder
+WORKDIR /app
+COPY . .
+RUN go build -o /service ./services/api-gateway
+
+FROM alpine:3.20
+COPY --from=builder /service /service
+ENTRYPOINT ["/service"]

--- a/services/api-gateway/main.go
+++ b/services/api-gateway/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"os"
 	"time"
 
 	"github.com/gin-contrib/cors"
@@ -23,55 +24,55 @@ import (
 // @in              header
 // @name            Authorization
 func main() {
-	clientClient, clientConn, err := gwgrpc.NewClientClient("localhost:50056")
+	clientClient, clientConn, err := gwgrpc.NewClientClient(os.Getenv("CLIENT_SERVICE_ADDR"))
 	if err != nil {
 		log.Fatalf("failed to connect to client-service: %v", err)
 	}
 	defer clientConn.Close()
 
-	employeeClient, empConn, err := gwgrpc.NewEmployeeClient("localhost:50051")
+	employeeClient, empConn, err := gwgrpc.NewEmployeeClient(os.Getenv("EMPLOYEE_SERVICE_ADDR"))
 	if err != nil {
 		log.Fatalf("failed to connect to employee-service: %v", err)
 	}
 	defer empConn.Close()
 
-	paymentClient, pmConn, err := gwgrpc.NewPaymentClient("localhost:50055")
+	paymentClient, pmConn, err := gwgrpc.NewPaymentClient(os.Getenv("PAYMENT_SERVICE_ADDR"))
 	if err != nil {
 		log.Fatalf("failed to connect to payment-service: %v", err)
 	}
 	defer pmConn.Close()
 
-	accountClient, accConn, err := gwgrpc.NewAccountClient("localhost:50054")
+	accountClient, accConn, err := gwgrpc.NewAccountClient(os.Getenv("ACCOUNT_SERVICE_ADDR"))
 	if err != nil {
 		log.Fatalf("failed to connect to account-service: %v", err)
 	}
 	defer accConn.Close()
 
-	authClient, authConn, err := gwgrpc.NewAuthClient("localhost:50052")
+	authClient, authConn, err := gwgrpc.NewAuthClient(os.Getenv("AUTH_SERVICE_ADDR"))
 	if err != nil {
 		log.Fatalf("failed to connect to auth-service: %v", err)
 	}
 	defer authConn.Close()
 
-	emailClient, emailConn, err := gwgrpc.NewEmailClient("localhost:50053")
+	emailClient, emailConn, err := gwgrpc.NewEmailClient(os.Getenv("EMAIL_SERVICE_ADDR"))
 	if err != nil {
 		log.Fatalf("failed to connect to email-service: %v", err)
 	}
 	defer emailConn.Close()
 
-	loanClient, loanConn, err := gwgrpc.NewLoanClient("localhost:50058")
+	loanClient, loanConn, err := gwgrpc.NewLoanClient(os.Getenv("LOAN_SERVICE_ADDR"))
 	if err != nil {
 		log.Fatalf("failed to connect to loan-service: %v", err)
 	}
 	defer loanConn.Close()
 
-	cardClient, cardConn, err := gwgrpc.NewCardClient("localhost:50059")
+	cardClient, cardConn, err := gwgrpc.NewCardClient(os.Getenv("CARD_SERVICE_ADDR"))
 	if err != nil {
 		log.Fatalf("failed to connect to card-service: %v", err)
 	}
 	defer cardConn.Close()
 
-	exchangeClient, exchangeConn, err := gwgrpc.NewExchangeClient("localhost:50057")
+	exchangeClient, exchangeConn, err := gwgrpc.NewExchangeClient(os.Getenv("EXCHANGE_SERVICE_ADDR"))
 	if err != nil {
 		log.Fatalf("failed to connect to exchange-service: %v", err)
 	}

--- a/services/api-gateway/middleware/auth.go
+++ b/services/api-gateway/middleware/auth.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -42,7 +43,7 @@ func GetUserIDFromToken(c *gin.Context) (int64, error) {
 	}
 }
 
-const jwtSecret = "secret-key-change-in-production"
+var jwtSecret = os.Getenv("JWT_SECRET")
 
 // GetCallerRoleFromToken returns "CLIENT" for client tokens, "EMPLOYEE" for employee tokens.
 func GetCallerRoleFromToken(c *gin.Context) string {

--- a/services/auth-service/Dockerfile
+++ b/services/auth-service/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.26-alpine AS builder
+WORKDIR /app
+COPY . .
+RUN go build -o /service ./services/auth-service
+
+FROM alpine:3.20
+COPY --from=builder /service /service
+ENTRYPOINT ["/service"]

--- a/services/auth-service/handlers/grpc_server.go
+++ b/services/auth-service/handlers/grpc_server.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"os"
 	"time"
 	"unicode"
 
@@ -23,7 +24,7 @@ import (
 	pb_emp "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/employee"
 )
 
-const jwtSecret = "secret-key-change-in-production"
+var jwtSecret = os.Getenv("JWT_SECRET")
 
 type AuthServer struct {
 	pb_auth.UnimplementedAuthServiceServer

--- a/services/auth-service/main.go
+++ b/services/auth-service/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log"
 	"net"
+	"os"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -16,13 +17,13 @@ import (
 )
 
 func main() {
-	database, err := authdb.Connect("postgres://auth_user:auth_pass@localhost:5434/auth_db?sslmode=disable")
+	database, err := authdb.Connect(os.Getenv("DB_URL"))
 	if err != nil {
 		log.Fatalf("failed to connect to auth-db: %v", err)
 	}
 	defer database.Close()
 
-	clientConn, err := grpc.NewClient("localhost:50056", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	clientConn, err := grpc.NewClient(os.Getenv("CLIENT_SERVICE_ADDR"), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		log.Fatalf("failed to connect to client-service: %v", err)
 	}
@@ -30,7 +31,7 @@ func main() {
 
 	clientClient := pb_client.NewClientServiceClient(clientConn)
 
-	empConn, err := grpc.NewClient("localhost:50051", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	empConn, err := grpc.NewClient(os.Getenv("EMPLOYEE_SERVICE_ADDR"), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		log.Fatalf("failed to connect to employee-service: %v", err)
 	}
@@ -38,7 +39,7 @@ func main() {
 
 	employeeClient := pb_emp.NewEmployeeServiceClient(empConn)
 
-	emailConn, err := grpc.NewClient("localhost:50053", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	emailConn, err := grpc.NewClient(os.Getenv("EMAIL_SERVICE_ADDR"), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		log.Fatalf("failed to connect to email-service: %v", err)
 	}

--- a/services/card-service/Dockerfile
+++ b/services/card-service/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.26-alpine AS builder
+WORKDIR /app
+COPY . .
+RUN go build -o /service ./services/card-service
+
+FROM alpine:3.20
+COPY --from=builder /service /service
+ENTRYPOINT ["/service"]

--- a/services/card-service/main.go
+++ b/services/card-service/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log"
 	"net"
+	"os"
 
 	carddb "github.com/RAF-SI-2025/EXBanka-4-Backend/services/card-service/db"
 	"github.com/RAF-SI-2025/EXBanka-4-Backend/services/card-service/handlers"
@@ -10,20 +11,16 @@ import (
 	"google.golang.org/grpc"
 )
 
-const (
-	cardDBDSN    = "postgres://card_user:card_pass@localhost:5440/card_db?sslmode=disable"
-	accountDBDSN = "postgres://account_user:account_pass@localhost:5436/account_db?sslmode=disable"
-	grpcPort     = ":50059"
-)
+const grpcPort = ":50059"
 
 func main() {
-	cardDB, err := carddb.Connect(cardDBDSN)
+	cardDB, err := carddb.Connect(os.Getenv("CARD_DB_URL"))
 	if err != nil {
 		log.Fatalf("failed to connect to card_db: %v", err)
 	}
 	defer cardDB.Close()
 
-	accountDB, err := carddb.Connect(accountDBDSN)
+	accountDB, err := carddb.Connect(os.Getenv("ACCOUNT_DB_URL"))
 	if err != nil {
 		log.Fatalf("failed to connect to account_db: %v", err)
 	}

--- a/services/client-service/Dockerfile
+++ b/services/client-service/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.26-alpine AS builder
+WORKDIR /app
+COPY . .
+RUN go build -o /service ./services/client-service
+
+FROM alpine:3.20
+COPY --from=builder /service /service
+ENTRYPOINT ["/service"]

--- a/services/client-service/main.go
+++ b/services/client-service/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log"
 	"net"
+	"os"
 
 	"google.golang.org/grpc"
 	clientdb "github.com/RAF-SI-2025/EXBanka-4-Backend/services/client-service/db"
@@ -11,7 +12,7 @@ import (
 )
 
 func main() {
-	database, err := clientdb.Connect("postgres://client_user:client_pass@localhost:5435/client_db?sslmode=disable")
+	database, err := clientdb.Connect(os.Getenv("DB_URL"))
 	if err != nil {
 		log.Fatalf("failed to connect to database: %v", err)
 	}

--- a/services/email-service/Dockerfile
+++ b/services/email-service/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.26-alpine AS builder
+WORKDIR /app
+COPY . .
+RUN go build -o /service ./services/email-service
+
+FROM alpine:3.20
+WORKDIR /app
+COPY --from=builder /service /app/service
+COPY services/email-service/templates/ /app/templates/
+ENTRYPOINT ["/app/service"]

--- a/services/employee-service/Dockerfile
+++ b/services/employee-service/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.26-alpine AS builder
+WORKDIR /app
+COPY . .
+RUN go build -o /service ./services/employee-service
+
+FROM alpine:3.20
+COPY --from=builder /service /service
+ENTRYPOINT ["/service"]

--- a/services/employee-service/main.go
+++ b/services/employee-service/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log"
 	"net"
+	"os"
 
 	"google.golang.org/grpc"
 	empdb "github.com/RAF-SI-2025/EXBanka-4-Backend/services/employee-service/db"
@@ -11,7 +12,7 @@ import (
 )
 
 func main() {
-	database, err := empdb.Connect("postgres://employee_user:employee_pass@localhost:5433/employee_db?sslmode=disable")
+	database, err := empdb.Connect(os.Getenv("DB_URL"))
 	if err != nil {
 		log.Fatalf("failed to connect to database: %v", err)
 	}

--- a/services/exchange-service/Dockerfile
+++ b/services/exchange-service/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.26-alpine AS builder
+WORKDIR /app
+COPY . .
+RUN go build -o /service ./services/exchange-service
+
+FROM alpine:3.20
+COPY --from=builder /service /service
+ENTRYPOINT ["/service"]

--- a/services/exchange-service/main.go
+++ b/services/exchange-service/main.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"log"
 	"net"
+	"os"
 
 	exdb "github.com/RAF-SI-2025/EXBanka-4-Backend/services/exchange-service/db"
 	"github.com/RAF-SI-2025/EXBanka-4-Backend/services/exchange-service/handlers"
@@ -11,11 +12,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-const (
-	exchangeDBDSN = "postgres://exchange_user:exchange_pass@localhost:5438/exchange_db?sslmode=disable"
-	accountDBDSN  = "postgres://account_user:account_pass@localhost:5436/account_db?sslmode=disable"
-	grpcPort      = ":50057"
-)
+const grpcPort = ":50057"
 
 func migrate(db *sql.DB) error {
 	_, err := db.Exec(`
@@ -47,13 +44,13 @@ func migrate(db *sql.DB) error {
 }
 
 func main() {
-	exchangeDB, err := exdb.Connect(exchangeDBDSN)
+	exchangeDB, err := exdb.Connect(os.Getenv("EXCHANGE_DB_URL"))
 	if err != nil {
 		log.Fatalf("failed to connect to exchange_db: %v", err)
 	}
 	defer exchangeDB.Close()
 
-	accountDB, err := exdb.Connect(accountDBDSN)
+	accountDB, err := exdb.Connect(os.Getenv("ACCOUNT_DB_URL"))
 	if err != nil {
 		log.Fatalf("failed to connect to account_db: %v", err)
 	}

--- a/services/loan-service/Dockerfile
+++ b/services/loan-service/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.26-alpine AS builder
+WORKDIR /app
+COPY . .
+RUN go build -o /service ./services/loan-service
+
+FROM alpine:3.20
+COPY --from=builder /service /service
+ENTRYPOINT ["/service"]

--- a/services/loan-service/main.go
+++ b/services/loan-service/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log"
 	"net"
+	"os"
 
 	loandb "github.com/RAF-SI-2025/EXBanka-4-Backend/services/loan-service/db"
 	"github.com/RAF-SI-2025/EXBanka-4-Backend/services/loan-service/handlers"
@@ -13,40 +14,35 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-const (
-	loanDBDSN     = "postgres://loan_user:loan_pass@localhost:5439/loan_db?sslmode=disable"
-	accountDBDSN  = "postgres://account_user:account_pass@localhost:5436/account_db?sslmode=disable"
-	exchangeDBDSN = "postgres://exchange_user:exchange_pass@localhost:5438/exchange_db?sslmode=disable"
-	grpcPort      = ":50058"
-)
+const grpcPort = ":50058"
 
 func main() {
-	loanDB, err := loandb.Connect(loanDBDSN)
+	loanDB, err := loandb.Connect(os.Getenv("LOAN_DB_URL"))
 	if err != nil {
 		log.Fatalf("failed to connect to loan_db: %v", err)
 	}
 	defer loanDB.Close()
 
-	accountDB, err := loandb.Connect(accountDBDSN)
+	accountDB, err := loandb.Connect(os.Getenv("ACCOUNT_DB_URL"))
 	if err != nil {
 		log.Fatalf("failed to connect to account_db: %v", err)
 	}
 	defer accountDB.Close()
 
-	exchangeDB, err := loandb.Connect(exchangeDBDSN)
+	exchangeDB, err := loandb.Connect(os.Getenv("EXCHANGE_DB_URL"))
 	if err != nil {
 		log.Fatalf("failed to connect to exchange_db: %v", err)
 	}
 	defer exchangeDB.Close()
 
-	emailConn, err := grpc.NewClient("localhost:50053", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	emailConn, err := grpc.NewClient(os.Getenv("EMAIL_SERVICE_ADDR"), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		log.Fatalf("failed to connect to email-service: %v", err)
 	}
 	defer emailConn.Close()
 	emailClient := pb_email.NewEmailServiceClient(emailConn)
 
-	clientConn, err := grpc.NewClient("localhost:50056", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	clientConn, err := grpc.NewClient(os.Getenv("CLIENT_SERVICE_ADDR"), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		log.Fatalf("failed to connect to client-service: %v", err)
 	}

--- a/services/payment-service/Dockerfile
+++ b/services/payment-service/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.26-alpine AS builder
+WORKDIR /app
+COPY . .
+RUN go build -o /service ./services/payment-service
+
+FROM alpine:3.20
+COPY --from=builder /service /service
+ENTRYPOINT ["/service"]

--- a/services/payment-service/main.go
+++ b/services/payment-service/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log"
 	"net"
+	"os"
 
 	"google.golang.org/grpc"
 
@@ -12,25 +13,25 @@ import (
 )
 
 func main() {
-	db, err := pmdb.Connect("postgres://payment_user:payment_pass@localhost:5437/payment_db?sslmode=disable")
+	db, err := pmdb.Connect(os.Getenv("PAYMENT_DB_URL"))
 	if err != nil {
 		log.Fatalf("failed to connect to payment_db: %v", err)
 	}
 	defer db.Close()
 
-	accountDB, err := pmdb.Connect("postgres://account_user:account_pass@localhost:5436/account_db?sslmode=disable")
+	accountDB, err := pmdb.Connect(os.Getenv("ACCOUNT_DB_URL"))
 	if err != nil {
 		log.Fatalf("failed to connect to account_db: %v", err)
 	}
 	defer accountDB.Close()
 
-	exchangeDB, err := pmdb.Connect("postgres://exchange_user:exchange_pass@localhost:5438/exchange_db?sslmode=disable")
+	exchangeDB, err := pmdb.Connect(os.Getenv("EXCHANGE_DB_URL"))
 	if err != nil {
 		log.Fatalf("failed to connect to exchange_db: %v", err)
 	}
 	defer exchangeDB.Close()
 
-	clientDB, err := pmdb.Connect("postgres://client_user:client_pass@localhost:5435/client_db?sslmode=disable")
+	clientDB, err := pmdb.Connect(os.Getenv("CLIENT_DB_URL"))
 	if err != nil {
 		log.Fatalf("failed to connect to client_db: %v", err)
 	}


### PR DESCRIPTION
Add Dockerfiles for all 10 services using multi-stage Go builds with golang:1.26-alpine builder and alpine:3.20 runtime. Refactor all main.go files to read DB connection strings and gRPC addresses from environment variables (DB_URL, *_SERVICE_ADDR) instead of hardcoded localhost values. Extract JWT secret to JWT_SECRET env var in both auth-service and api-gateway middleware.