### PR TITLE
feat(loans): add POST /admin/loans/trigger-installments endpoint

### DIFF
--- a/services/api-gateway/handlers/loan.go
+++ b/services/api-gateway/handlers/loan.go
@@ -391,3 +391,30 @@ func loanDetailsToJSON(loans []*pb.LoanDetail) []map[string]interface{} {
 	}
 	return result
 }
+
+// TriggerInstallments godoc
+// @Summary      Manually trigger daily installment collection (admin/test only)
+// @Tags         loans
+// @Produce      json
+// @Success      200  {object}  map[string]int
+// @Router       /admin/loans/trigger-installments [post]
+func TriggerInstallments(client pb.LoanServiceClient) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var body struct {
+			ForceLoanId int64 `json:"forceLoanId"`
+		}
+		_ = c.ShouldBindJSON(&body) // optional body — ignore parse errors
+
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 30*time.Second)
+		defer cancel()
+
+		resp, err := client.TriggerInstallments(ctx, &pb.TriggerInstallmentsRequest{
+			ForceLoanId: body.ForceLoanId,
+		})
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": status.Convert(err).Message()})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"processed": resp.Processed})
+	}
+}

--- a/services/api-gateway/main.go
+++ b/services/api-gateway/main.go
@@ -148,6 +148,7 @@ func main() {
 	r.PUT("/admin/loans/:id/approve", middleware.RequireRole("ADMIN"), handlers.ApproveLoan(loanClient))
 	r.PUT("/admin/loans/:id/reject", middleware.RequireRole("ADMIN"), handlers.RejectLoan(loanClient))
 	r.GET("/admin/loans", middleware.RequireRole("ADMIN"), handlers.GetAllLoans(loanClient))
+	r.POST("/admin/loans/trigger-installments", middleware.RequireRole("ADMIN"), handlers.TriggerInstallments(loanClient))
 	r.GET("/api/cards", handlers.GetMyCards(accountClient, cardClient))
 	r.GET("/api/cards/by-account/:accountNumber", middleware.RequireRole("EMPLOYEE"), handlers.GetCardsByAccount(cardClient))
 	r.POST("/api/cards/request", handlers.InitiateCardRequest(cardClient, clientClient, emailClient))

--- a/services/loan-service/handlers/cron.go
+++ b/services/loan-service/handlers/cron.go
@@ -30,30 +30,41 @@ func (s *LoanServer) runDailyCron() {
 		next := time.Date(now.Year(), now.Month(), now.Day()+1, 0, 0, 0, 0, now.Location())
 		time.Sleep(time.Until(next))
 		log.Println("loan-service: running daily installment deduction")
-		s.collectInstallments()
+		s.collectInstallments(0)
 	}
 }
 
-func (s *LoanServer) collectInstallments() {
+func (s *LoanServer) collectInstallments(forceLoanID int64) int {
 	ctx := context.Background()
 
-	// Find all loans due today (APPROVED) OR IN_DELAY with no retry in last 72h
-	rows, err := s.DB.QueryContext(ctx, `
-		SELECT id, loan_number, client_id, account_number, next_installment_amount, currency, remaining_debt
-		FROM loans
-		WHERE (
-		    (status = 'APPROVED' AND next_installment_date = CURRENT_DATE)
-		    OR
-		    (status = 'IN_DELAY' AND EXISTS (
-		        SELECT 1 FROM loan_installments
-		        WHERE loan_id = loans.id AND status IN ('UNPAID', 'LATE')
-		          AND (last_retry_at IS NULL OR last_retry_at < NOW() - INTERVAL '72 hours')
-		        LIMIT 1
-		    ))
-		)`)
+	var rows *sql.Rows
+	var err error
+
+	if forceLoanID > 0 {
+		// Force-process a specific loan regardless of next_installment_date (used by tests)
+		rows, err = s.DB.QueryContext(ctx, `
+			SELECT id, loan_number, client_id, account_number, next_installment_amount, currency, remaining_debt
+			FROM loans
+			WHERE id = $1 AND status IN ('APPROVED', 'IN_DELAY')`, forceLoanID)
+	} else {
+		// Normal daily run: find all loans due today
+		rows, err = s.DB.QueryContext(ctx, `
+			SELECT id, loan_number, client_id, account_number, next_installment_amount, currency, remaining_debt
+			FROM loans
+			WHERE (
+			    (status = 'APPROVED' AND next_installment_date = CURRENT_DATE)
+			    OR
+			    (status = 'IN_DELAY' AND EXISTS (
+			        SELECT 1 FROM loan_installments
+			        WHERE loan_id = loans.id AND status IN ('UNPAID', 'LATE')
+			          AND (last_retry_at IS NULL OR last_retry_at < NOW() - INTERVAL '72 hours')
+			        LIMIT 1
+			    ))
+			)`)
+	}
 	if err != nil {
 		log.Printf("loan-service: daily cron query error: %v", err)
-		return
+		return 0
 	}
 	defer rows.Close()
 
@@ -93,6 +104,7 @@ func (s *LoanServer) collectInstallments() {
 	for _, l := range loans {
 		s.processInstallment(ctx, l.id, l.loanNumber, l.clientID, l.accountNumber, l.amount, l.currency, l.remainingDebt)
 	}
+	return len(loans)
 }
 
 func (s *LoanServer) processInstallment(ctx context.Context, loanID int64, loanNumber int64, clientID int64, accountNumber string, amount float64, currency string, remainingDebt float64) {

--- a/services/loan-service/handlers/grpc_server.go
+++ b/services/loan-service/handlers/grpc_server.go
@@ -461,3 +461,10 @@ func scanLoanDetails(rows *sql.Rows) ([]*pb.LoanDetail, error) {
 	}
 	return loans, nil
 }
+
+// TriggerInstallments manually fires the daily installment collection.
+// Used by the admin API for testing and operational purposes.
+func (s *LoanServer) TriggerInstallments(_ context.Context, req *pb.TriggerInstallmentsRequest) (*pb.TriggerInstallmentsResponse, error) {
+	processed := s.collectInstallments(req.ForceLoanId)
+	return &pb.TriggerInstallmentsResponse{Processed: int32(processed)}, nil
+}

--- a/shared/pb/loan/loan.pb.go
+++ b/shared/pb/loan/loan.pb.go
@@ -1282,6 +1282,94 @@ func (x *GetAllLoansResponse) GetLoans() []*LoanDetail {
 	return nil
 }
 
+type TriggerInstallmentsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ForceLoanId   int64                  `protobuf:"varint,1,opt,name=force_loan_id,json=forceLoanId,proto3" json:"force_loan_id,omitempty"` // if > 0, process this loan regardless of next_installment_date
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TriggerInstallmentsRequest) Reset() {
+	*x = TriggerInstallmentsRequest{}
+	mi := &file_loan_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TriggerInstallmentsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TriggerInstallmentsRequest) ProtoMessage() {}
+
+func (x *TriggerInstallmentsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_loan_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TriggerInstallmentsRequest.ProtoReflect.Descriptor instead.
+func (*TriggerInstallmentsRequest) Descriptor() ([]byte, []int) {
+	return file_loan_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *TriggerInstallmentsRequest) GetForceLoanId() int64 {
+	if x != nil {
+		return x.ForceLoanId
+	}
+	return 0
+}
+
+type TriggerInstallmentsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Processed     int32                  `protobuf:"varint,1,opt,name=processed,proto3" json:"processed,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TriggerInstallmentsResponse) Reset() {
+	*x = TriggerInstallmentsResponse{}
+	mi := &file_loan_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TriggerInstallmentsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TriggerInstallmentsResponse) ProtoMessage() {}
+
+func (x *TriggerInstallmentsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_loan_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TriggerInstallmentsResponse.ProtoReflect.Descriptor instead.
+func (*TriggerInstallmentsResponse) Descriptor() ([]byte, []int) {
+	return file_loan_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *TriggerInstallmentsResponse) GetProcessed() int32 {
+	if x != nil {
+		return x.Processed
+	}
+	return 0
+}
+
 var File_loan_proto protoreflect.FileDescriptor
 
 const file_loan_proto_rawDesc = "" +
@@ -1387,7 +1475,11 @@ const file_loan_proto_rawDesc = "" +
 	"\x0eaccount_number\x18\x02 \x01(\tR\raccountNumber\x12\x16\n" +
 	"\x06status\x18\x03 \x01(\tR\x06status\"=\n" +
 	"\x13GetAllLoansResponse\x12&\n" +
-	"\x05loans\x18\x01 \x03(\v2\x10.loan.LoanDetailR\x05loans2\x93\x05\n" +
+	"\x05loans\x18\x01 \x03(\v2\x10.loan.LoanDetailR\x05loans\"@\n" +
+	"\x1aTriggerInstallmentsRequest\x12\"\n" +
+	"\rforce_loan_id\x18\x01 \x01(\x03R\vforceLoanId\";\n" +
+	"\x1bTriggerInstallmentsResponse\x12\x1c\n" +
+	"\tprocessed\x18\x01 \x01(\x05R\tprocessed2\xef\x05\n" +
 	"\vLoanService\x12K\n" +
 	"\x0eGetClientLoans\x12\x1b.loan.GetClientLoansRequest\x1a\x1c.loan.GetClientLoansResponse\x12K\n" +
 	"\x0eGetLoanDetails\x12\x1b.loan.GetLoanDetailsRequest\x1a\x1c.loan.GetLoanDetailsResponse\x12Z\n" +
@@ -1397,7 +1489,8 @@ const file_loan_proto_rawDesc = "" +
 	"\n" +
 	"RejectLoan\x12\x17.loan.RejectLoanRequest\x1a\x18.loan.RejectLoanResponse\x12c\n" +
 	"\x16GetAllLoanApplications\x12#.loan.GetAllLoanApplicationsRequest\x1a$.loan.GetAllLoanApplicationsResponse\x12B\n" +
-	"\vGetAllLoans\x12\x18.loan.GetAllLoansRequest\x1a\x19.loan.GetAllLoansResponseB9Z7github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/loanb\x06proto3"
+	"\vGetAllLoans\x12\x18.loan.GetAllLoansRequest\x1a\x19.loan.GetAllLoansResponse\x12Z\n" +
+	"\x13TriggerInstallments\x12 .loan.TriggerInstallmentsRequest\x1a!.loan.TriggerInstallmentsResponseB9Z7github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/loanb\x06proto3"
 
 var (
 	file_loan_proto_rawDescOnce sync.Once
@@ -1411,7 +1504,7 @@ func file_loan_proto_rawDescGZIP() []byte {
 	return file_loan_proto_rawDescData
 }
 
-var file_loan_proto_msgTypes = make([]protoimpl.MessageInfo, 19)
+var file_loan_proto_msgTypes = make([]protoimpl.MessageInfo, 21)
 var file_loan_proto_goTypes = []any{
 	(*LoanSummary)(nil),                    // 0: loan.LoanSummary
 	(*LoanDetail)(nil),                     // 1: loan.LoanDetail
@@ -1432,6 +1525,8 @@ var file_loan_proto_goTypes = []any{
 	(*GetAllLoanApplicationsResponse)(nil), // 16: loan.GetAllLoanApplicationsResponse
 	(*GetAllLoansRequest)(nil),             // 17: loan.GetAllLoansRequest
 	(*GetAllLoansResponse)(nil),            // 18: loan.GetAllLoansResponse
+	(*TriggerInstallmentsRequest)(nil),     // 19: loan.TriggerInstallmentsRequest
+	(*TriggerInstallmentsResponse)(nil),    // 20: loan.TriggerInstallmentsResponse
 }
 var file_loan_proto_depIdxs = []int32{
 	0,  // 0: loan.GetClientLoansResponse.loans:type_name -> loan.LoanSummary
@@ -1448,16 +1543,18 @@ var file_loan_proto_depIdxs = []int32{
 	13, // 11: loan.LoanService.RejectLoan:input_type -> loan.RejectLoanRequest
 	15, // 12: loan.LoanService.GetAllLoanApplications:input_type -> loan.GetAllLoanApplicationsRequest
 	17, // 13: loan.LoanService.GetAllLoans:input_type -> loan.GetAllLoansRequest
-	4,  // 14: loan.LoanService.GetClientLoans:output_type -> loan.GetClientLoansResponse
-	6,  // 15: loan.LoanService.GetLoanDetails:output_type -> loan.GetLoanDetailsResponse
-	8,  // 16: loan.LoanService.GetLoanInstallments:output_type -> loan.GetLoanInstallmentsResponse
-	10, // 17: loan.LoanService.SubmitLoanApplication:output_type -> loan.SubmitLoanApplicationResponse
-	12, // 18: loan.LoanService.ApproveLoan:output_type -> loan.ApproveLoanResponse
-	14, // 19: loan.LoanService.RejectLoan:output_type -> loan.RejectLoanResponse
-	16, // 20: loan.LoanService.GetAllLoanApplications:output_type -> loan.GetAllLoanApplicationsResponse
-	18, // 21: loan.LoanService.GetAllLoans:output_type -> loan.GetAllLoansResponse
-	14, // [14:22] is the sub-list for method output_type
-	6,  // [6:14] is the sub-list for method input_type
+	19, // 14: loan.LoanService.TriggerInstallments:input_type -> loan.TriggerInstallmentsRequest
+	4,  // 15: loan.LoanService.GetClientLoans:output_type -> loan.GetClientLoansResponse
+	6,  // 16: loan.LoanService.GetLoanDetails:output_type -> loan.GetLoanDetailsResponse
+	8,  // 17: loan.LoanService.GetLoanInstallments:output_type -> loan.GetLoanInstallmentsResponse
+	10, // 18: loan.LoanService.SubmitLoanApplication:output_type -> loan.SubmitLoanApplicationResponse
+	12, // 19: loan.LoanService.ApproveLoan:output_type -> loan.ApproveLoanResponse
+	14, // 20: loan.LoanService.RejectLoan:output_type -> loan.RejectLoanResponse
+	16, // 21: loan.LoanService.GetAllLoanApplications:output_type -> loan.GetAllLoanApplicationsResponse
+	18, // 22: loan.LoanService.GetAllLoans:output_type -> loan.GetAllLoansResponse
+	20, // 23: loan.LoanService.TriggerInstallments:output_type -> loan.TriggerInstallmentsResponse
+	15, // [15:24] is the sub-list for method output_type
+	6,  // [6:15] is the sub-list for method input_type
 	6,  // [6:6] is the sub-list for extension type_name
 	6,  // [6:6] is the sub-list for extension extendee
 	0,  // [0:6] is the sub-list for field type_name
@@ -1474,7 +1571,7 @@ func file_loan_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_loan_proto_rawDesc), len(file_loan_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   19,
+			NumMessages:   21,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/shared/pb/loan/loan_grpc.pb.go
+++ b/shared/pb/loan/loan_grpc.pb.go
@@ -27,6 +27,7 @@ const (
 	LoanService_RejectLoan_FullMethodName             = "/loan.LoanService/RejectLoan"
 	LoanService_GetAllLoanApplications_FullMethodName = "/loan.LoanService/GetAllLoanApplications"
 	LoanService_GetAllLoans_FullMethodName            = "/loan.LoanService/GetAllLoans"
+	LoanService_TriggerInstallments_FullMethodName    = "/loan.LoanService/TriggerInstallments"
 )
 
 // LoanServiceClient is the client API for LoanService service.
@@ -41,6 +42,7 @@ type LoanServiceClient interface {
 	RejectLoan(ctx context.Context, in *RejectLoanRequest, opts ...grpc.CallOption) (*RejectLoanResponse, error)
 	GetAllLoanApplications(ctx context.Context, in *GetAllLoanApplicationsRequest, opts ...grpc.CallOption) (*GetAllLoanApplicationsResponse, error)
 	GetAllLoans(ctx context.Context, in *GetAllLoansRequest, opts ...grpc.CallOption) (*GetAllLoansResponse, error)
+	TriggerInstallments(ctx context.Context, in *TriggerInstallmentsRequest, opts ...grpc.CallOption) (*TriggerInstallmentsResponse, error)
 }
 
 type loanServiceClient struct {
@@ -131,6 +133,16 @@ func (c *loanServiceClient) GetAllLoans(ctx context.Context, in *GetAllLoansRequ
 	return out, nil
 }
 
+func (c *loanServiceClient) TriggerInstallments(ctx context.Context, in *TriggerInstallmentsRequest, opts ...grpc.CallOption) (*TriggerInstallmentsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(TriggerInstallmentsResponse)
+	err := c.cc.Invoke(ctx, LoanService_TriggerInstallments_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // LoanServiceServer is the server API for LoanService service.
 // All implementations must embed UnimplementedLoanServiceServer
 // for forward compatibility.
@@ -143,6 +155,7 @@ type LoanServiceServer interface {
 	RejectLoan(context.Context, *RejectLoanRequest) (*RejectLoanResponse, error)
 	GetAllLoanApplications(context.Context, *GetAllLoanApplicationsRequest) (*GetAllLoanApplicationsResponse, error)
 	GetAllLoans(context.Context, *GetAllLoansRequest) (*GetAllLoansResponse, error)
+	TriggerInstallments(context.Context, *TriggerInstallmentsRequest) (*TriggerInstallmentsResponse, error)
 	mustEmbedUnimplementedLoanServiceServer()
 }
 
@@ -176,6 +189,9 @@ func (UnimplementedLoanServiceServer) GetAllLoanApplications(context.Context, *G
 }
 func (UnimplementedLoanServiceServer) GetAllLoans(context.Context, *GetAllLoansRequest) (*GetAllLoansResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetAllLoans not implemented")
+}
+func (UnimplementedLoanServiceServer) TriggerInstallments(context.Context, *TriggerInstallmentsRequest) (*TriggerInstallmentsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method TriggerInstallments not implemented")
 }
 func (UnimplementedLoanServiceServer) mustEmbedUnimplementedLoanServiceServer() {}
 func (UnimplementedLoanServiceServer) testEmbeddedByValue()                     {}
@@ -342,6 +358,24 @@ func _LoanService_GetAllLoans_Handler(srv interface{}, ctx context.Context, dec 
 	return interceptor(ctx, in, info, handler)
 }
 
+func _LoanService_TriggerInstallments_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(TriggerInstallmentsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(LoanServiceServer).TriggerInstallments(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: LoanService_TriggerInstallments_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(LoanServiceServer).TriggerInstallments(ctx, req.(*TriggerInstallmentsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // LoanService_ServiceDesc is the grpc.ServiceDesc for LoanService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -380,6 +414,10 @@ var LoanService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetAllLoans",
 			Handler:    _LoanService_GetAllLoans_Handler,
+		},
+		{
+			MethodName: "TriggerInstallments",
+			Handler:    _LoanService_TriggerInstallments_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/shared/proto/loan.proto
+++ b/shared/proto/loan.proto
@@ -150,6 +150,15 @@ message GetAllLoansResponse {
 
 // --- Service ---
 
+// --- TriggerInstallments ---
+
+message TriggerInstallmentsRequest {
+  int64 force_loan_id = 1; // if > 0, process this loan regardless of next_installment_date
+}
+message TriggerInstallmentsResponse { int32 processed = 1; }
+
+// --- Service ---
+
 service LoanService {
   rpc GetClientLoans          (GetClientLoansRequest)          returns (GetClientLoansResponse);
   rpc GetLoanDetails          (GetLoanDetailsRequest)          returns (GetLoanDetailsResponse);
@@ -159,4 +168,5 @@ service LoanService {
   rpc RejectLoan              (RejectLoanRequest)              returns (RejectLoanResponse);
   rpc GetAllLoanApplications  (GetAllLoanApplicationsRequest)  returns (GetAllLoanApplicationsResponse);
   rpc GetAllLoans             (GetAllLoansRequest)             returns (GetAllLoansResponse);
+  rpc TriggerInstallments     (TriggerInstallmentsRequest)     returns (TriggerInstallmentsResponse);
 }


### PR DESCRIPTION
Expose a manual trigger for the daily installment cron so Cypress e2e tests (S37, S38) can fire it on demand without waiting for midnight.

- Add TriggerInstallments rpc to loan.proto with optional force_loan_id field to bypass date check for a specific loan; regenerate pb files
- Refactor collectInstallments() to accept forceLoanID and return count
- Implement TriggerInstallments gRPC handler in loan-service
- Add TriggerInstallments HTTP handler and route in api-gateway