### PR TITLE
fix: resolve Gin routing conflict in stock-exchanges is-open route

### DIFF
--- a/services/api-gateway/handlers/securities.go
+++ b/services/api-gateway/handlers/securities.go
@@ -519,12 +519,15 @@ func SetTestMode(client pb.SecuritiesServiceClient) gin.HandlerFunc {
 // IsExchangeOpen godoc
 // @Summary      Check if an exchange is currently open
 // @Tags         securities
-// @Param        mic  path  string  true  "MIC code"
+// @Param        id  path  string  true  "Exchange ID or MIC code"
 // @Success      200  {object}  map[string]interface{}
-// @Router       /stock-exchanges/{mic}/is-open [get]
+// @Router       /stock-exchanges/{id}/is-open [get]
 func IsExchangeOpen(client pb.SecuritiesServiceClient) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		mic := c.Param("mic")
+		mic := resolveExchangeMIC(c, client, c.Param("id"))
+		if mic == "" {
+			return
+		}
 		ctx, cancel := context.WithTimeout(c.Request.Context(), 10*time.Second)
 		defer cancel()
 

--- a/services/api-gateway/main.go
+++ b/services/api-gateway/main.go
@@ -181,7 +181,7 @@ func main() {
 	r.GET("/stock-exchanges/:id/holidays", middleware.RequireRole("EMPLOYEE"), handlers.GetHolidays(securitiesClient))
 	r.POST("/stock-exchanges/holidays", middleware.RequireRole("ADMIN"), handlers.AddHoliday(securitiesClient))
 	r.DELETE("/stock-exchanges/holidays/:polity/:date", middleware.RequireRole("ADMIN"), handlers.DeleteHoliday(securitiesClient))
-	r.GET("/stock-exchanges/:mic/is-open", middleware.RequireRole("EMPLOYEE"), handlers.IsExchangeOpen(securitiesClient))
+	r.GET("/stock-exchanges/:id/is-open", middleware.RequireRole("EMPLOYEE"), handlers.IsExchangeOpen(securitiesClient))
 	r.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 	r.Run(":8083")
 }


### PR DESCRIPTION
## Summary
- Renames `:mic` to `:id` in `GET /stock-exchanges/:id/is-open` to match the other stock-exchange routes updated in #142
- Updates `IsExchangeOpen` handler to use `resolveExchangeMIC` so the endpoint accepts both numeric IDs and MIC codes
- Without this fix the api-gateway panics on startup due to conflicting wildcard names (`:mic` vs `:id`) on the same path segment

## Test plan
- [ ] `docker compose up --build api-gateway` — gateway starts without panic
- [ ] `GET /stock-exchanges/XNYS/is-open` returns open/closed status by MIC
- [ ] `GET /stock-exchanges/1/is-open` returns open/closed status by numeric ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)