### PR TITLE
feat: test mode toggle for exchange working hours (#141)

### DIFF
--- a/services/api-gateway/handlers/securities.go
+++ b/services/api-gateway/handlers/securities.go
@@ -400,6 +400,55 @@ func DeleteHoliday(client pb.SecuritiesServiceClient) gin.HandlerFunc {
 
 // ── Exchange Status ───────────────────────────────────────────────────────────
 
+// GetTestMode godoc
+// @Summary      Get test mode status
+// @Tags         securities
+// @Produce      json
+// @Success      200  {object}  map[string]bool
+// @Router       /stock-exchanges/test-mode [get]
+func GetTestMode(client pb.SecuritiesServiceClient) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 10*time.Second)
+		defer cancel()
+
+		resp, err := client.GetTestMode(ctx, &pb.GetTestModeRequest{})
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get test mode"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"enabled": resp.Enabled})
+	}
+}
+
+// SetTestMode godoc
+// @Summary      Enable or disable test mode
+// @Tags         securities
+// @Accept       json
+// @Produce      json
+// @Success      200  {object}  map[string]bool
+// @Router       /stock-exchanges/test-mode [post]
+func SetTestMode(client pb.SecuritiesServiceClient) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var body struct {
+			Enabled bool `json:"enabled"`
+		}
+		if err := c.ShouldBindJSON(&body); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 10*time.Second)
+		defer cancel()
+
+		resp, err := client.SetTestMode(ctx, &pb.SetTestModeRequest{Enabled: body.Enabled})
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to set test mode"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"enabled": resp.Enabled})
+	}
+}
+
 // IsExchangeOpen godoc
 // @Summary      Check if an exchange is currently open
 // @Tags         securities

--- a/services/api-gateway/handlers/securities_test.go
+++ b/services/api-gateway/handlers/securities_test.go
@@ -1,0 +1,177 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	pb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/securities"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// ---- stub securities service client ----
+
+type stubSecuritiesClient struct {
+	getExchangesFn    func(context.Context, *pb.GetStockExchangesRequest, ...grpc.CallOption) (*pb.GetStockExchangesResponse, error)
+	getByMICFn        func(context.Context, *pb.GetStockExchangeByMICRequest, ...grpc.CallOption) (*pb.GetStockExchangeByMICResponse, error)
+	createExchangeFn  func(context.Context, *pb.CreateStockExchangeRequest, ...grpc.CallOption) (*pb.CreateStockExchangeResponse, error)
+	updateExchangeFn  func(context.Context, *pb.UpdateStockExchangeRequest, ...grpc.CallOption) (*pb.UpdateStockExchangeResponse, error)
+	deleteExchangeFn  func(context.Context, *pb.DeleteStockExchangeRequest, ...grpc.CallOption) (*pb.DeleteStockExchangeResponse, error)
+	getHoursFn        func(context.Context, *pb.GetWorkingHoursRequest, ...grpc.CallOption) (*pb.GetWorkingHoursResponse, error)
+	setHoursFn        func(context.Context, *pb.SetWorkingHoursRequest, ...grpc.CallOption) (*pb.SetWorkingHoursResponse, error)
+	getHolidaysFn     func(context.Context, *pb.GetHolidaysRequest, ...grpc.CallOption) (*pb.GetHolidaysResponse, error)
+	addHolidayFn      func(context.Context, *pb.AddHolidayRequest, ...grpc.CallOption) (*pb.AddHolidayResponse, error)
+	deleteHolidayFn   func(context.Context, *pb.DeleteHolidayRequest, ...grpc.CallOption) (*pb.DeleteHolidayResponse, error)
+	isOpenFn          func(context.Context, *pb.IsExchangeOpenRequest, ...grpc.CallOption) (*pb.IsExchangeOpenResponse, error)
+	getTestModeFn     func(context.Context, *pb.GetTestModeRequest, ...grpc.CallOption) (*pb.GetTestModeResponse, error)
+	setTestModeFn     func(context.Context, *pb.SetTestModeRequest, ...grpc.CallOption) (*pb.SetTestModeResponse, error)
+}
+
+func (s *stubSecuritiesClient) Ping(ctx context.Context, in *pb.PingRequest, opts ...grpc.CallOption) (*pb.PingResponse, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+func (s *stubSecuritiesClient) GetStockExchanges(ctx context.Context, in *pb.GetStockExchangesRequest, opts ...grpc.CallOption) (*pb.GetStockExchangesResponse, error) {
+	if s.getExchangesFn != nil {
+		return s.getExchangesFn(ctx, in, opts...)
+	}
+	return nil, fmt.Errorf("not implemented")
+}
+func (s *stubSecuritiesClient) GetStockExchangeByMIC(ctx context.Context, in *pb.GetStockExchangeByMICRequest, opts ...grpc.CallOption) (*pb.GetStockExchangeByMICResponse, error) {
+	if s.getByMICFn != nil {
+		return s.getByMICFn(ctx, in, opts...)
+	}
+	return nil, fmt.Errorf("not implemented")
+}
+func (s *stubSecuritiesClient) CreateStockExchange(ctx context.Context, in *pb.CreateStockExchangeRequest, opts ...grpc.CallOption) (*pb.CreateStockExchangeResponse, error) {
+	if s.createExchangeFn != nil {
+		return s.createExchangeFn(ctx, in, opts...)
+	}
+	return nil, fmt.Errorf("not implemented")
+}
+func (s *stubSecuritiesClient) UpdateStockExchange(ctx context.Context, in *pb.UpdateStockExchangeRequest, opts ...grpc.CallOption) (*pb.UpdateStockExchangeResponse, error) {
+	if s.updateExchangeFn != nil {
+		return s.updateExchangeFn(ctx, in, opts...)
+	}
+	return nil, fmt.Errorf("not implemented")
+}
+func (s *stubSecuritiesClient) DeleteStockExchange(ctx context.Context, in *pb.DeleteStockExchangeRequest, opts ...grpc.CallOption) (*pb.DeleteStockExchangeResponse, error) {
+	if s.deleteExchangeFn != nil {
+		return s.deleteExchangeFn(ctx, in, opts...)
+	}
+	return nil, fmt.Errorf("not implemented")
+}
+func (s *stubSecuritiesClient) GetWorkingHours(ctx context.Context, in *pb.GetWorkingHoursRequest, opts ...grpc.CallOption) (*pb.GetWorkingHoursResponse, error) {
+	if s.getHoursFn != nil {
+		return s.getHoursFn(ctx, in, opts...)
+	}
+	return nil, fmt.Errorf("not implemented")
+}
+func (s *stubSecuritiesClient) SetWorkingHours(ctx context.Context, in *pb.SetWorkingHoursRequest, opts ...grpc.CallOption) (*pb.SetWorkingHoursResponse, error) {
+	if s.setHoursFn != nil {
+		return s.setHoursFn(ctx, in, opts...)
+	}
+	return nil, fmt.Errorf("not implemented")
+}
+func (s *stubSecuritiesClient) GetHolidays(ctx context.Context, in *pb.GetHolidaysRequest, opts ...grpc.CallOption) (*pb.GetHolidaysResponse, error) {
+	if s.getHolidaysFn != nil {
+		return s.getHolidaysFn(ctx, in, opts...)
+	}
+	return nil, fmt.Errorf("not implemented")
+}
+func (s *stubSecuritiesClient) AddHoliday(ctx context.Context, in *pb.AddHolidayRequest, opts ...grpc.CallOption) (*pb.AddHolidayResponse, error) {
+	if s.addHolidayFn != nil {
+		return s.addHolidayFn(ctx, in, opts...)
+	}
+	return nil, fmt.Errorf("not implemented")
+}
+func (s *stubSecuritiesClient) DeleteHoliday(ctx context.Context, in *pb.DeleteHolidayRequest, opts ...grpc.CallOption) (*pb.DeleteHolidayResponse, error) {
+	if s.deleteHolidayFn != nil {
+		return s.deleteHolidayFn(ctx, in, opts...)
+	}
+	return nil, fmt.Errorf("not implemented")
+}
+func (s *stubSecuritiesClient) IsExchangeOpen(ctx context.Context, in *pb.IsExchangeOpenRequest, opts ...grpc.CallOption) (*pb.IsExchangeOpenResponse, error) {
+	if s.isOpenFn != nil {
+		return s.isOpenFn(ctx, in, opts...)
+	}
+	return nil, fmt.Errorf("not implemented")
+}
+func (s *stubSecuritiesClient) GetTestMode(ctx context.Context, in *pb.GetTestModeRequest, opts ...grpc.CallOption) (*pb.GetTestModeResponse, error) {
+	if s.getTestModeFn != nil {
+		return s.getTestModeFn(ctx, in, opts...)
+	}
+	return nil, fmt.Errorf("not implemented")
+}
+func (s *stubSecuritiesClient) SetTestMode(ctx context.Context, in *pb.SetTestModeRequest, opts ...grpc.CallOption) (*pb.SetTestModeResponse, error) {
+	if s.setTestModeFn != nil {
+		return s.setTestModeFn(ctx, in, opts...)
+	}
+	return nil, fmt.Errorf("not implemented")
+}
+
+// ---- GetTestMode ----
+
+func TestGetTestMode_Happy(t *testing.T) {
+	client := &stubSecuritiesClient{
+		getTestModeFn: func(ctx context.Context, in *pb.GetTestModeRequest, opts ...grpc.CallOption) (*pb.GetTestModeResponse, error) {
+			return &pb.GetTestModeResponse{Enabled: true}, nil
+		},
+	}
+	w := serveHandler(GetTestMode(client), "GET", "/stock-exchanges/test-mode", "/stock-exchanges/test-mode", "")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"enabled":true`)
+}
+
+func TestGetTestMode_Error(t *testing.T) {
+	client := &stubSecuritiesClient{
+		getTestModeFn: func(ctx context.Context, in *pb.GetTestModeRequest, opts ...grpc.CallOption) (*pb.GetTestModeResponse, error) {
+			return nil, status.Error(codes.Internal, "db error")
+		},
+	}
+	w := serveHandler(GetTestMode(client), "GET", "/stock-exchanges/test-mode", "/stock-exchanges/test-mode", "")
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// ---- SetTestMode ----
+
+func TestSetTestMode_Enable(t *testing.T) {
+	client := &stubSecuritiesClient{
+		setTestModeFn: func(ctx context.Context, in *pb.SetTestModeRequest, opts ...grpc.CallOption) (*pb.SetTestModeResponse, error) {
+			return &pb.SetTestModeResponse{Enabled: in.Enabled}, nil
+		},
+	}
+	w := serveHandler(SetTestMode(client), "POST", "/stock-exchanges/test-mode", "/stock-exchanges/test-mode", `{"enabled":true}`)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"enabled":true`)
+}
+
+func TestSetTestMode_Disable(t *testing.T) {
+	client := &stubSecuritiesClient{
+		setTestModeFn: func(ctx context.Context, in *pb.SetTestModeRequest, opts ...grpc.CallOption) (*pb.SetTestModeResponse, error) {
+			return &pb.SetTestModeResponse{Enabled: in.Enabled}, nil
+		},
+	}
+	w := serveHandler(SetTestMode(client), "POST", "/stock-exchanges/test-mode", "/stock-exchanges/test-mode", `{"enabled":false}`)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"enabled":false`)
+}
+
+func TestSetTestMode_InvalidBody(t *testing.T) {
+	client := &stubSecuritiesClient{}
+	w := serveHandler(SetTestMode(client), "POST", "/stock-exchanges/test-mode", "/stock-exchanges/test-mode", `not-json`)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSetTestMode_Error(t *testing.T) {
+	client := &stubSecuritiesClient{
+		setTestModeFn: func(ctx context.Context, in *pb.SetTestModeRequest, opts ...grpc.CallOption) (*pb.SetTestModeResponse, error) {
+			return nil, status.Error(codes.Internal, "db error")
+		},
+	}
+	w := serveHandler(SetTestMode(client), "POST", "/stock-exchanges/test-mode", "/stock-exchanges/test-mode", `{"enabled":true}`)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}

--- a/services/api-gateway/main.go
+++ b/services/api-gateway/main.go
@@ -171,6 +171,8 @@ func main() {
 	r.PUT("/api/cards/:id/limit", middleware.RequireRole("EMPLOYEE"), handlers.UpdateCardLimit(cardClient))
 	r.GET("/stock-exchanges", middleware.RequireRole("EMPLOYEE"), handlers.GetStockExchanges(securitiesClient))
 	r.POST("/stock-exchanges", middleware.RequireRole("ADMIN"), handlers.CreateStockExchange(securitiesClient))
+	r.GET("/stock-exchanges/test-mode", middleware.RequireRole("ADMIN"), handlers.GetTestMode(securitiesClient))
+	r.POST("/stock-exchanges/test-mode", middleware.RequireRole("ADMIN"), handlers.SetTestMode(securitiesClient))
 	r.GET("/stock-exchanges/:mic", middleware.RequireRole("EMPLOYEE"), handlers.GetStockExchangeByMIC(securitiesClient))
 	r.PUT("/stock-exchanges/:mic", middleware.RequireRole("ADMIN"), handlers.UpdateStockExchange(securitiesClient))
 	r.DELETE("/stock-exchanges/:mic", middleware.RequireRole("ADMIN"), handlers.DeleteStockExchange(securitiesClient))

--- a/services/securities-service/db/schema.sql
+++ b/services/securities-service/db/schema.sql
@@ -28,3 +28,10 @@ CREATE TABLE exchange_holidays (
     description  VARCHAR(255),
     UNIQUE (polity, holiday_date)
 );
+
+-- Global settings (single row enforced by CHECK).
+CREATE TABLE settings (
+    id                BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (id = TRUE),
+    test_mode_enabled BOOLEAN NOT NULL DEFAULT FALSE
+);
+INSERT INTO settings (test_mode_enabled) VALUES (FALSE);

--- a/services/securities-service/handlers/grpc_server.go
+++ b/services/securities-service/handlers/grpc_server.go
@@ -217,10 +217,40 @@ func (s *SecuritiesServer) DeleteHoliday(ctx context.Context, req *pb.DeleteHoli
 	return &pb.DeleteHolidayResponse{}, nil
 }
 
+// ── Test Mode ─────────────────────────────────────────────────────────────────
+
+func (s *SecuritiesServer) GetTestMode(ctx context.Context, _ *pb.GetTestModeRequest) (*pb.GetTestModeResponse, error) {
+	var enabled bool
+	err := s.DB.QueryRowContext(ctx, `SELECT test_mode_enabled FROM settings WHERE id = TRUE`).Scan(&enabled)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "query failed: %v", err)
+	}
+	return &pb.GetTestModeResponse{Enabled: enabled}, nil
+}
+
+func (s *SecuritiesServer) SetTestMode(ctx context.Context, req *pb.SetTestModeRequest) (*pb.SetTestModeResponse, error) {
+	_, err := s.DB.ExecContext(ctx, `UPDATE settings SET test_mode_enabled = $1 WHERE id = TRUE`, req.Enabled)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "update failed: %v", err)
+	}
+	return &pb.SetTestModeResponse{Enabled: req.Enabled}, nil
+}
+
 // ── Exchange Status ───────────────────────────────────────────────────────────
 
 func (s *SecuritiesServer) IsExchangeOpen(ctx context.Context, req *pb.IsExchangeOpenRequest) (*pb.IsExchangeOpenResponse, error) {
-	// 1. Fetch timezone and polity for the exchange
+	// 1. Check test mode — if enabled, all exchanges are treated as open
+	var testMode bool
+	if err := s.DB.QueryRowContext(ctx, `SELECT test_mode_enabled FROM settings WHERE id = TRUE`).Scan(&testMode); err != nil {
+		return nil, status.Errorf(codes.Internal, "test mode check failed: %v", err)
+	}
+	if testMode {
+		return &pb.IsExchangeOpenResponse{
+			MicCode: req.MicCode, IsOpen: true, Segment: "test_mode",
+		}, nil
+	}
+
+	// 2. Fetch timezone and polity for the exchange
 	var timezone, polity string
 	err := s.DB.QueryRowContext(ctx,
 		`SELECT timezone, polity FROM stock_exchanges WHERE mic_code = $1`, req.MicCode).
@@ -232,7 +262,7 @@ func (s *SecuritiesServer) IsExchangeOpen(ctx context.Context, req *pb.IsExchang
 		return nil, status.Errorf(codes.Internal, "query failed: %v", err)
 	}
 
-	// 2. Get current time in the exchange's local timezone
+	// 3. Get current time in the exchange's local timezone
 	loc, err := time.LoadLocation(timezone)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "invalid timezone %q: %v", timezone, err)
@@ -241,7 +271,7 @@ func (s *SecuritiesServer) IsExchangeOpen(ctx context.Context, req *pb.IsExchang
 	today := now.Format("2006-01-02")
 	currentTime := now.Format("15:04")
 
-	// 3. Check if today is a holiday
+	// 4. Check if today is a holiday
 	var holidayExists bool
 	err = s.DB.QueryRowContext(ctx,
 		`SELECT EXISTS(SELECT 1 FROM exchange_holidays WHERE polity = $1 AND holiday_date = $2)`,
@@ -258,7 +288,7 @@ func (s *SecuritiesServer) IsExchangeOpen(ctx context.Context, req *pb.IsExchang
 		}, nil
 	}
 
-	// 4. Load working hours for this polity
+	// 5. Load working hours for this polity
 	rows, err := s.DB.QueryContext(ctx,
 		`SELECT segment, open_time, close_time FROM exchange_working_hours WHERE polity = $1`,
 		polity)
@@ -267,7 +297,7 @@ func (s *SecuritiesServer) IsExchangeOpen(ctx context.Context, req *pb.IsExchang
 	}
 	defer rows.Close()
 
-	// 5. Check which segment (if any) the current time falls in
+	// 6. Check which segment (if any) the current time falls in
 	for rows.Next() {
 		var segment, openStr, closeStr string
 		if err := rows.Scan(&segment, &openStr, &closeStr); err != nil {
@@ -283,7 +313,7 @@ func (s *SecuritiesServer) IsExchangeOpen(ctx context.Context, req *pb.IsExchang
 		}
 	}
 
-	// 6. No segment matched — exchange is closed
+	// 7. No segment matched — exchange is closed
 	return &pb.IsExchangeOpenResponse{
 		MicCode:          req.MicCode,
 		IsOpen:           false,

--- a/services/securities-service/handlers/grpc_server_test.go
+++ b/services/securities-service/handlers/grpc_server_test.go
@@ -231,3 +231,85 @@ func TestDeleteStockExchange_DBError(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, codes.Internal, status.Code(err))
 }
+
+// ── GetTestMode ───────────────────────────────────────────────────────────────
+
+func TestGetTestMode_DefaultFalse(t *testing.T) {
+	s, mock := newServer(t)
+	mock.ExpectQuery("SELECT test_mode_enabled FROM settings").
+		WillReturnRows(sqlmock.NewRows([]string{"test_mode_enabled"}).AddRow(false))
+
+	resp, err := s.GetTestMode(context.Background(), &pb.GetTestModeRequest{})
+	require.NoError(t, err)
+	assert.False(t, resp.Enabled)
+}
+
+func TestGetTestMode_True(t *testing.T) {
+	s, mock := newServer(t)
+	mock.ExpectQuery("SELECT test_mode_enabled FROM settings").
+		WillReturnRows(sqlmock.NewRows([]string{"test_mode_enabled"}).AddRow(true))
+
+	resp, err := s.GetTestMode(context.Background(), &pb.GetTestModeRequest{})
+	require.NoError(t, err)
+	assert.True(t, resp.Enabled)
+}
+
+func TestGetTestMode_DBError(t *testing.T) {
+	s, mock := newServer(t)
+	mock.ExpectQuery("SELECT test_mode_enabled FROM settings").
+		WillReturnError(sql.ErrConnDone)
+
+	_, err := s.GetTestMode(context.Background(), &pb.GetTestModeRequest{})
+	require.Error(t, err)
+	assert.Equal(t, codes.Internal, status.Code(err))
+}
+
+// ── SetTestMode ───────────────────────────────────────────────────────────────
+
+func TestSetTestMode_Enable(t *testing.T) {
+	s, mock := newServer(t)
+	mock.ExpectExec("UPDATE settings").
+		WithArgs(true).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	resp, err := s.SetTestMode(context.Background(), &pb.SetTestModeRequest{Enabled: true})
+	require.NoError(t, err)
+	assert.True(t, resp.Enabled)
+}
+
+func TestSetTestMode_Disable(t *testing.T) {
+	s, mock := newServer(t)
+	mock.ExpectExec("UPDATE settings").
+		WithArgs(false).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	resp, err := s.SetTestMode(context.Background(), &pb.SetTestModeRequest{Enabled: false})
+	require.NoError(t, err)
+	assert.False(t, resp.Enabled)
+}
+
+func TestSetTestMode_DBError(t *testing.T) {
+	s, mock := newServer(t)
+	mock.ExpectExec("UPDATE settings").
+		WillReturnError(sql.ErrConnDone)
+
+	_, err := s.SetTestMode(context.Background(), &pb.SetTestModeRequest{Enabled: true})
+	require.Error(t, err)
+	assert.Equal(t, codes.Internal, status.Code(err))
+}
+
+// ── IsExchangeOpen (test mode) ────────────────────────────────────────────────
+
+func TestIsExchangeOpen_TestModeOn(t *testing.T) {
+	s, mock := newServer(t)
+	mock.ExpectQuery("SELECT test_mode_enabled FROM settings").
+		WillReturnRows(sqlmock.NewRows([]string{"test_mode_enabled"}).AddRow(true))
+
+	resp, err := s.IsExchangeOpen(context.Background(), &pb.IsExchangeOpenRequest{MicCode: "XNYS"})
+	require.NoError(t, err)
+	assert.True(t, resp.IsOpen)
+	assert.Equal(t, "test_mode", resp.Segment)
+	assert.Equal(t, "XNYS", resp.MicCode)
+	// No further DB queries should have been made
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/services/securities-service/handlers/working_hours_test.go
+++ b/services/securities-service/handlers/working_hours_test.go
@@ -236,6 +236,8 @@ func TestDeleteHoliday_DBError(t *testing.T) {
 
 func TestIsExchangeOpen_ExchangeNotFound(t *testing.T) {
 	s, mock := newServer(t)
+	mock.ExpectQuery("SELECT test_mode_enabled FROM settings").
+		WillReturnRows(sqlmock.NewRows([]string{"test_mode_enabled"}).AddRow(false))
 	mock.ExpectQuery("SELECT timezone, polity FROM stock_exchanges").
 		WithArgs("XXXX").
 		WillReturnError(sql.ErrNoRows)
@@ -247,6 +249,8 @@ func TestIsExchangeOpen_ExchangeNotFound(t *testing.T) {
 
 func TestIsExchangeOpen_DBError(t *testing.T) {
 	s, mock := newServer(t)
+	mock.ExpectQuery("SELECT test_mode_enabled FROM settings").
+		WillReturnRows(sqlmock.NewRows([]string{"test_mode_enabled"}).AddRow(false))
 	mock.ExpectQuery("SELECT timezone, polity FROM stock_exchanges").
 		WithArgs("XNYS").
 		WillReturnError(sql.ErrConnDone)
@@ -258,6 +262,8 @@ func TestIsExchangeOpen_DBError(t *testing.T) {
 
 func TestIsExchangeOpen_Holiday(t *testing.T) {
 	s, mock := newServer(t)
+	mock.ExpectQuery("SELECT test_mode_enabled FROM settings").
+		WillReturnRows(sqlmock.NewRows([]string{"test_mode_enabled"}).AddRow(false))
 	mock.ExpectQuery("SELECT timezone, polity FROM stock_exchanges").
 		WithArgs("XNYS").
 		WillReturnRows(sqlmock.NewRows([]string{"timezone", "polity"}).
@@ -275,6 +281,8 @@ func TestIsExchangeOpen_Holiday(t *testing.T) {
 
 func TestIsExchangeOpen_NoHoursConfigured(t *testing.T) {
 	s, mock := newServer(t)
+	mock.ExpectQuery("SELECT test_mode_enabled FROM settings").
+		WillReturnRows(sqlmock.NewRows([]string{"test_mode_enabled"}).AddRow(false))
 	mock.ExpectQuery("SELECT timezone, polity FROM stock_exchanges").
 		WithArgs("XNYS").
 		WillReturnRows(sqlmock.NewRows([]string{"timezone", "polity"}).

--- a/shared/pb/securities/securities.pb.go
+++ b/shared/pb/securities/securities.pb.go
@@ -1369,7 +1369,7 @@ type IsExchangeOpenResponse struct {
 	state            protoimpl.MessageState `protogen:"open.v1"`
 	MicCode          string                 `protobuf:"bytes,1,opt,name=mic_code,json=micCode,proto3" json:"mic_code,omitempty"`
 	IsOpen           bool                   `protobuf:"varint,2,opt,name=is_open,json=isOpen,proto3" json:"is_open,omitempty"`
-	Segment          string                 `protobuf:"bytes,3,opt,name=segment,proto3" json:"segment,omitempty"`                                             // "pre_market", "regular", "post_market", or "closed"
+	Segment          string                 `protobuf:"bytes,3,opt,name=segment,proto3" json:"segment,omitempty"`                                             // "pre_market", "regular", "post_market", "test_mode", or "closed"
 	CurrentTimeLocal string                 `protobuf:"bytes,4,opt,name=current_time_local,json=currentTimeLocal,proto3" json:"current_time_local,omitempty"` // "HH:MM" in exchange's local timezone
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache
@@ -1431,6 +1431,174 @@ func (x *IsExchangeOpenResponse) GetCurrentTimeLocal() string {
 		return x.CurrentTimeLocal
 	}
 	return ""
+}
+
+type GetTestModeRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetTestModeRequest) Reset() {
+	*x = GetTestModeRequest{}
+	mi := &file_securities_proto_msgTypes[27]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetTestModeRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetTestModeRequest) ProtoMessage() {}
+
+func (x *GetTestModeRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_securities_proto_msgTypes[27]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetTestModeRequest.ProtoReflect.Descriptor instead.
+func (*GetTestModeRequest) Descriptor() ([]byte, []int) {
+	return file_securities_proto_rawDescGZIP(), []int{27}
+}
+
+type GetTestModeResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Enabled       bool                   `protobuf:"varint,1,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetTestModeResponse) Reset() {
+	*x = GetTestModeResponse{}
+	mi := &file_securities_proto_msgTypes[28]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetTestModeResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetTestModeResponse) ProtoMessage() {}
+
+func (x *GetTestModeResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_securities_proto_msgTypes[28]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetTestModeResponse.ProtoReflect.Descriptor instead.
+func (*GetTestModeResponse) Descriptor() ([]byte, []int) {
+	return file_securities_proto_rawDescGZIP(), []int{28}
+}
+
+func (x *GetTestModeResponse) GetEnabled() bool {
+	if x != nil {
+		return x.Enabled
+	}
+	return false
+}
+
+type SetTestModeRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Enabled       bool                   `protobuf:"varint,1,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SetTestModeRequest) Reset() {
+	*x = SetTestModeRequest{}
+	mi := &file_securities_proto_msgTypes[29]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SetTestModeRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SetTestModeRequest) ProtoMessage() {}
+
+func (x *SetTestModeRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_securities_proto_msgTypes[29]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SetTestModeRequest.ProtoReflect.Descriptor instead.
+func (*SetTestModeRequest) Descriptor() ([]byte, []int) {
+	return file_securities_proto_rawDescGZIP(), []int{29}
+}
+
+func (x *SetTestModeRequest) GetEnabled() bool {
+	if x != nil {
+		return x.Enabled
+	}
+	return false
+}
+
+type SetTestModeResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Enabled       bool                   `protobuf:"varint,1,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SetTestModeResponse) Reset() {
+	*x = SetTestModeResponse{}
+	mi := &file_securities_proto_msgTypes[30]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SetTestModeResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SetTestModeResponse) ProtoMessage() {}
+
+func (x *SetTestModeResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_securities_proto_msgTypes[30]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SetTestModeResponse.ProtoReflect.Descriptor instead.
+func (*SetTestModeResponse) Descriptor() ([]byte, []int) {
+	return file_securities_proto_rawDescGZIP(), []int{30}
+}
+
+func (x *SetTestModeResponse) GetEnabled() bool {
+	if x != nil {
+		return x.Enabled
+	}
+	return false
 }
 
 var File_securities_proto protoreflect.FileDescriptor
@@ -1522,7 +1690,14 @@ const file_securities_proto_rawDesc = "" +
 	"\bmic_code\x18\x01 \x01(\tR\amicCode\x12\x17\n" +
 	"\ais_open\x18\x02 \x01(\bR\x06isOpen\x12\x18\n" +
 	"\asegment\x18\x03 \x01(\tR\asegment\x12,\n" +
-	"\x12current_time_local\x18\x04 \x01(\tR\x10currentTimeLocal2\xda\b\n" +
+	"\x12current_time_local\x18\x04 \x01(\tR\x10currentTimeLocal\"\x14\n" +
+	"\x12GetTestModeRequest\"/\n" +
+	"\x13GetTestModeResponse\x12\x18\n" +
+	"\aenabled\x18\x01 \x01(\bR\aenabled\".\n" +
+	"\x12SetTestModeRequest\x12\x18\n" +
+	"\aenabled\x18\x01 \x01(\bR\aenabled\"/\n" +
+	"\x13SetTestModeResponse\x12\x18\n" +
+	"\aenabled\x18\x01 \x01(\bR\aenabled2\xfa\t\n" +
 	"\x11SecuritiesService\x129\n" +
 	"\x04Ping\x12\x17.securities.PingRequest\x1a\x18.securities.PingResponse\x12`\n" +
 	"\x11GetStockExchanges\x12$.securities.GetStockExchangesRequest\x1a%.securities.GetStockExchangesResponse\x12l\n" +
@@ -1536,7 +1711,9 @@ const file_securities_proto_rawDesc = "" +
 	"\n" +
 	"AddHoliday\x12\x1d.securities.AddHolidayRequest\x1a\x1e.securities.AddHolidayResponse\x12T\n" +
 	"\rDeleteHoliday\x12 .securities.DeleteHolidayRequest\x1a!.securities.DeleteHolidayResponse\x12W\n" +
-	"\x0eIsExchangeOpen\x12!.securities.IsExchangeOpenRequest\x1a\".securities.IsExchangeOpenResponseB?Z=github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/securitiesb\x06proto3"
+	"\x0eIsExchangeOpen\x12!.securities.IsExchangeOpenRequest\x1a\".securities.IsExchangeOpenResponse\x12N\n" +
+	"\vGetTestMode\x12\x1e.securities.GetTestModeRequest\x1a\x1f.securities.GetTestModeResponse\x12N\n" +
+	"\vSetTestMode\x12\x1e.securities.SetTestModeRequest\x1a\x1f.securities.SetTestModeResponseB?Z=github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/securitiesb\x06proto3"
 
 var (
 	file_securities_proto_rawDescOnce sync.Once
@@ -1550,7 +1727,7 @@ func file_securities_proto_rawDescGZIP() []byte {
 	return file_securities_proto_rawDescData
 }
 
-var file_securities_proto_msgTypes = make([]protoimpl.MessageInfo, 27)
+var file_securities_proto_msgTypes = make([]protoimpl.MessageInfo, 31)
 var file_securities_proto_goTypes = []any{
 	(*PingRequest)(nil),                   // 0: securities.PingRequest
 	(*PingResponse)(nil),                  // 1: securities.PingResponse
@@ -1579,6 +1756,10 @@ var file_securities_proto_goTypes = []any{
 	(*DeleteHolidayResponse)(nil),         // 24: securities.DeleteHolidayResponse
 	(*IsExchangeOpenRequest)(nil),         // 25: securities.IsExchangeOpenRequest
 	(*IsExchangeOpenResponse)(nil),        // 26: securities.IsExchangeOpenResponse
+	(*GetTestModeRequest)(nil),            // 27: securities.GetTestModeRequest
+	(*GetTestModeResponse)(nil),           // 28: securities.GetTestModeResponse
+	(*SetTestModeRequest)(nil),            // 29: securities.SetTestModeRequest
+	(*SetTestModeResponse)(nil),           // 30: securities.SetTestModeResponse
 }
 var file_securities_proto_depIdxs = []int32{
 	2,  // 0: securities.GetStockExchangesResponse.exchanges:type_name -> securities.StockExchange
@@ -1601,20 +1782,24 @@ var file_securities_proto_depIdxs = []int32{
 	21, // 17: securities.SecuritiesService.AddHoliday:input_type -> securities.AddHolidayRequest
 	23, // 18: securities.SecuritiesService.DeleteHoliday:input_type -> securities.DeleteHolidayRequest
 	25, // 19: securities.SecuritiesService.IsExchangeOpen:input_type -> securities.IsExchangeOpenRequest
-	1,  // 20: securities.SecuritiesService.Ping:output_type -> securities.PingResponse
-	4,  // 21: securities.SecuritiesService.GetStockExchanges:output_type -> securities.GetStockExchangesResponse
-	6,  // 22: securities.SecuritiesService.GetStockExchangeByMIC:output_type -> securities.GetStockExchangeByMICResponse
-	8,  // 23: securities.SecuritiesService.CreateStockExchange:output_type -> securities.CreateStockExchangeResponse
-	10, // 24: securities.SecuritiesService.UpdateStockExchange:output_type -> securities.UpdateStockExchangeResponse
-	12, // 25: securities.SecuritiesService.DeleteStockExchange:output_type -> securities.DeleteStockExchangeResponse
-	15, // 26: securities.SecuritiesService.GetWorkingHours:output_type -> securities.GetWorkingHoursResponse
-	17, // 27: securities.SecuritiesService.SetWorkingHours:output_type -> securities.SetWorkingHoursResponse
-	20, // 28: securities.SecuritiesService.GetHolidays:output_type -> securities.GetHolidaysResponse
-	22, // 29: securities.SecuritiesService.AddHoliday:output_type -> securities.AddHolidayResponse
-	24, // 30: securities.SecuritiesService.DeleteHoliday:output_type -> securities.DeleteHolidayResponse
-	26, // 31: securities.SecuritiesService.IsExchangeOpen:output_type -> securities.IsExchangeOpenResponse
-	20, // [20:32] is the sub-list for method output_type
-	8,  // [8:20] is the sub-list for method input_type
+	27, // 20: securities.SecuritiesService.GetTestMode:input_type -> securities.GetTestModeRequest
+	29, // 21: securities.SecuritiesService.SetTestMode:input_type -> securities.SetTestModeRequest
+	1,  // 22: securities.SecuritiesService.Ping:output_type -> securities.PingResponse
+	4,  // 23: securities.SecuritiesService.GetStockExchanges:output_type -> securities.GetStockExchangesResponse
+	6,  // 24: securities.SecuritiesService.GetStockExchangeByMIC:output_type -> securities.GetStockExchangeByMICResponse
+	8,  // 25: securities.SecuritiesService.CreateStockExchange:output_type -> securities.CreateStockExchangeResponse
+	10, // 26: securities.SecuritiesService.UpdateStockExchange:output_type -> securities.UpdateStockExchangeResponse
+	12, // 27: securities.SecuritiesService.DeleteStockExchange:output_type -> securities.DeleteStockExchangeResponse
+	15, // 28: securities.SecuritiesService.GetWorkingHours:output_type -> securities.GetWorkingHoursResponse
+	17, // 29: securities.SecuritiesService.SetWorkingHours:output_type -> securities.SetWorkingHoursResponse
+	20, // 30: securities.SecuritiesService.GetHolidays:output_type -> securities.GetHolidaysResponse
+	22, // 31: securities.SecuritiesService.AddHoliday:output_type -> securities.AddHolidayResponse
+	24, // 32: securities.SecuritiesService.DeleteHoliday:output_type -> securities.DeleteHolidayResponse
+	26, // 33: securities.SecuritiesService.IsExchangeOpen:output_type -> securities.IsExchangeOpenResponse
+	28, // 34: securities.SecuritiesService.GetTestMode:output_type -> securities.GetTestModeResponse
+	30, // 35: securities.SecuritiesService.SetTestMode:output_type -> securities.SetTestModeResponse
+	22, // [22:36] is the sub-list for method output_type
+	8,  // [8:22] is the sub-list for method input_type
 	8,  // [8:8] is the sub-list for extension type_name
 	8,  // [8:8] is the sub-list for extension extendee
 	0,  // [0:8] is the sub-list for field type_name
@@ -1631,7 +1816,7 @@ func file_securities_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_securities_proto_rawDesc), len(file_securities_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   27,
+			NumMessages:   31,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/shared/pb/securities/securities_grpc.pb.go
+++ b/shared/pb/securities/securities_grpc.pb.go
@@ -31,6 +31,8 @@ const (
 	SecuritiesService_AddHoliday_FullMethodName            = "/securities.SecuritiesService/AddHoliday"
 	SecuritiesService_DeleteHoliday_FullMethodName         = "/securities.SecuritiesService/DeleteHoliday"
 	SecuritiesService_IsExchangeOpen_FullMethodName        = "/securities.SecuritiesService/IsExchangeOpen"
+	SecuritiesService_GetTestMode_FullMethodName           = "/securities.SecuritiesService/GetTestMode"
+	SecuritiesService_SetTestMode_FullMethodName           = "/securities.SecuritiesService/SetTestMode"
 )
 
 // SecuritiesServiceClient is the client API for SecuritiesService service.
@@ -53,6 +55,9 @@ type SecuritiesServiceClient interface {
 	DeleteHoliday(ctx context.Context, in *DeleteHolidayRequest, opts ...grpc.CallOption) (*DeleteHolidayResponse, error)
 	// Status
 	IsExchangeOpen(ctx context.Context, in *IsExchangeOpenRequest, opts ...grpc.CallOption) (*IsExchangeOpenResponse, error)
+	// Test Mode
+	GetTestMode(ctx context.Context, in *GetTestModeRequest, opts ...grpc.CallOption) (*GetTestModeResponse, error)
+	SetTestMode(ctx context.Context, in *SetTestModeRequest, opts ...grpc.CallOption) (*SetTestModeResponse, error)
 }
 
 type securitiesServiceClient struct {
@@ -183,6 +188,26 @@ func (c *securitiesServiceClient) IsExchangeOpen(ctx context.Context, in *IsExch
 	return out, nil
 }
 
+func (c *securitiesServiceClient) GetTestMode(ctx context.Context, in *GetTestModeRequest, opts ...grpc.CallOption) (*GetTestModeResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetTestModeResponse)
+	err := c.cc.Invoke(ctx, SecuritiesService_GetTestMode_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *securitiesServiceClient) SetTestMode(ctx context.Context, in *SetTestModeRequest, opts ...grpc.CallOption) (*SetTestModeResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SetTestModeResponse)
+	err := c.cc.Invoke(ctx, SecuritiesService_SetTestMode_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // SecuritiesServiceServer is the server API for SecuritiesService service.
 // All implementations must embed UnimplementedSecuritiesServiceServer
 // for forward compatibility.
@@ -203,6 +228,9 @@ type SecuritiesServiceServer interface {
 	DeleteHoliday(context.Context, *DeleteHolidayRequest) (*DeleteHolidayResponse, error)
 	// Status
 	IsExchangeOpen(context.Context, *IsExchangeOpenRequest) (*IsExchangeOpenResponse, error)
+	// Test Mode
+	GetTestMode(context.Context, *GetTestModeRequest) (*GetTestModeResponse, error)
+	SetTestMode(context.Context, *SetTestModeRequest) (*SetTestModeResponse, error)
 	mustEmbedUnimplementedSecuritiesServiceServer()
 }
 
@@ -248,6 +276,12 @@ func (UnimplementedSecuritiesServiceServer) DeleteHoliday(context.Context, *Dele
 }
 func (UnimplementedSecuritiesServiceServer) IsExchangeOpen(context.Context, *IsExchangeOpenRequest) (*IsExchangeOpenResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method IsExchangeOpen not implemented")
+}
+func (UnimplementedSecuritiesServiceServer) GetTestMode(context.Context, *GetTestModeRequest) (*GetTestModeResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetTestMode not implemented")
+}
+func (UnimplementedSecuritiesServiceServer) SetTestMode(context.Context, *SetTestModeRequest) (*SetTestModeResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method SetTestMode not implemented")
 }
 func (UnimplementedSecuritiesServiceServer) mustEmbedUnimplementedSecuritiesServiceServer() {}
 func (UnimplementedSecuritiesServiceServer) testEmbeddedByValue()                           {}
@@ -486,6 +520,42 @@ func _SecuritiesService_IsExchangeOpen_Handler(srv interface{}, ctx context.Cont
 	return interceptor(ctx, in, info, handler)
 }
 
+func _SecuritiesService_GetTestMode_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetTestModeRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SecuritiesServiceServer).GetTestMode(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SecuritiesService_GetTestMode_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SecuritiesServiceServer).GetTestMode(ctx, req.(*GetTestModeRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _SecuritiesService_SetTestMode_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SetTestModeRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SecuritiesServiceServer).SetTestMode(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SecuritiesService_SetTestMode_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SecuritiesServiceServer).SetTestMode(ctx, req.(*SetTestModeRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // SecuritiesService_ServiceDesc is the grpc.ServiceDesc for SecuritiesService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -540,6 +610,14 @@ var SecuritiesService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "IsExchangeOpen",
 			Handler:    _SecuritiesService_IsExchangeOpen_Handler,
+		},
+		{
+			MethodName: "GetTestMode",
+			Handler:    _SecuritiesService_GetTestMode_Handler,
+		},
+		{
+			MethodName: "SetTestMode",
+			Handler:    _SecuritiesService_SetTestMode_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/shared/proto/securities.proto
+++ b/shared/proto/securities.proto
@@ -103,9 +103,17 @@ message IsExchangeOpenRequest  { string mic_code = 1; }
 message IsExchangeOpenResponse {
   string mic_code          = 1;
   bool   is_open           = 2;
-  string segment           = 3; // "pre_market", "regular", "post_market", or "closed"
+  string segment           = 3; // "pre_market", "regular", "post_market", "test_mode", or "closed"
   string current_time_local = 4; // "HH:MM" in exchange's local timezone
 }
+
+// ── Test Mode ─────────────────────────────────────────────────────────────────
+
+message GetTestModeRequest  {}
+message GetTestModeResponse { bool enabled = 1; }
+
+message SetTestModeRequest  { bool enabled = 1; }
+message SetTestModeResponse { bool enabled = 1; }
 
 // ── Service ───────────────────────────────────────────────────────────────────
 
@@ -130,4 +138,8 @@ service SecuritiesService {
 
   // Status
   rpc IsExchangeOpen        (IsExchangeOpenRequest)        returns (IsExchangeOpenResponse);
+
+  // Test Mode
+  rpc GetTestMode           (GetTestModeRequest)           returns (GetTestModeResponse);
+  rpc SetTestMode           (SetTestModeRequest)           returns (SetTestModeResponse);
 }


### PR DESCRIPTION
## Summary

- Adds a global `test_mode_enabled` flag persisted in a new `settings` table in the securities-service DB
- When enabled, `IsExchangeOpen` skips all holiday and working hours checks and returns `is_open: true, segment: "test_mode"` for any exchange
- Exposes `GET /stock-exchanges/test-mode` and `POST /stock-exchanges/test-mode` endpoints in the API gateway (ADMIN role required)
- Adds `GetTestMode` and `SetTestMode` gRPC RPCs to `securities.proto` with regenerated bindings

## Test plan

- [x] 7 new gRPC handler tests (`TestGetTestMode_*`, `TestSetTestMode_*`, `TestIsExchangeOpen_TestModeOn`)
- [x] 5 new API gateway handler tests in new `securities_test.go`
- [x] Updated 3 existing `IsExchangeOpen` tests in `working_hours_test.go` to mock the new settings query
- [x] All tests pass: `go test ./handlers/...` in both `securities-service` and `api-gateway`

## Closes

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)