### PR TITLE
fix: read FRONTEND_URL env var for email activation/reset links

### DIFF
--- a/services/api-gateway/handlers/auth.go
+++ b/services/api-gateway/handlers/auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -203,7 +204,11 @@ func ForgotPassword(authClient pb.AuthServiceClient, emailClient pb_email.EmailS
 			return
 		}
 
-		resetLink := fmt.Sprintf("http://localhost:5173/reset-password?token=%s", resp.Token)
+		frontendURL := os.Getenv("FRONTEND_URL")
+		if frontendURL == "" {
+			frontendURL = "http://localhost:5173"
+		}
+		resetLink := fmt.Sprintf("%s/reset-password?token=%s", frontendURL, resp.Token)
 		go func() {
 			emailCtx, emailCancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer emailCancel()

--- a/services/api-gateway/handlers/clients.go
+++ b/services/api-gateway/handlers/clients.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 	"net/mail"
+	"os"
 	"strconv"
 	"time"
 
@@ -231,7 +232,11 @@ func CreateClient(clientSvc pb.ClientServiceClient, authClient authpb.AuthServic
 			return
 		}
 
-		link := fmt.Sprintf("http://localhost:5173/client/activate?token=%s", tokenResp.Token)
+		frontendURL := os.Getenv("FRONTEND_URL")
+		if frontendURL == "" {
+			frontendURL = "http://localhost:5173"
+		}
+		link := fmt.Sprintf("%s/client/activate?token=%s", frontendURL, tokenResp.Token)
 		go func() {
 			_, err := emailClient.SendActivationEmail(context.Background(),
 				&emailpb.SendActivationEmailRequest{

--- a/services/api-gateway/handlers/employees.go
+++ b/services/api-gateway/handlers/employees.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 	"net/mail"
+	"os"
 	"strconv"
 	"time"
 
@@ -360,7 +361,11 @@ func CreateEmployee(empClient pb.EmployeeServiceClient, authClient authpb.AuthSe
 			return
 		}
 
-		link := fmt.Sprintf("http://localhost:5173/set-password?token=%s", tokenResp.Token)
+		frontendURL := os.Getenv("FRONTEND_URL")
+		if frontendURL == "" {
+			frontendURL = "http://localhost:5173"
+		}
+		link := fmt.Sprintf("%s/set-password?token=%s", frontendURL, tokenResp.Token)
 		go func() {
 			_, err := emailClient.SendActivationEmail(context.Background(),
 				&emailpb.SendActivationEmailRequest{


### PR DESCRIPTION
Replace hardcoded http://localhost:5173 in email link construction with os.Getenv("FRONTEND_URL"), defaulting to localhost:5173 for local dev. Affects employee activation, client activation, and password reset emails.