### PR TITLE
feat(securities): listing schema, gRPC endpoints, and tests (#149, #1…

### DIFF
--- a/services/securities-service/db/schema.sql
+++ b/services/securities-service/db/schema.sql
@@ -35,3 +35,71 @@ CREATE TABLE settings (
     test_mode_enabled BOOLEAN NOT NULL DEFAULT FALSE
 );
 INSERT INTO settings (test_mode_enabled) VALUES (FALSE);
+
+-- ── Listings ──────────────────────────────────────────────────────────────────
+
+CREATE TYPE listing_type AS ENUM ('STOCK', 'FOREX_PAIR', 'FUTURES_CONTRACT', 'OPTION');
+CREATE TYPE liquidity_level AS ENUM ('HIGH', 'MEDIUM', 'LOW');
+CREATE TYPE option_type_enum AS ENUM ('CALL', 'PUT');
+
+-- Base listing (all subtypes share this row).
+CREATE TABLE listing (
+    id           BIGSERIAL     PRIMARY KEY,
+    ticker       VARCHAR(20)   NOT NULL UNIQUE,
+    name         VARCHAR(255)  NOT NULL,
+    exchange_id  BIGINT        NOT NULL REFERENCES stock_exchanges(id),
+    last_refresh TIMESTAMP,
+    price        NUMERIC(20,6) NOT NULL DEFAULT 0,
+    ask          NUMERIC(20,6) NOT NULL DEFAULT 0,
+    bid          NUMERIC(20,6) NOT NULL DEFAULT 0,
+    volume       BIGINT        NOT NULL DEFAULT 0,
+    change       NUMERIC(20,6) NOT NULL DEFAULT 0,
+    type         listing_type  NOT NULL
+);
+
+-- Daily OHLCV snapshot — one row per listing per calendar day.
+CREATE TABLE listing_daily_price_info (
+    id         BIGSERIAL     PRIMARY KEY,
+    listing_id BIGINT        NOT NULL REFERENCES listing(id) ON DELETE CASCADE,
+    date       DATE          NOT NULL,
+    price      NUMERIC(20,6) NOT NULL,
+    ask        NUMERIC(20,6) NOT NULL,
+    bid        NUMERIC(20,6) NOT NULL,
+    change     NUMERIC(20,6) NOT NULL DEFAULT 0,
+    volume     BIGINT        NOT NULL DEFAULT 0,
+    UNIQUE (listing_id, date)
+);
+
+-- Subtype: stock
+CREATE TABLE listing_stock (
+    listing_id         BIGINT        PRIMARY KEY REFERENCES listing(id) ON DELETE CASCADE,
+    outstanding_shares BIGINT        NOT NULL DEFAULT 0,
+    dividend_yield     NUMERIC(10,6) NOT NULL DEFAULT 0
+);
+
+-- Subtype: forex pair
+CREATE TABLE listing_forex_pair (
+    listing_id     BIGINT         PRIMARY KEY REFERENCES listing(id) ON DELETE CASCADE,
+    base_currency  VARCHAR(10)    NOT NULL,
+    quote_currency VARCHAR(10)    NOT NULL,
+    liquidity      liquidity_level NOT NULL DEFAULT 'MEDIUM'
+);
+
+-- Subtype: futures contract
+CREATE TABLE listing_futures_contract (
+    listing_id      BIGINT        PRIMARY KEY REFERENCES listing(id) ON DELETE CASCADE,
+    contract_size   NUMERIC(20,6) NOT NULL DEFAULT 1,
+    contract_unit   VARCHAR(50)   NOT NULL DEFAULT '',
+    settlement_date DATE
+);
+
+-- Subtype: option (listing_option avoids collision with SQL reserved word OPTION)
+CREATE TABLE listing_option (
+    listing_id         BIGINT           PRIMARY KEY REFERENCES listing(id) ON DELETE CASCADE,
+    stock_listing_id   BIGINT           NOT NULL REFERENCES listing(id),
+    option_type        option_type_enum NOT NULL,
+    strike_price       NUMERIC(20,6)    NOT NULL DEFAULT 0,
+    implied_volatility NUMERIC(10,6)    NOT NULL DEFAULT 0,
+    open_interest      BIGINT           NOT NULL DEFAULT 0,
+    settlement_date    DATE
+);

--- a/services/securities-service/handlers/grpc_server.go
+++ b/services/securities-service/handlers/grpc_server.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"time"
 
 	"github.com/lib/pq"
@@ -365,5 +366,348 @@ func nullableString(s string) interface{} {
 		return nil
 	}
 	return s
+}
+
+// ── Listings ──────────────────────────────────────────────────────────────────
+
+const listingBaseFrom = `
+	FROM listing l
+	JOIN stock_exchanges se ON l.exchange_id = se.id
+	LEFT JOIN listing_stock ls ON l.id = ls.listing_id
+	LEFT JOIN listing_futures_contract lfc ON l.id = lfc.listing_id
+	LEFT JOIN listing_option lo ON l.id = lo.listing_id
+	LEFT JOIN listing stock_ul ON lo.stock_listing_id = stock_ul.id`
+
+const listingBaseWhere = `
+	WHERE ($1 = '' OR l.type = $1::listing_type)
+	  AND ($2 = 0   OR l.exchange_id = $2)
+	  AND ($3 = ''  OR l.ticker ILIKE $3||'%')
+	  AND ($4 = ''  OR l.name   ILIKE '%'||$4||'%')`
+
+func (s *SecuritiesServer) GetListings(ctx context.Context, req *pb.GetListingsRequest) (*pb.GetListingsResponse, error) {
+	page, pageSize := req.Page, req.PageSize
+	if page <= 0 {
+		page = 1
+	}
+	if pageSize <= 0 {
+		pageSize = 20
+	}
+	offset := (page - 1) * pageSize
+
+	// Whitelisted ORDER BY — safe for fmt.Sprintf because values come from a switch
+	col := "l.id"
+	switch req.SortBy {
+	case "price":
+		col = "l.price"
+	case "volume":
+		col = "l.volume"
+	case "change_percent", "change":
+		col = "l.change"
+	}
+	ord := "ASC"
+	if req.SortOrder == "DESC" {
+		ord = "DESC"
+	}
+
+	var total int64
+	if err := s.DB.QueryRowContext(ctx,
+		`SELECT COUNT(*) `+listingBaseFrom+listingBaseWhere,
+		req.Type, req.ExchangeId, req.TickerPrefix, req.NameSearch,
+	).Scan(&total); err != nil {
+		return nil, status.Errorf(codes.Internal, "count failed: %v", err)
+	}
+	totalPages := int32((total + int64(pageSize) - 1) / int64(pageSize))
+
+	query := fmt.Sprintf(`
+		SELECT l.id, l.ticker, l.name, l.type::text, se.acronym,
+		       l.price, l.ask, l.bid, l.volume, l.change,
+		       COALESCE(ls.outstanding_shares, 0),
+		       COALESCE(lfc.contract_size, 1),
+		       lo.stock_listing_id,
+		       COALESCE(stock_ul.price, 0)
+		%s%s
+		ORDER BY %s %s
+		LIMIT $5 OFFSET $6`, listingBaseFrom, listingBaseWhere, col, ord)
+
+	rows, err := s.DB.QueryContext(ctx, query,
+		req.Type, req.ExchangeId, req.TickerPrefix, req.NameSearch, pageSize, offset)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "query failed: %v", err)
+	}
+	defer rows.Close()
+
+	var listings []*pb.ListingSummary
+	for rows.Next() {
+		var (
+			id             int64
+			ticker, name   string
+			lType, acronym string
+			price, ask, bid float64
+			volume          int64
+			change          float64
+			outshares       int64
+			contractSize    float64
+			stockListingID  sql.NullInt64
+			stockPrice      float64
+		)
+		if err := rows.Scan(
+			&id, &ticker, &name, &lType, &acronym,
+			&price, &ask, &bid, &volume, &change,
+			&outshares, &contractSize, &stockListingID, &stockPrice,
+		); err != nil {
+			return nil, status.Errorf(codes.Internal, "scan failed: %v", err)
+		}
+		mm := computeMaintenanceMargin(lType, price, outshares, contractSize, stockPrice)
+		cp := listingChangePercent(price, change)
+		listings = append(listings, &pb.ListingSummary{
+			Id:                id,
+			Ticker:            ticker,
+			Name:              name,
+			Type:              lType,
+			ExchangeAcronym:   acronym,
+			Price:             price,
+			Ask:               ask,
+			Bid:               bid,
+			Volume:            volume,
+			ChangePercent:     cp,
+			MaintenanceMargin: mm,
+			InitialMarginCost: mm * 1.1,
+			NominalValue:      listingNominalValue(lType, price, contractSize),
+		})
+	}
+	return &pb.GetListingsResponse{
+		Listings:      listings,
+		TotalPages:    totalPages,
+		TotalElements: total,
+	}, nil
+}
+
+func (s *SecuritiesServer) GetListingById(ctx context.Context, req *pb.GetListingByIdRequest) (*pb.GetListingByIdResponse, error) {
+	var (
+		id                          int64
+		ticker, name, lType, acronym string
+		price, ask, bid             float64
+		volume                      int64
+		change                      float64
+		// stock
+		outshares     sql.NullInt64
+		dividendYield sql.NullFloat64
+		// forex
+		baseCurrency, quoteCurrency, liquidity sql.NullString
+		// futures
+		contractSize      sql.NullFloat64
+		contractUnit      sql.NullString
+		futuresSettlement sql.NullTime
+		// option
+		stockListingID  sql.NullInt64
+		optionType      sql.NullString
+		strikePrice     sql.NullFloat64
+		impliedVol      sql.NullFloat64
+		openInterest    sql.NullInt64
+		optionSettlement sql.NullTime
+	)
+	err := s.DB.QueryRowContext(ctx, `
+		SELECT l.id, l.ticker, l.name, l.type::text, se.acronym,
+		       l.price, l.ask, l.bid, l.volume, l.change,
+		       ls.outstanding_shares, ls.dividend_yield,
+		       lfp.base_currency, lfp.quote_currency, lfp.liquidity::text,
+		       lfc.contract_size, lfc.contract_unit, lfc.settlement_date,
+		       lo.stock_listing_id, lo.option_type::text, lo.strike_price,
+		       lo.implied_volatility, lo.open_interest, lo.settlement_date
+		FROM listing l
+		JOIN stock_exchanges se ON l.exchange_id = se.id
+		LEFT JOIN listing_stock ls ON l.id = ls.listing_id
+		LEFT JOIN listing_forex_pair lfp ON l.id = lfp.listing_id
+		LEFT JOIN listing_futures_contract lfc ON l.id = lfc.listing_id
+		LEFT JOIN listing_option lo ON l.id = lo.listing_id
+		WHERE l.id = $1`, req.Id).Scan(
+		&id, &ticker, &name, &lType, &acronym,
+		&price, &ask, &bid, &volume, &change,
+		&outshares, &dividendYield,
+		&baseCurrency, &quoteCurrency, &liquidity,
+		&contractSize, &contractUnit, &futuresSettlement,
+		&stockListingID, &optionType, &strikePrice,
+		&impliedVol, &openInterest, &optionSettlement,
+	)
+	if err == sql.ErrNoRows {
+		return nil, status.Errorf(codes.NotFound, "listing with ID %d not found", req.Id)
+	}
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "query failed: %v", err)
+	}
+
+	// Fetch underlying stock price for options
+	var stockPrice float64
+	if stockListingID.Valid {
+		_ = s.DB.QueryRowContext(ctx, `SELECT price FROM listing WHERE id = $1`, stockListingID.Int64).Scan(&stockPrice)
+	}
+
+	csVal := 1.0
+	if contractSize.Valid {
+		csVal = contractSize.Float64
+	}
+	mm := computeMaintenanceMargin(lType, price, outshares.Int64, csVal, stockPrice)
+	cp := listingChangePercent(price, change)
+
+	summary := &pb.ListingSummary{
+		Id:                id,
+		Ticker:            ticker,
+		Name:              name,
+		Type:              lType,
+		ExchangeAcronym:   acronym,
+		Price:             price,
+		Ask:               ask,
+		Bid:               bid,
+		Volume:            volume,
+		ChangePercent:     cp,
+		MaintenanceMargin: mm,
+		InitialMarginCost: mm * 1.1,
+		NominalValue:      listingNominalValue(lType, price, csVal),
+	}
+
+	// Fetch last 30 days price history (descending)
+	histRows, err := s.DB.QueryContext(ctx, `
+		SELECT date, price, ask, bid, change, volume
+		FROM listing_daily_price_info
+		WHERE listing_id = $1
+		ORDER BY date DESC
+		LIMIT 30`, id)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "history query failed: %v", err)
+	}
+	defer histRows.Close()
+
+	var history []*pb.DailyPriceInfo
+	for histRows.Next() {
+		var d time.Time
+		p := &pb.DailyPriceInfo{}
+		if err := histRows.Scan(&d, &p.Price, &p.Ask, &p.Bid, &p.Change, &p.Volume); err != nil {
+			return nil, status.Errorf(codes.Internal, "history scan failed: %v", err)
+		}
+		p.Date = d.Format("2006-01-02")
+		history = append(history, p)
+	}
+
+	resp := &pb.GetListingByIdResponse{Summary: summary, PriceHistory: history}
+
+	switch lType {
+	case "STOCK":
+		resp.Detail = &pb.GetListingByIdResponse_Stock{
+			Stock: &pb.StockDetail{
+				OutstandingShares: outshares.Int64,
+				DividendYield:     dividendYield.Float64,
+				MarketCap:         float64(outshares.Int64) * price,
+			},
+		}
+	case "FOREX_PAIR":
+		resp.Detail = &pb.GetListingByIdResponse_Forex{
+			Forex: &pb.ForexDetail{
+				BaseCurrency:  baseCurrency.String,
+				QuoteCurrency: quoteCurrency.String,
+				Liquidity:     liquidity.String,
+				NominalValue:  1000 * price,
+			},
+		}
+	case "FUTURES_CONTRACT":
+		sd := ""
+		if futuresSettlement.Valid {
+			sd = futuresSettlement.Time.Format("2006-01-02")
+		}
+		resp.Detail = &pb.GetListingByIdResponse_Futures{
+			Futures: &pb.FuturesDetail{
+				ContractSize:   csVal,
+				ContractUnit:   contractUnit.String,
+				SettlementDate: sd,
+			},
+		}
+	case "OPTION":
+		sd := ""
+		if optionSettlement.Valid {
+			sd = optionSettlement.Time.Format("2006-01-02")
+		}
+		resp.Detail = &pb.GetListingByIdResponse_Option{
+			Option: &pb.OptionDetail{
+				StockListingId:    stockListingID.Int64,
+				OptionType:        optionType.String,
+				StrikePrice:       strikePrice.Float64,
+				ImpliedVolatility: impliedVol.Float64,
+				OpenInterest:      openInterest.Int64,
+				SettlementDate:    sd,
+			},
+		}
+	}
+
+	return resp, nil
+}
+
+func (s *SecuritiesServer) GetListingHistory(ctx context.Context, req *pb.GetListingHistoryRequest) (*pb.GetListingHistoryResponse, error) {
+	var exists bool
+	if err := s.DB.QueryRowContext(ctx,
+		`SELECT EXISTS(SELECT 1 FROM listing WHERE id = $1)`, req.Id,
+	).Scan(&exists); err != nil {
+		return nil, status.Errorf(codes.Internal, "query failed: %v", err)
+	}
+	if !exists {
+		return nil, status.Errorf(codes.NotFound, "listing with ID %d not found", req.Id)
+	}
+
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT date, price, ask, bid, change, volume
+		FROM listing_daily_price_info
+		WHERE listing_id = $1
+		  AND date BETWEEN $2::date AND $3::date
+		ORDER BY date ASC`, req.Id, req.FromDate, req.ToDate)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "query failed: %v", err)
+	}
+	defer rows.Close()
+
+	var history []*pb.DailyPriceInfo
+	for rows.Next() {
+		var d time.Time
+		p := &pb.DailyPriceInfo{}
+		if err := rows.Scan(&d, &p.Price, &p.Ask, &p.Bid, &p.Change, &p.Volume); err != nil {
+			return nil, status.Errorf(codes.Internal, "scan failed: %v", err)
+		}
+		p.Date = d.Format("2006-01-02")
+		history = append(history, p)
+	}
+	return &pb.GetListingHistoryResponse{History: history}, nil
+}
+
+// ── Derived field helpers ──────────────────────────────────────────────────────
+
+func computeMaintenanceMargin(lType string, price float64, outshares int64, contractSize, stockPrice float64) float64 {
+	switch lType {
+	case "STOCK":
+		return 0.5 * price
+	case "FOREX_PAIR":
+		return 1000 * price * 0.10
+	case "FUTURES_CONTRACT":
+		return contractSize * price * 0.10
+	case "OPTION":
+		return 100 * 0.5 * stockPrice
+	}
+	return 0
+}
+
+func listingChangePercent(price, change float64) float64 {
+	prev := price - change
+	if prev == 0 {
+		return 0
+	}
+	return (100 * change) / prev
+}
+
+func listingNominalValue(lType string, price, contractSize float64) float64 {
+	switch lType {
+	case "FOREX_PAIR":
+		return 1000 * price
+	case "FUTURES_CONTRACT":
+		return contractSize * price
+	case "OPTION":
+		return 100 * price
+	}
+	return price // STOCK: contractSize = 1
 }
 

--- a/services/securities-service/handlers/listing_test.go
+++ b/services/securities-service/handlers/listing_test.go
@@ -1,0 +1,497 @@
+package handlers
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	pb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/securities"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Column sets for row builders
+var listingSummaryCols = []string{
+	"id", "ticker", "name", "type", "acronym",
+	"price", "ask", "bid", "volume", "change",
+	"outstanding_shares", "contract_size", "stock_listing_id", "stock_price",
+}
+
+var listingDetailCols = []string{
+	"id", "ticker", "name", "type", "acronym",
+	"price", "ask", "bid", "volume", "change",
+	"outstanding_shares", "dividend_yield",
+	"base_currency", "quote_currency", "liquidity",
+	"contract_size", "contract_unit", "futures_settlement_date",
+	"stock_listing_id", "option_type", "strike_price",
+	"implied_volatility", "open_interest", "option_settlement_date",
+}
+
+var historyCols = []string{"date", "price", "ask", "bid", "change", "volume"}
+
+// ── GetListings ────────────────────────────────────────────────────────────────
+
+func TestGetListings_Empty(t *testing.T) {
+	s, mock := newServer(t)
+	mock.ExpectQuery("SELECT COUNT").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery("SELECT l.id").
+		WillReturnRows(sqlmock.NewRows(listingSummaryCols))
+
+	resp, err := s.GetListings(context.Background(), &pb.GetListingsRequest{})
+	require.NoError(t, err)
+	assert.Empty(t, resp.Listings)
+	assert.Equal(t, int64(0), resp.TotalElements)
+	assert.Equal(t, int32(0), resp.TotalPages)
+}
+
+func TestGetListings_StockDerivedFields(t *testing.T) {
+	s, mock := newServer(t)
+	mock.ExpectQuery("SELECT COUNT").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+	mock.ExpectQuery("SELECT l.id").
+		WillReturnRows(sqlmock.NewRows(listingSummaryCols).
+			// price=200, change=10 → prev=190, changePercent=5.263...
+			// maintenanceMargin(STOCK) = 0.5*200 = 100
+			// nominalValue(STOCK) = 200
+			AddRow(1, "AAPL", "Apple Inc", "STOCK", "NASDAQ",
+				200.0, 202.0, 198.0, int64(1000000), 10.0,
+				int64(5000000), 1.0, nil, 0.0))
+
+	resp, err := s.GetListings(context.Background(), &pb.GetListingsRequest{Page: 1, PageSize: 10})
+	require.NoError(t, err)
+	require.Len(t, resp.Listings, 1)
+
+	l := resp.Listings[0]
+	assert.Equal(t, int64(1), l.Id)
+	assert.Equal(t, "AAPL", l.Ticker)
+	assert.Equal(t, "STOCK", l.Type)
+	assert.Equal(t, "NASDAQ", l.ExchangeAcronym)
+	assert.InDelta(t, 100.0, l.MaintenanceMargin, 0.001)
+	assert.InDelta(t, 110.0, l.InitialMarginCost, 0.001)
+	assert.InDelta(t, 200.0, l.NominalValue, 0.001)
+	// changePercent = (100 * 10) / (200 - 10) = 1000/190 ≈ 5.263
+	assert.InDelta(t, 5.263, l.ChangePercent, 0.01)
+}
+
+func TestGetListings_ForexDerivedFields(t *testing.T) {
+	s, mock := newServer(t)
+	mock.ExpectQuery("SELECT COUNT").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+	mock.ExpectQuery("SELECT l.id").
+		WillReturnRows(sqlmock.NewRows(listingSummaryCols).
+			// maintenanceMargin(FOREX_PAIR) = 1000 * 1.1 * 0.10 = 110
+			// nominalValue(FOREX_PAIR) = 1000 * 1.1 = 1100
+			AddRow(2, "EUR/USD", "Euro / US Dollar", "FOREX_PAIR", "FOREX",
+				1.1, 1.101, 1.099, int64(0), 0.0,
+				int64(0), 1.0, nil, 0.0))
+
+	resp, err := s.GetListings(context.Background(), &pb.GetListingsRequest{})
+	require.NoError(t, err)
+	require.Len(t, resp.Listings, 1)
+	l := resp.Listings[0]
+	assert.InDelta(t, 110.0, l.MaintenanceMargin, 0.001)
+	assert.InDelta(t, 1100.0, l.NominalValue, 0.001)
+}
+
+func TestGetListings_FuturesDerivedFields(t *testing.T) {
+	s, mock := newServer(t)
+	mock.ExpectQuery("SELECT COUNT").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+	mock.ExpectQuery("SELECT l.id").
+		WillReturnRows(sqlmock.NewRows(listingSummaryCols).
+			// contractSize=1000, price=80 → maintenanceMargin = 1000*80*0.10 = 8000
+			AddRow(3, "CLJ25", "Crude Oil Jul 2025", "FUTURES_CONTRACT", "NYMEX",
+				80.0, 80.5, 79.5, int64(50000), 0.0,
+				int64(0), 1000.0, nil, 0.0))
+
+	resp, err := s.GetListings(context.Background(), &pb.GetListingsRequest{})
+	require.NoError(t, err)
+	require.Len(t, resp.Listings, 1)
+	l := resp.Listings[0]
+	assert.InDelta(t, 8000.0, l.MaintenanceMargin, 0.001)
+	assert.InDelta(t, 80000.0, l.NominalValue, 0.001)
+}
+
+func TestGetListings_OptionDerivedFields(t *testing.T) {
+	s, mock := newServer(t)
+	mock.ExpectQuery("SELECT COUNT").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+	mock.ExpectQuery("SELECT l.id").
+		WillReturnRows(sqlmock.NewRows(listingSummaryCols).
+			// stock_listing_id=1, stockPrice=200 → maintenanceMargin = 100*0.5*200 = 10000
+			AddRow(4, "AAPL240101C00150000", "AAPL Call", "OPTION", "CBOE",
+				5.0, 5.1, 4.9, int64(200), 0.0,
+				int64(0), 1.0, int64(1), 200.0))
+
+	resp, err := s.GetListings(context.Background(), &pb.GetListingsRequest{})
+	require.NoError(t, err)
+	require.Len(t, resp.Listings, 1)
+	l := resp.Listings[0]
+	assert.InDelta(t, 10000.0, l.MaintenanceMargin, 0.001)
+	assert.InDelta(t, 500.0, l.NominalValue, 0.001) // 100 * 5.0
+}
+
+func TestGetListings_DefaultPagination(t *testing.T) {
+	s, mock := newServer(t)
+	mock.ExpectQuery("SELECT COUNT").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery("SELECT l.id").
+		WillReturnRows(sqlmock.NewRows(listingSummaryCols))
+
+	// Zero values should default to page=1, pageSize=20
+	resp, err := s.GetListings(context.Background(), &pb.GetListingsRequest{Page: 0, PageSize: 0})
+	require.NoError(t, err)
+	assert.Empty(t, resp.Listings)
+}
+
+func TestGetListings_Pagination(t *testing.T) {
+	s, mock := newServer(t)
+	mock.ExpectQuery("SELECT COUNT").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(25))
+	mock.ExpectQuery("SELECT l.id").
+		WillReturnRows(sqlmock.NewRows(listingSummaryCols))
+
+	resp, err := s.GetListings(context.Background(), &pb.GetListingsRequest{Page: 2, PageSize: 10})
+	require.NoError(t, err)
+	assert.Equal(t, int64(25), resp.TotalElements)
+	assert.Equal(t, int32(3), resp.TotalPages) // ceil(25/10) = 3
+}
+
+func TestGetListings_CountDBError(t *testing.T) {
+	s, mock := newServer(t)
+	mock.ExpectQuery("SELECT COUNT").WillReturnError(sql.ErrConnDone)
+
+	_, err := s.GetListings(context.Background(), &pb.GetListingsRequest{})
+	require.Error(t, err)
+	assert.Equal(t, codes.Internal, status.Code(err))
+}
+
+func TestGetListings_QueryDBError(t *testing.T) {
+	s, mock := newServer(t)
+	mock.ExpectQuery("SELECT COUNT").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+	mock.ExpectQuery("SELECT l.id").WillReturnError(sql.ErrConnDone)
+
+	_, err := s.GetListings(context.Background(), &pb.GetListingsRequest{})
+	require.Error(t, err)
+	assert.Equal(t, codes.Internal, status.Code(err))
+}
+
+// ── GetListingById ─────────────────────────────────────────────────────────────
+
+func addStockDetailRow(rows *sqlmock.Rows) *sqlmock.Rows {
+	return rows.AddRow(
+		int64(1), "AAPL", "Apple Inc", "STOCK", "NASDAQ",
+		150.0, 151.0, 149.0, int64(500000), 5.0,
+		// stock
+		int64(1000000), 0.02,
+		// forex (nil)
+		nil, nil, nil,
+		// futures (nil)
+		nil, nil, nil,
+		// option (nil)
+		nil, nil, nil, nil, nil, nil,
+	)
+}
+
+func TestGetListingById_Stock(t *testing.T) {
+	s, mock := newServer(t)
+	mock.ExpectQuery("SELECT l.id, l.ticker").
+		WithArgs(int64(1)).
+		WillReturnRows(addStockDetailRow(sqlmock.NewRows(listingDetailCols)))
+	// history query
+	mock.ExpectQuery("SELECT date, price").
+		WillReturnRows(sqlmock.NewRows(historyCols).
+			AddRow(time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC), 150.0, 151.0, 149.0, 5.0, int64(500000)).
+			AddRow(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), 145.0, 146.0, 144.0, 3.0, int64(400000)))
+
+	resp, err := s.GetListingById(context.Background(), &pb.GetListingByIdRequest{Id: 1})
+	require.NoError(t, err)
+	require.NotNil(t, resp.Summary)
+	assert.Equal(t, "AAPL", resp.Summary.Ticker)
+	assert.Equal(t, "STOCK", resp.Summary.Type)
+	assert.InDelta(t, 75.0, resp.Summary.MaintenanceMargin, 0.001) // 0.5*150
+
+	require.Len(t, resp.PriceHistory, 2)
+	assert.Equal(t, "2025-01-02", resp.PriceHistory[0].Date)
+	assert.Equal(t, "2025-01-01", resp.PriceHistory[1].Date)
+
+	stockDetail, ok := resp.Detail.(*pb.GetListingByIdResponse_Stock)
+	require.True(t, ok, "expected Stock detail oneof")
+	assert.Equal(t, int64(1000000), stockDetail.Stock.OutstandingShares)
+	assert.InDelta(t, 0.02, stockDetail.Stock.DividendYield, 0.0001)
+	assert.InDelta(t, 150_000_000.0, stockDetail.Stock.MarketCap, 0.001) // 1M * 150
+}
+
+func TestGetListingById_Forex(t *testing.T) {
+	s, mock := newServer(t)
+	mock.ExpectQuery("SELECT l.id, l.ticker").
+		WithArgs(int64(2)).
+		WillReturnRows(sqlmock.NewRows(listingDetailCols).AddRow(
+			int64(2), "EUR/USD", "Euro / US Dollar", "FOREX_PAIR", "FOREX",
+			1.1, 1.101, 1.099, int64(0), 0.0,
+			// stock (nil)
+			nil, nil,
+			// forex
+			"EUR", "USD", "HIGH",
+			// futures (nil)
+			nil, nil, nil,
+			// option (nil)
+			nil, nil, nil, nil, nil, nil,
+		))
+	mock.ExpectQuery("SELECT date, price").
+		WillReturnRows(sqlmock.NewRows(historyCols))
+
+	resp, err := s.GetListingById(context.Background(), &pb.GetListingByIdRequest{Id: 2})
+	require.NoError(t, err)
+	assert.Equal(t, "EUR/USD", resp.Summary.Ticker)
+
+	forexDetail, ok := resp.Detail.(*pb.GetListingByIdResponse_Forex)
+	require.True(t, ok, "expected Forex detail oneof")
+	assert.Equal(t, "EUR", forexDetail.Forex.BaseCurrency)
+	assert.Equal(t, "USD", forexDetail.Forex.QuoteCurrency)
+	assert.Equal(t, "HIGH", forexDetail.Forex.Liquidity)
+	assert.InDelta(t, 1100.0, forexDetail.Forex.NominalValue, 0.001) // 1000 * 1.1
+}
+
+func TestGetListingById_Futures(t *testing.T) {
+	s, mock := newServer(t)
+	settleDate := time.Date(2025, 6, 30, 0, 0, 0, 0, time.UTC)
+	mock.ExpectQuery("SELECT l.id, l.ticker").
+		WithArgs(int64(3)).
+		WillReturnRows(sqlmock.NewRows(listingDetailCols).AddRow(
+			int64(3), "CLJ25", "Crude Oil", "FUTURES_CONTRACT", "NYMEX",
+			80.0, 80.5, 79.5, int64(50000), 0.0,
+			// stock (nil)
+			nil, nil,
+			// forex (nil)
+			nil, nil, nil,
+			// futures
+			1000.0, "Barrel", settleDate,
+			// option (nil)
+			nil, nil, nil, nil, nil, nil,
+		))
+	mock.ExpectQuery("SELECT date, price").
+		WillReturnRows(sqlmock.NewRows(historyCols))
+
+	resp, err := s.GetListingById(context.Background(), &pb.GetListingByIdRequest{Id: 3})
+	require.NoError(t, err)
+
+	futuresDetail, ok := resp.Detail.(*pb.GetListingByIdResponse_Futures)
+	require.True(t, ok, "expected Futures detail oneof")
+	assert.InDelta(t, 1000.0, futuresDetail.Futures.ContractSize, 0.001)
+	assert.Equal(t, "Barrel", futuresDetail.Futures.ContractUnit)
+	assert.Equal(t, "2025-06-30", futuresDetail.Futures.SettlementDate)
+}
+
+func TestGetListingById_Option(t *testing.T) {
+	s, mock := newServer(t)
+	settleDate := time.Date(2025, 3, 21, 0, 0, 0, 0, time.UTC)
+	mock.ExpectQuery("SELECT l.id, l.ticker").
+		WithArgs(int64(4)).
+		WillReturnRows(sqlmock.NewRows(listingDetailCols).AddRow(
+			int64(4), "AAPL250321C00150000", "AAPL Call 150", "OPTION", "CBOE",
+			5.0, 5.2, 4.8, int64(200), 0.0,
+			// stock (nil)
+			nil, nil,
+			// forex (nil)
+			nil, nil, nil,
+			// futures (nil)
+			nil, nil, nil,
+			// option
+			int64(1), "CALL", 150.0, 0.25, int64(5000), settleDate,
+		))
+	// Underlying stock price lookup
+	mock.ExpectQuery("SELECT price FROM listing WHERE id").
+		WithArgs(int64(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"price"}).AddRow(200.0))
+	mock.ExpectQuery("SELECT date, price").
+		WillReturnRows(sqlmock.NewRows(historyCols))
+
+	resp, err := s.GetListingById(context.Background(), &pb.GetListingByIdRequest{Id: 4})
+	require.NoError(t, err)
+
+	// maintenanceMargin = 100 * 0.5 * 200 = 10000
+	assert.InDelta(t, 10000.0, resp.Summary.MaintenanceMargin, 0.001)
+
+	optDetail, ok := resp.Detail.(*pb.GetListingByIdResponse_Option)
+	require.True(t, ok, "expected Option detail oneof")
+	assert.Equal(t, int64(1), optDetail.Option.StockListingId)
+	assert.Equal(t, "CALL", optDetail.Option.OptionType)
+	assert.InDelta(t, 150.0, optDetail.Option.StrikePrice, 0.001)
+	assert.InDelta(t, 0.25, optDetail.Option.ImpliedVolatility, 0.0001)
+	assert.Equal(t, int64(5000), optDetail.Option.OpenInterest)
+	assert.Equal(t, "2025-03-21", optDetail.Option.SettlementDate)
+}
+
+func TestGetListingById_NotFound(t *testing.T) {
+	s, mock := newServer(t)
+	mock.ExpectQuery("SELECT l.id, l.ticker").
+		WithArgs(int64(999)).
+		WillReturnError(sql.ErrNoRows)
+
+	_, err := s.GetListingById(context.Background(), &pb.GetListingByIdRequest{Id: 999})
+	require.Error(t, err)
+	assert.Equal(t, codes.NotFound, status.Code(err))
+}
+
+func TestGetListingById_DBError(t *testing.T) {
+	s, mock := newServer(t)
+	mock.ExpectQuery("SELECT l.id, l.ticker").
+		WithArgs(int64(1)).
+		WillReturnError(sql.ErrConnDone)
+
+	_, err := s.GetListingById(context.Background(), &pb.GetListingByIdRequest{Id: 1})
+	require.Error(t, err)
+	assert.Equal(t, codes.Internal, status.Code(err))
+}
+
+func TestGetListingById_EmptyHistory(t *testing.T) {
+	s, mock := newServer(t)
+	mock.ExpectQuery("SELECT l.id, l.ticker").
+		WithArgs(int64(1)).
+		WillReturnRows(addStockDetailRow(sqlmock.NewRows(listingDetailCols)))
+	mock.ExpectQuery("SELECT date, price").
+		WillReturnRows(sqlmock.NewRows(historyCols)) // no rows
+
+	resp, err := s.GetListingById(context.Background(), &pb.GetListingByIdRequest{Id: 1})
+	require.NoError(t, err)
+	assert.Empty(t, resp.PriceHistory)
+}
+
+// ── GetListingHistory ──────────────────────────────────────────────────────────
+
+func TestGetListingHistory_Found(t *testing.T) {
+	s, mock := newServer(t)
+	mock.ExpectQuery("SELECT EXISTS").
+		WithArgs(int64(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+	mock.ExpectQuery("SELECT date, price").
+		WillReturnRows(sqlmock.NewRows(historyCols).
+			AddRow(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), 100.0, 101.0, 99.0, 2.0, int64(300000)).
+			AddRow(time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC), 102.0, 103.0, 101.0, 2.0, int64(350000)).
+			AddRow(time.Date(2025, 1, 3, 0, 0, 0, 0, time.UTC), 104.0, 105.0, 103.0, 2.0, int64(400000)))
+
+	resp, err := s.GetListingHistory(context.Background(), &pb.GetListingHistoryRequest{
+		Id: 1, FromDate: "2025-01-01", ToDate: "2025-01-03",
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.History, 3)
+	assert.Equal(t, "2025-01-01", resp.History[0].Date)
+	assert.Equal(t, "2025-01-03", resp.History[2].Date)
+	assert.InDelta(t, 100.0, resp.History[0].Price, 0.001)
+}
+
+func TestGetListingHistory_NotFound(t *testing.T) {
+	s, mock := newServer(t)
+	mock.ExpectQuery("SELECT EXISTS").
+		WithArgs(int64(999)).
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+
+	_, err := s.GetListingHistory(context.Background(), &pb.GetListingHistoryRequest{
+		Id: 999, FromDate: "2025-01-01", ToDate: "2025-01-31",
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.NotFound, status.Code(err))
+}
+
+func TestGetListingHistory_ExistsDBError(t *testing.T) {
+	s, mock := newServer(t)
+	mock.ExpectQuery("SELECT EXISTS").
+		WithArgs(int64(1)).
+		WillReturnError(sql.ErrConnDone)
+
+	_, err := s.GetListingHistory(context.Background(), &pb.GetListingHistoryRequest{
+		Id: 1, FromDate: "2025-01-01", ToDate: "2025-01-31",
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.Internal, status.Code(err))
+}
+
+func TestGetListingHistory_EmptyRange(t *testing.T) {
+	s, mock := newServer(t)
+	mock.ExpectQuery("SELECT EXISTS").
+		WithArgs(int64(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+	mock.ExpectQuery("SELECT date, price").
+		WillReturnRows(sqlmock.NewRows(historyCols)) // no rows in range
+
+	resp, err := s.GetListingHistory(context.Background(), &pb.GetListingHistoryRequest{
+		Id: 1, FromDate: "2020-01-01", ToDate: "2020-01-31",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, resp.History)
+}
+
+// ── Helper function unit tests ─────────────────────────────────────────────────
+
+func TestComputeMaintenanceMargin(t *testing.T) {
+	tests := []struct {
+		name         string
+		lType        string
+		price        float64
+		outshares    int64
+		contractSize float64
+		stockPrice   float64
+		want         float64
+	}{
+		{"STOCK 50% of price", "STOCK", 200.0, 1000, 1.0, 0, 100.0},
+		{"STOCK zero price", "STOCK", 0.0, 0, 1.0, 0, 0.0},
+		{"FOREX_PAIR 10% of 1000*price", "FOREX_PAIR", 1.1, 0, 1.0, 0, 110.0},
+		{"FUTURES contractSize*price*10%", "FUTURES_CONTRACT", 80.0, 0, 1000.0, 0, 8000.0},
+		{"OPTION 100*50%*stockPrice", "OPTION", 5.0, 0, 1.0, 200.0, 10000.0},
+		{"unknown type returns 0", "UNKNOWN", 100.0, 0, 1.0, 0, 0.0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := computeMaintenanceMargin(tc.lType, tc.price, tc.outshares, tc.contractSize, tc.stockPrice)
+			assert.InDelta(t, tc.want, got, 0.001)
+		})
+	}
+}
+
+func TestListingChangePercent(t *testing.T) {
+	tests := []struct {
+		name   string
+		price  float64
+		change float64
+		want   float64
+	}{
+		{"positive change", 200.0, 10.0, 5.263}, // 100*10/190
+		{"negative change", 95.0, -5.0, -5.0},  // 100*(-5)/100
+		{"zero change", 100.0, 0.0, 0.0},
+		{"zero prev price guard", 5.0, 5.0, 0.0}, // prev = 0 → guard
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := listingChangePercent(tc.price, tc.change)
+			assert.InDelta(t, tc.want, got, 0.01)
+		})
+	}
+}
+
+func TestListingNominalValue(t *testing.T) {
+	tests := []struct {
+		lType        string
+		price        float64
+		contractSize float64
+		want         float64
+	}{
+		{"STOCK", 150.0, 1.0, 150.0},
+		{"FOREX_PAIR", 1.1, 1.0, 1100.0},
+		{"FUTURES_CONTRACT", 80.0, 1000.0, 80000.0},
+		{"OPTION", 5.0, 1.0, 500.0},
+		{"unknown", 100.0, 1.0, 100.0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.lType, func(t *testing.T) {
+			got := listingNominalValue(tc.lType, tc.price, tc.contractSize)
+			assert.InDelta(t, tc.want, got, 0.001)
+		})
+	}
+}

--- a/shared/pb/securities/securities.pb.go
+++ b/shared/pb/securities/securities.pb.go
@@ -1713,6 +1713,940 @@ func (x *SetTestModeResponse) GetEnabled() bool {
 	return false
 }
 
+type GetListingsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Type          string                 `protobuf:"bytes,1,opt,name=type,proto3" json:"type,omitempty"`                                // STOCK, FOREX_PAIR, FUTURES_CONTRACT, OPTION — empty = all
+	ExchangeId    int64                  `protobuf:"varint,2,opt,name=exchange_id,json=exchangeId,proto3" json:"exchange_id,omitempty"` // 0 = all exchanges
+	TickerPrefix  string                 `protobuf:"bytes,3,opt,name=ticker_prefix,json=tickerPrefix,proto3" json:"ticker_prefix,omitempty"`
+	NameSearch    string                 `protobuf:"bytes,4,opt,name=name_search,json=nameSearch,proto3" json:"name_search,omitempty"`
+	Page          int32                  `protobuf:"varint,5,opt,name=page,proto3" json:"page,omitempty"`                           // 1-based, default 1
+	PageSize      int32                  `protobuf:"varint,6,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`   // default 10
+	SortBy        string                 `protobuf:"bytes,7,opt,name=sort_by,json=sortBy,proto3" json:"sort_by,omitempty"`          // price, volume, change_percent, maintenance_margin
+	SortOrder     string                 `protobuf:"bytes,8,opt,name=sort_order,json=sortOrder,proto3" json:"sort_order,omitempty"` // ASC, DESC
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetListingsRequest) Reset() {
+	*x = GetListingsRequest{}
+	mi := &file_securities_proto_msgTypes[33]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetListingsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetListingsRequest) ProtoMessage() {}
+
+func (x *GetListingsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_securities_proto_msgTypes[33]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetListingsRequest.ProtoReflect.Descriptor instead.
+func (*GetListingsRequest) Descriptor() ([]byte, []int) {
+	return file_securities_proto_rawDescGZIP(), []int{33}
+}
+
+func (x *GetListingsRequest) GetType() string {
+	if x != nil {
+		return x.Type
+	}
+	return ""
+}
+
+func (x *GetListingsRequest) GetExchangeId() int64 {
+	if x != nil {
+		return x.ExchangeId
+	}
+	return 0
+}
+
+func (x *GetListingsRequest) GetTickerPrefix() string {
+	if x != nil {
+		return x.TickerPrefix
+	}
+	return ""
+}
+
+func (x *GetListingsRequest) GetNameSearch() string {
+	if x != nil {
+		return x.NameSearch
+	}
+	return ""
+}
+
+func (x *GetListingsRequest) GetPage() int32 {
+	if x != nil {
+		return x.Page
+	}
+	return 0
+}
+
+func (x *GetListingsRequest) GetPageSize() int32 {
+	if x != nil {
+		return x.PageSize
+	}
+	return 0
+}
+
+func (x *GetListingsRequest) GetSortBy() string {
+	if x != nil {
+		return x.SortBy
+	}
+	return ""
+}
+
+func (x *GetListingsRequest) GetSortOrder() string {
+	if x != nil {
+		return x.SortOrder
+	}
+	return ""
+}
+
+type ListingSummary struct {
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	Id                int64                  `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	Ticker            string                 `protobuf:"bytes,2,opt,name=ticker,proto3" json:"ticker,omitempty"`
+	Name              string                 `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
+	Type              string                 `protobuf:"bytes,4,opt,name=type,proto3" json:"type,omitempty"`
+	ExchangeAcronym   string                 `protobuf:"bytes,5,opt,name=exchange_acronym,json=exchangeAcronym,proto3" json:"exchange_acronym,omitempty"`
+	Price             float64                `protobuf:"fixed64,6,opt,name=price,proto3" json:"price,omitempty"`
+	Ask               float64                `protobuf:"fixed64,7,opt,name=ask,proto3" json:"ask,omitempty"`
+	Bid               float64                `protobuf:"fixed64,8,opt,name=bid,proto3" json:"bid,omitempty"`
+	Volume            int64                  `protobuf:"varint,9,opt,name=volume,proto3" json:"volume,omitempty"`
+	ChangePercent     float64                `protobuf:"fixed64,10,opt,name=change_percent,json=changePercent,proto3" json:"change_percent,omitempty"`
+	MaintenanceMargin float64                `protobuf:"fixed64,11,opt,name=maintenance_margin,json=maintenanceMargin,proto3" json:"maintenance_margin,omitempty"`
+	InitialMarginCost float64                `protobuf:"fixed64,12,opt,name=initial_margin_cost,json=initialMarginCost,proto3" json:"initial_margin_cost,omitempty"`
+	NominalValue      float64                `protobuf:"fixed64,13,opt,name=nominal_value,json=nominalValue,proto3" json:"nominal_value,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *ListingSummary) Reset() {
+	*x = ListingSummary{}
+	mi := &file_securities_proto_msgTypes[34]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListingSummary) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListingSummary) ProtoMessage() {}
+
+func (x *ListingSummary) ProtoReflect() protoreflect.Message {
+	mi := &file_securities_proto_msgTypes[34]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListingSummary.ProtoReflect.Descriptor instead.
+func (*ListingSummary) Descriptor() ([]byte, []int) {
+	return file_securities_proto_rawDescGZIP(), []int{34}
+}
+
+func (x *ListingSummary) GetId() int64 {
+	if x != nil {
+		return x.Id
+	}
+	return 0
+}
+
+func (x *ListingSummary) GetTicker() string {
+	if x != nil {
+		return x.Ticker
+	}
+	return ""
+}
+
+func (x *ListingSummary) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *ListingSummary) GetType() string {
+	if x != nil {
+		return x.Type
+	}
+	return ""
+}
+
+func (x *ListingSummary) GetExchangeAcronym() string {
+	if x != nil {
+		return x.ExchangeAcronym
+	}
+	return ""
+}
+
+func (x *ListingSummary) GetPrice() float64 {
+	if x != nil {
+		return x.Price
+	}
+	return 0
+}
+
+func (x *ListingSummary) GetAsk() float64 {
+	if x != nil {
+		return x.Ask
+	}
+	return 0
+}
+
+func (x *ListingSummary) GetBid() float64 {
+	if x != nil {
+		return x.Bid
+	}
+	return 0
+}
+
+func (x *ListingSummary) GetVolume() int64 {
+	if x != nil {
+		return x.Volume
+	}
+	return 0
+}
+
+func (x *ListingSummary) GetChangePercent() float64 {
+	if x != nil {
+		return x.ChangePercent
+	}
+	return 0
+}
+
+func (x *ListingSummary) GetMaintenanceMargin() float64 {
+	if x != nil {
+		return x.MaintenanceMargin
+	}
+	return 0
+}
+
+func (x *ListingSummary) GetInitialMarginCost() float64 {
+	if x != nil {
+		return x.InitialMarginCost
+	}
+	return 0
+}
+
+func (x *ListingSummary) GetNominalValue() float64 {
+	if x != nil {
+		return x.NominalValue
+	}
+	return 0
+}
+
+type GetListingsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Listings      []*ListingSummary      `protobuf:"bytes,1,rep,name=listings,proto3" json:"listings,omitempty"`
+	TotalPages    int32                  `protobuf:"varint,2,opt,name=total_pages,json=totalPages,proto3" json:"total_pages,omitempty"`
+	TotalElements int64                  `protobuf:"varint,3,opt,name=total_elements,json=totalElements,proto3" json:"total_elements,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetListingsResponse) Reset() {
+	*x = GetListingsResponse{}
+	mi := &file_securities_proto_msgTypes[35]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetListingsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetListingsResponse) ProtoMessage() {}
+
+func (x *GetListingsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_securities_proto_msgTypes[35]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetListingsResponse.ProtoReflect.Descriptor instead.
+func (*GetListingsResponse) Descriptor() ([]byte, []int) {
+	return file_securities_proto_rawDescGZIP(), []int{35}
+}
+
+func (x *GetListingsResponse) GetListings() []*ListingSummary {
+	if x != nil {
+		return x.Listings
+	}
+	return nil
+}
+
+func (x *GetListingsResponse) GetTotalPages() int32 {
+	if x != nil {
+		return x.TotalPages
+	}
+	return 0
+}
+
+func (x *GetListingsResponse) GetTotalElements() int64 {
+	if x != nil {
+		return x.TotalElements
+	}
+	return 0
+}
+
+type GetListingByIdRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            int64                  `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetListingByIdRequest) Reset() {
+	*x = GetListingByIdRequest{}
+	mi := &file_securities_proto_msgTypes[36]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetListingByIdRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetListingByIdRequest) ProtoMessage() {}
+
+func (x *GetListingByIdRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_securities_proto_msgTypes[36]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetListingByIdRequest.ProtoReflect.Descriptor instead.
+func (*GetListingByIdRequest) Descriptor() ([]byte, []int) {
+	return file_securities_proto_rawDescGZIP(), []int{36}
+}
+
+func (x *GetListingByIdRequest) GetId() int64 {
+	if x != nil {
+		return x.Id
+	}
+	return 0
+}
+
+type DailyPriceInfo struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Date          string                 `protobuf:"bytes,1,opt,name=date,proto3" json:"date,omitempty"` // "YYYY-MM-DD"
+	Price         float64                `protobuf:"fixed64,2,opt,name=price,proto3" json:"price,omitempty"`
+	Ask           float64                `protobuf:"fixed64,3,opt,name=ask,proto3" json:"ask,omitempty"`
+	Bid           float64                `protobuf:"fixed64,4,opt,name=bid,proto3" json:"bid,omitempty"`
+	Change        float64                `protobuf:"fixed64,5,opt,name=change,proto3" json:"change,omitempty"`
+	Volume        int64                  `protobuf:"varint,6,opt,name=volume,proto3" json:"volume,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DailyPriceInfo) Reset() {
+	*x = DailyPriceInfo{}
+	mi := &file_securities_proto_msgTypes[37]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DailyPriceInfo) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DailyPriceInfo) ProtoMessage() {}
+
+func (x *DailyPriceInfo) ProtoReflect() protoreflect.Message {
+	mi := &file_securities_proto_msgTypes[37]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DailyPriceInfo.ProtoReflect.Descriptor instead.
+func (*DailyPriceInfo) Descriptor() ([]byte, []int) {
+	return file_securities_proto_rawDescGZIP(), []int{37}
+}
+
+func (x *DailyPriceInfo) GetDate() string {
+	if x != nil {
+		return x.Date
+	}
+	return ""
+}
+
+func (x *DailyPriceInfo) GetPrice() float64 {
+	if x != nil {
+		return x.Price
+	}
+	return 0
+}
+
+func (x *DailyPriceInfo) GetAsk() float64 {
+	if x != nil {
+		return x.Ask
+	}
+	return 0
+}
+
+func (x *DailyPriceInfo) GetBid() float64 {
+	if x != nil {
+		return x.Bid
+	}
+	return 0
+}
+
+func (x *DailyPriceInfo) GetChange() float64 {
+	if x != nil {
+		return x.Change
+	}
+	return 0
+}
+
+func (x *DailyPriceInfo) GetVolume() int64 {
+	if x != nil {
+		return x.Volume
+	}
+	return 0
+}
+
+type StockDetail struct {
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	OutstandingShares int64                  `protobuf:"varint,1,opt,name=outstanding_shares,json=outstandingShares,proto3" json:"outstanding_shares,omitempty"`
+	DividendYield     float64                `protobuf:"fixed64,2,opt,name=dividend_yield,json=dividendYield,proto3" json:"dividend_yield,omitempty"`
+	MarketCap         float64                `protobuf:"fixed64,3,opt,name=market_cap,json=marketCap,proto3" json:"market_cap,omitempty"` // derived: outstanding_shares × price
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *StockDetail) Reset() {
+	*x = StockDetail{}
+	mi := &file_securities_proto_msgTypes[38]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StockDetail) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StockDetail) ProtoMessage() {}
+
+func (x *StockDetail) ProtoReflect() protoreflect.Message {
+	mi := &file_securities_proto_msgTypes[38]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StockDetail.ProtoReflect.Descriptor instead.
+func (*StockDetail) Descriptor() ([]byte, []int) {
+	return file_securities_proto_rawDescGZIP(), []int{38}
+}
+
+func (x *StockDetail) GetOutstandingShares() int64 {
+	if x != nil {
+		return x.OutstandingShares
+	}
+	return 0
+}
+
+func (x *StockDetail) GetDividendYield() float64 {
+	if x != nil {
+		return x.DividendYield
+	}
+	return 0
+}
+
+func (x *StockDetail) GetMarketCap() float64 {
+	if x != nil {
+		return x.MarketCap
+	}
+	return 0
+}
+
+type ForexDetail struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	BaseCurrency  string                 `protobuf:"bytes,1,opt,name=base_currency,json=baseCurrency,proto3" json:"base_currency,omitempty"`
+	QuoteCurrency string                 `protobuf:"bytes,2,opt,name=quote_currency,json=quoteCurrency,proto3" json:"quote_currency,omitempty"`
+	Liquidity     string                 `protobuf:"bytes,3,opt,name=liquidity,proto3" json:"liquidity,omitempty"`
+	NominalValue  float64                `protobuf:"fixed64,4,opt,name=nominal_value,json=nominalValue,proto3" json:"nominal_value,omitempty"` // derived: 1000 × price
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ForexDetail) Reset() {
+	*x = ForexDetail{}
+	mi := &file_securities_proto_msgTypes[39]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ForexDetail) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ForexDetail) ProtoMessage() {}
+
+func (x *ForexDetail) ProtoReflect() protoreflect.Message {
+	mi := &file_securities_proto_msgTypes[39]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ForexDetail.ProtoReflect.Descriptor instead.
+func (*ForexDetail) Descriptor() ([]byte, []int) {
+	return file_securities_proto_rawDescGZIP(), []int{39}
+}
+
+func (x *ForexDetail) GetBaseCurrency() string {
+	if x != nil {
+		return x.BaseCurrency
+	}
+	return ""
+}
+
+func (x *ForexDetail) GetQuoteCurrency() string {
+	if x != nil {
+		return x.QuoteCurrency
+	}
+	return ""
+}
+
+func (x *ForexDetail) GetLiquidity() string {
+	if x != nil {
+		return x.Liquidity
+	}
+	return ""
+}
+
+func (x *ForexDetail) GetNominalValue() float64 {
+	if x != nil {
+		return x.NominalValue
+	}
+	return 0
+}
+
+type FuturesDetail struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	ContractSize   float64                `protobuf:"fixed64,1,opt,name=contract_size,json=contractSize,proto3" json:"contract_size,omitempty"`
+	ContractUnit   string                 `protobuf:"bytes,2,opt,name=contract_unit,json=contractUnit,proto3" json:"contract_unit,omitempty"`
+	SettlementDate string                 `protobuf:"bytes,3,opt,name=settlement_date,json=settlementDate,proto3" json:"settlement_date,omitempty"` // "YYYY-MM-DD"
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *FuturesDetail) Reset() {
+	*x = FuturesDetail{}
+	mi := &file_securities_proto_msgTypes[40]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *FuturesDetail) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FuturesDetail) ProtoMessage() {}
+
+func (x *FuturesDetail) ProtoReflect() protoreflect.Message {
+	mi := &file_securities_proto_msgTypes[40]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FuturesDetail.ProtoReflect.Descriptor instead.
+func (*FuturesDetail) Descriptor() ([]byte, []int) {
+	return file_securities_proto_rawDescGZIP(), []int{40}
+}
+
+func (x *FuturesDetail) GetContractSize() float64 {
+	if x != nil {
+		return x.ContractSize
+	}
+	return 0
+}
+
+func (x *FuturesDetail) GetContractUnit() string {
+	if x != nil {
+		return x.ContractUnit
+	}
+	return ""
+}
+
+func (x *FuturesDetail) GetSettlementDate() string {
+	if x != nil {
+		return x.SettlementDate
+	}
+	return ""
+}
+
+type OptionDetail struct {
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	StockListingId    int64                  `protobuf:"varint,1,opt,name=stock_listing_id,json=stockListingId,proto3" json:"stock_listing_id,omitempty"`
+	OptionType        string                 `protobuf:"bytes,2,opt,name=option_type,json=optionType,proto3" json:"option_type,omitempty"` // CALL, PUT
+	StrikePrice       float64                `protobuf:"fixed64,3,opt,name=strike_price,json=strikePrice,proto3" json:"strike_price,omitempty"`
+	ImpliedVolatility float64                `protobuf:"fixed64,4,opt,name=implied_volatility,json=impliedVolatility,proto3" json:"implied_volatility,omitempty"`
+	OpenInterest      int64                  `protobuf:"varint,5,opt,name=open_interest,json=openInterest,proto3" json:"open_interest,omitempty"`
+	SettlementDate    string                 `protobuf:"bytes,6,opt,name=settlement_date,json=settlementDate,proto3" json:"settlement_date,omitempty"` // "YYYY-MM-DD"
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *OptionDetail) Reset() {
+	*x = OptionDetail{}
+	mi := &file_securities_proto_msgTypes[41]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *OptionDetail) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OptionDetail) ProtoMessage() {}
+
+func (x *OptionDetail) ProtoReflect() protoreflect.Message {
+	mi := &file_securities_proto_msgTypes[41]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use OptionDetail.ProtoReflect.Descriptor instead.
+func (*OptionDetail) Descriptor() ([]byte, []int) {
+	return file_securities_proto_rawDescGZIP(), []int{41}
+}
+
+func (x *OptionDetail) GetStockListingId() int64 {
+	if x != nil {
+		return x.StockListingId
+	}
+	return 0
+}
+
+func (x *OptionDetail) GetOptionType() string {
+	if x != nil {
+		return x.OptionType
+	}
+	return ""
+}
+
+func (x *OptionDetail) GetStrikePrice() float64 {
+	if x != nil {
+		return x.StrikePrice
+	}
+	return 0
+}
+
+func (x *OptionDetail) GetImpliedVolatility() float64 {
+	if x != nil {
+		return x.ImpliedVolatility
+	}
+	return 0
+}
+
+func (x *OptionDetail) GetOpenInterest() int64 {
+	if x != nil {
+		return x.OpenInterest
+	}
+	return 0
+}
+
+func (x *OptionDetail) GetSettlementDate() string {
+	if x != nil {
+		return x.SettlementDate
+	}
+	return ""
+}
+
+type GetListingByIdResponse struct {
+	state        protoimpl.MessageState `protogen:"open.v1"`
+	Summary      *ListingSummary        `protobuf:"bytes,1,opt,name=summary,proto3" json:"summary,omitempty"`
+	PriceHistory []*DailyPriceInfo      `protobuf:"bytes,2,rep,name=price_history,json=priceHistory,proto3" json:"price_history,omitempty"` // last 30 days, descending
+	// Types that are valid to be assigned to Detail:
+	//
+	//	*GetListingByIdResponse_Stock
+	//	*GetListingByIdResponse_Forex
+	//	*GetListingByIdResponse_Futures
+	//	*GetListingByIdResponse_Option
+	Detail        isGetListingByIdResponse_Detail `protobuf_oneof:"detail"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetListingByIdResponse) Reset() {
+	*x = GetListingByIdResponse{}
+	mi := &file_securities_proto_msgTypes[42]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetListingByIdResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetListingByIdResponse) ProtoMessage() {}
+
+func (x *GetListingByIdResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_securities_proto_msgTypes[42]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetListingByIdResponse.ProtoReflect.Descriptor instead.
+func (*GetListingByIdResponse) Descriptor() ([]byte, []int) {
+	return file_securities_proto_rawDescGZIP(), []int{42}
+}
+
+func (x *GetListingByIdResponse) GetSummary() *ListingSummary {
+	if x != nil {
+		return x.Summary
+	}
+	return nil
+}
+
+func (x *GetListingByIdResponse) GetPriceHistory() []*DailyPriceInfo {
+	if x != nil {
+		return x.PriceHistory
+	}
+	return nil
+}
+
+func (x *GetListingByIdResponse) GetDetail() isGetListingByIdResponse_Detail {
+	if x != nil {
+		return x.Detail
+	}
+	return nil
+}
+
+func (x *GetListingByIdResponse) GetStock() *StockDetail {
+	if x != nil {
+		if x, ok := x.Detail.(*GetListingByIdResponse_Stock); ok {
+			return x.Stock
+		}
+	}
+	return nil
+}
+
+func (x *GetListingByIdResponse) GetForex() *ForexDetail {
+	if x != nil {
+		if x, ok := x.Detail.(*GetListingByIdResponse_Forex); ok {
+			return x.Forex
+		}
+	}
+	return nil
+}
+
+func (x *GetListingByIdResponse) GetFutures() *FuturesDetail {
+	if x != nil {
+		if x, ok := x.Detail.(*GetListingByIdResponse_Futures); ok {
+			return x.Futures
+		}
+	}
+	return nil
+}
+
+func (x *GetListingByIdResponse) GetOption() *OptionDetail {
+	if x != nil {
+		if x, ok := x.Detail.(*GetListingByIdResponse_Option); ok {
+			return x.Option
+		}
+	}
+	return nil
+}
+
+type isGetListingByIdResponse_Detail interface {
+	isGetListingByIdResponse_Detail()
+}
+
+type GetListingByIdResponse_Stock struct {
+	Stock *StockDetail `protobuf:"bytes,3,opt,name=stock,proto3,oneof"`
+}
+
+type GetListingByIdResponse_Forex struct {
+	Forex *ForexDetail `protobuf:"bytes,4,opt,name=forex,proto3,oneof"`
+}
+
+type GetListingByIdResponse_Futures struct {
+	Futures *FuturesDetail `protobuf:"bytes,5,opt,name=futures,proto3,oneof"`
+}
+
+type GetListingByIdResponse_Option struct {
+	Option *OptionDetail `protobuf:"bytes,6,opt,name=option,proto3,oneof"`
+}
+
+func (*GetListingByIdResponse_Stock) isGetListingByIdResponse_Detail() {}
+
+func (*GetListingByIdResponse_Forex) isGetListingByIdResponse_Detail() {}
+
+func (*GetListingByIdResponse_Futures) isGetListingByIdResponse_Detail() {}
+
+func (*GetListingByIdResponse_Option) isGetListingByIdResponse_Detail() {}
+
+type GetListingHistoryRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            int64                  `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	FromDate      string                 `protobuf:"bytes,2,opt,name=from_date,json=fromDate,proto3" json:"from_date,omitempty"` // "YYYY-MM-DD"
+	ToDate        string                 `protobuf:"bytes,3,opt,name=to_date,json=toDate,proto3" json:"to_date,omitempty"`       // "YYYY-MM-DD"
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetListingHistoryRequest) Reset() {
+	*x = GetListingHistoryRequest{}
+	mi := &file_securities_proto_msgTypes[43]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetListingHistoryRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetListingHistoryRequest) ProtoMessage() {}
+
+func (x *GetListingHistoryRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_securities_proto_msgTypes[43]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetListingHistoryRequest.ProtoReflect.Descriptor instead.
+func (*GetListingHistoryRequest) Descriptor() ([]byte, []int) {
+	return file_securities_proto_rawDescGZIP(), []int{43}
+}
+
+func (x *GetListingHistoryRequest) GetId() int64 {
+	if x != nil {
+		return x.Id
+	}
+	return 0
+}
+
+func (x *GetListingHistoryRequest) GetFromDate() string {
+	if x != nil {
+		return x.FromDate
+	}
+	return ""
+}
+
+func (x *GetListingHistoryRequest) GetToDate() string {
+	if x != nil {
+		return x.ToDate
+	}
+	return ""
+}
+
+type GetListingHistoryResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	History       []*DailyPriceInfo      `protobuf:"bytes,1,rep,name=history,proto3" json:"history,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetListingHistoryResponse) Reset() {
+	*x = GetListingHistoryResponse{}
+	mi := &file_securities_proto_msgTypes[44]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetListingHistoryResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetListingHistoryResponse) ProtoMessage() {}
+
+func (x *GetListingHistoryResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_securities_proto_msgTypes[44]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetListingHistoryResponse.ProtoReflect.Descriptor instead.
+func (*GetListingHistoryResponse) Descriptor() ([]byte, []int) {
+	return file_securities_proto_rawDescGZIP(), []int{44}
+}
+
+func (x *GetListingHistoryResponse) GetHistory() []*DailyPriceInfo {
+	if x != nil {
+		return x.History
+	}
+	return nil
+}
+
 var File_securities_proto protoreflect.FileDescriptor
 
 const file_securities_proto_rawDesc = "" +
@@ -1817,8 +2751,84 @@ const file_securities_proto_rawDesc = "" +
 	"\x12SetTestModeRequest\x12\x18\n" +
 	"\aenabled\x18\x01 \x01(\bR\aenabled\"/\n" +
 	"\x13SetTestModeResponse\x12\x18\n" +
-	"\aenabled\x18\x01 \x01(\bR\aenabled2\xe5\n" +
+	"\aenabled\x18\x01 \x01(\bR\aenabled\"\xf8\x01\n" +
+	"\x12GetListingsRequest\x12\x12\n" +
+	"\x04type\x18\x01 \x01(\tR\x04type\x12\x1f\n" +
+	"\vexchange_id\x18\x02 \x01(\x03R\n" +
+	"exchangeId\x12#\n" +
+	"\rticker_prefix\x18\x03 \x01(\tR\ftickerPrefix\x12\x1f\n" +
+	"\vname_search\x18\x04 \x01(\tR\n" +
+	"nameSearch\x12\x12\n" +
+	"\x04page\x18\x05 \x01(\x05R\x04page\x12\x1b\n" +
+	"\tpage_size\x18\x06 \x01(\x05R\bpageSize\x12\x17\n" +
+	"\asort_by\x18\a \x01(\tR\x06sortBy\x12\x1d\n" +
 	"\n" +
+	"sort_order\x18\b \x01(\tR\tsortOrder\"\x88\x03\n" +
+	"\x0eListingSummary\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\x03R\x02id\x12\x16\n" +
+	"\x06ticker\x18\x02 \x01(\tR\x06ticker\x12\x12\n" +
+	"\x04name\x18\x03 \x01(\tR\x04name\x12\x12\n" +
+	"\x04type\x18\x04 \x01(\tR\x04type\x12)\n" +
+	"\x10exchange_acronym\x18\x05 \x01(\tR\x0fexchangeAcronym\x12\x14\n" +
+	"\x05price\x18\x06 \x01(\x01R\x05price\x12\x10\n" +
+	"\x03ask\x18\a \x01(\x01R\x03ask\x12\x10\n" +
+	"\x03bid\x18\b \x01(\x01R\x03bid\x12\x16\n" +
+	"\x06volume\x18\t \x01(\x03R\x06volume\x12%\n" +
+	"\x0echange_percent\x18\n" +
+	" \x01(\x01R\rchangePercent\x12-\n" +
+	"\x12maintenance_margin\x18\v \x01(\x01R\x11maintenanceMargin\x12.\n" +
+	"\x13initial_margin_cost\x18\f \x01(\x01R\x11initialMarginCost\x12#\n" +
+	"\rnominal_value\x18\r \x01(\x01R\fnominalValue\"\x95\x01\n" +
+	"\x13GetListingsResponse\x126\n" +
+	"\blistings\x18\x01 \x03(\v2\x1a.securities.ListingSummaryR\blistings\x12\x1f\n" +
+	"\vtotal_pages\x18\x02 \x01(\x05R\n" +
+	"totalPages\x12%\n" +
+	"\x0etotal_elements\x18\x03 \x01(\x03R\rtotalElements\"'\n" +
+	"\x15GetListingByIdRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\x03R\x02id\"\x8e\x01\n" +
+	"\x0eDailyPriceInfo\x12\x12\n" +
+	"\x04date\x18\x01 \x01(\tR\x04date\x12\x14\n" +
+	"\x05price\x18\x02 \x01(\x01R\x05price\x12\x10\n" +
+	"\x03ask\x18\x03 \x01(\x01R\x03ask\x12\x10\n" +
+	"\x03bid\x18\x04 \x01(\x01R\x03bid\x12\x16\n" +
+	"\x06change\x18\x05 \x01(\x01R\x06change\x12\x16\n" +
+	"\x06volume\x18\x06 \x01(\x03R\x06volume\"\x82\x01\n" +
+	"\vStockDetail\x12-\n" +
+	"\x12outstanding_shares\x18\x01 \x01(\x03R\x11outstandingShares\x12%\n" +
+	"\x0edividend_yield\x18\x02 \x01(\x01R\rdividendYield\x12\x1d\n" +
+	"\n" +
+	"market_cap\x18\x03 \x01(\x01R\tmarketCap\"\x9c\x01\n" +
+	"\vForexDetail\x12#\n" +
+	"\rbase_currency\x18\x01 \x01(\tR\fbaseCurrency\x12%\n" +
+	"\x0equote_currency\x18\x02 \x01(\tR\rquoteCurrency\x12\x1c\n" +
+	"\tliquidity\x18\x03 \x01(\tR\tliquidity\x12#\n" +
+	"\rnominal_value\x18\x04 \x01(\x01R\fnominalValue\"\x82\x01\n" +
+	"\rFuturesDetail\x12#\n" +
+	"\rcontract_size\x18\x01 \x01(\x01R\fcontractSize\x12#\n" +
+	"\rcontract_unit\x18\x02 \x01(\tR\fcontractUnit\x12'\n" +
+	"\x0fsettlement_date\x18\x03 \x01(\tR\x0esettlementDate\"\xf9\x01\n" +
+	"\fOptionDetail\x12(\n" +
+	"\x10stock_listing_id\x18\x01 \x01(\x03R\x0estockListingId\x12\x1f\n" +
+	"\voption_type\x18\x02 \x01(\tR\n" +
+	"optionType\x12!\n" +
+	"\fstrike_price\x18\x03 \x01(\x01R\vstrikePrice\x12-\n" +
+	"\x12implied_volatility\x18\x04 \x01(\x01R\x11impliedVolatility\x12#\n" +
+	"\ropen_interest\x18\x05 \x01(\x03R\fopenInterest\x12'\n" +
+	"\x0fsettlement_date\x18\x06 \x01(\tR\x0esettlementDate\"\xe6\x02\n" +
+	"\x16GetListingByIdResponse\x124\n" +
+	"\asummary\x18\x01 \x01(\v2\x1a.securities.ListingSummaryR\asummary\x12?\n" +
+	"\rprice_history\x18\x02 \x03(\v2\x1a.securities.DailyPriceInfoR\fpriceHistory\x12/\n" +
+	"\x05stock\x18\x03 \x01(\v2\x17.securities.StockDetailH\x00R\x05stock\x12/\n" +
+	"\x05forex\x18\x04 \x01(\v2\x17.securities.ForexDetailH\x00R\x05forex\x125\n" +
+	"\afutures\x18\x05 \x01(\v2\x19.securities.FuturesDetailH\x00R\afutures\x122\n" +
+	"\x06option\x18\x06 \x01(\v2\x18.securities.OptionDetailH\x00R\x06optionB\b\n" +
+	"\x06detail\"`\n" +
+	"\x18GetListingHistoryRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\x03R\x02id\x12\x1b\n" +
+	"\tfrom_date\x18\x02 \x01(\tR\bfromDate\x12\x17\n" +
+	"\ato_date\x18\x03 \x01(\tR\x06toDate\"Q\n" +
+	"\x19GetListingHistoryResponse\x124\n" +
+	"\ahistory\x18\x01 \x03(\v2\x1a.securities.DailyPriceInfoR\ahistory2\xf0\f\n" +
 	"\x11SecuritiesService\x129\n" +
 	"\x04Ping\x12\x17.securities.PingRequest\x1a\x18.securities.PingResponse\x12`\n" +
 	"\x11GetStockExchanges\x12$.securities.GetStockExchangesRequest\x1a%.securities.GetStockExchangesResponse\x12l\n" +
@@ -1835,7 +2845,10 @@ const file_securities_proto_rawDesc = "" +
 	"\rDeleteHoliday\x12 .securities.DeleteHolidayRequest\x1a!.securities.DeleteHolidayResponse\x12W\n" +
 	"\x0eIsExchangeOpen\x12!.securities.IsExchangeOpenRequest\x1a\".securities.IsExchangeOpenResponse\x12N\n" +
 	"\vGetTestMode\x12\x1e.securities.GetTestModeRequest\x1a\x1f.securities.GetTestModeResponse\x12N\n" +
-	"\vSetTestMode\x12\x1e.securities.SetTestModeRequest\x1a\x1f.securities.SetTestModeResponseB?Z=github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/securitiesb\x06proto3"
+	"\vSetTestMode\x12\x1e.securities.SetTestModeRequest\x1a\x1f.securities.SetTestModeResponse\x12N\n" +
+	"\vGetListings\x12\x1e.securities.GetListingsRequest\x1a\x1f.securities.GetListingsResponse\x12W\n" +
+	"\x0eGetListingById\x12!.securities.GetListingByIdRequest\x1a\".securities.GetListingByIdResponse\x12`\n" +
+	"\x11GetListingHistory\x12$.securities.GetListingHistoryRequest\x1a%.securities.GetListingHistoryResponseB?Z=github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/securitiesb\x06proto3"
 
 var (
 	file_securities_proto_rawDescOnce sync.Once
@@ -1849,7 +2862,7 @@ func file_securities_proto_rawDescGZIP() []byte {
 	return file_securities_proto_rawDescData
 }
 
-var file_securities_proto_msgTypes = make([]protoimpl.MessageInfo, 33)
+var file_securities_proto_msgTypes = make([]protoimpl.MessageInfo, 45)
 var file_securities_proto_goTypes = []any{
 	(*PingRequest)(nil),                   // 0: securities.PingRequest
 	(*PingResponse)(nil),                  // 1: securities.PingResponse
@@ -1884,6 +2897,18 @@ var file_securities_proto_goTypes = []any{
 	(*GetTestModeResponse)(nil),           // 30: securities.GetTestModeResponse
 	(*SetTestModeRequest)(nil),            // 31: securities.SetTestModeRequest
 	(*SetTestModeResponse)(nil),           // 32: securities.SetTestModeResponse
+	(*GetListingsRequest)(nil),            // 33: securities.GetListingsRequest
+	(*ListingSummary)(nil),                // 34: securities.ListingSummary
+	(*GetListingsResponse)(nil),           // 35: securities.GetListingsResponse
+	(*GetListingByIdRequest)(nil),         // 36: securities.GetListingByIdRequest
+	(*DailyPriceInfo)(nil),                // 37: securities.DailyPriceInfo
+	(*StockDetail)(nil),                   // 38: securities.StockDetail
+	(*ForexDetail)(nil),                   // 39: securities.ForexDetail
+	(*FuturesDetail)(nil),                 // 40: securities.FuturesDetail
+	(*OptionDetail)(nil),                  // 41: securities.OptionDetail
+	(*GetListingByIdResponse)(nil),        // 42: securities.GetListingByIdResponse
+	(*GetListingHistoryRequest)(nil),      // 43: securities.GetListingHistoryRequest
+	(*GetListingHistoryResponse)(nil),     // 44: securities.GetListingHistoryResponse
 }
 var file_securities_proto_depIdxs = []int32{
 	2,  // 0: securities.GetStockExchangesResponse.exchanges:type_name -> securities.StockExchange
@@ -1895,41 +2920,55 @@ var file_securities_proto_depIdxs = []int32{
 	15, // 6: securities.SetWorkingHoursResponse.hours:type_name -> securities.ExchangeWorkingHours
 	20, // 7: securities.GetHolidaysResponse.holidays:type_name -> securities.ExchangeHoliday
 	20, // 8: securities.AddHolidayResponse.holiday:type_name -> securities.ExchangeHoliday
-	0,  // 9: securities.SecuritiesService.Ping:input_type -> securities.PingRequest
-	3,  // 10: securities.SecuritiesService.GetStockExchanges:input_type -> securities.GetStockExchangesRequest
-	5,  // 11: securities.SecuritiesService.GetStockExchangeByMIC:input_type -> securities.GetStockExchangeByMICRequest
-	7,  // 12: securities.SecuritiesService.GetStockExchangeById:input_type -> securities.GetStockExchangeByIdRequest
-	9,  // 13: securities.SecuritiesService.CreateStockExchange:input_type -> securities.CreateStockExchangeRequest
-	11, // 14: securities.SecuritiesService.UpdateStockExchange:input_type -> securities.UpdateStockExchangeRequest
-	13, // 15: securities.SecuritiesService.DeleteStockExchange:input_type -> securities.DeleteStockExchangeRequest
-	16, // 16: securities.SecuritiesService.GetWorkingHours:input_type -> securities.GetWorkingHoursRequest
-	18, // 17: securities.SecuritiesService.SetWorkingHours:input_type -> securities.SetWorkingHoursRequest
-	21, // 18: securities.SecuritiesService.GetHolidays:input_type -> securities.GetHolidaysRequest
-	23, // 19: securities.SecuritiesService.AddHoliday:input_type -> securities.AddHolidayRequest
-	25, // 20: securities.SecuritiesService.DeleteHoliday:input_type -> securities.DeleteHolidayRequest
-	27, // 21: securities.SecuritiesService.IsExchangeOpen:input_type -> securities.IsExchangeOpenRequest
-	29, // 22: securities.SecuritiesService.GetTestMode:input_type -> securities.GetTestModeRequest
-	31, // 23: securities.SecuritiesService.SetTestMode:input_type -> securities.SetTestModeRequest
-	1,  // 24: securities.SecuritiesService.Ping:output_type -> securities.PingResponse
-	4,  // 25: securities.SecuritiesService.GetStockExchanges:output_type -> securities.GetStockExchangesResponse
-	6,  // 26: securities.SecuritiesService.GetStockExchangeByMIC:output_type -> securities.GetStockExchangeByMICResponse
-	8,  // 27: securities.SecuritiesService.GetStockExchangeById:output_type -> securities.GetStockExchangeByIdResponse
-	10, // 28: securities.SecuritiesService.CreateStockExchange:output_type -> securities.CreateStockExchangeResponse
-	12, // 29: securities.SecuritiesService.UpdateStockExchange:output_type -> securities.UpdateStockExchangeResponse
-	14, // 30: securities.SecuritiesService.DeleteStockExchange:output_type -> securities.DeleteStockExchangeResponse
-	17, // 31: securities.SecuritiesService.GetWorkingHours:output_type -> securities.GetWorkingHoursResponse
-	19, // 32: securities.SecuritiesService.SetWorkingHours:output_type -> securities.SetWorkingHoursResponse
-	22, // 33: securities.SecuritiesService.GetHolidays:output_type -> securities.GetHolidaysResponse
-	24, // 34: securities.SecuritiesService.AddHoliday:output_type -> securities.AddHolidayResponse
-	26, // 35: securities.SecuritiesService.DeleteHoliday:output_type -> securities.DeleteHolidayResponse
-	28, // 36: securities.SecuritiesService.IsExchangeOpen:output_type -> securities.IsExchangeOpenResponse
-	30, // 37: securities.SecuritiesService.GetTestMode:output_type -> securities.GetTestModeResponse
-	32, // 38: securities.SecuritiesService.SetTestMode:output_type -> securities.SetTestModeResponse
-	24, // [24:39] is the sub-list for method output_type
-	9,  // [9:24] is the sub-list for method input_type
-	9,  // [9:9] is the sub-list for extension type_name
-	9,  // [9:9] is the sub-list for extension extendee
-	0,  // [0:9] is the sub-list for field type_name
+	34, // 9: securities.GetListingsResponse.listings:type_name -> securities.ListingSummary
+	34, // 10: securities.GetListingByIdResponse.summary:type_name -> securities.ListingSummary
+	37, // 11: securities.GetListingByIdResponse.price_history:type_name -> securities.DailyPriceInfo
+	38, // 12: securities.GetListingByIdResponse.stock:type_name -> securities.StockDetail
+	39, // 13: securities.GetListingByIdResponse.forex:type_name -> securities.ForexDetail
+	40, // 14: securities.GetListingByIdResponse.futures:type_name -> securities.FuturesDetail
+	41, // 15: securities.GetListingByIdResponse.option:type_name -> securities.OptionDetail
+	37, // 16: securities.GetListingHistoryResponse.history:type_name -> securities.DailyPriceInfo
+	0,  // 17: securities.SecuritiesService.Ping:input_type -> securities.PingRequest
+	3,  // 18: securities.SecuritiesService.GetStockExchanges:input_type -> securities.GetStockExchangesRequest
+	5,  // 19: securities.SecuritiesService.GetStockExchangeByMIC:input_type -> securities.GetStockExchangeByMICRequest
+	7,  // 20: securities.SecuritiesService.GetStockExchangeById:input_type -> securities.GetStockExchangeByIdRequest
+	9,  // 21: securities.SecuritiesService.CreateStockExchange:input_type -> securities.CreateStockExchangeRequest
+	11, // 22: securities.SecuritiesService.UpdateStockExchange:input_type -> securities.UpdateStockExchangeRequest
+	13, // 23: securities.SecuritiesService.DeleteStockExchange:input_type -> securities.DeleteStockExchangeRequest
+	16, // 24: securities.SecuritiesService.GetWorkingHours:input_type -> securities.GetWorkingHoursRequest
+	18, // 25: securities.SecuritiesService.SetWorkingHours:input_type -> securities.SetWorkingHoursRequest
+	21, // 26: securities.SecuritiesService.GetHolidays:input_type -> securities.GetHolidaysRequest
+	23, // 27: securities.SecuritiesService.AddHoliday:input_type -> securities.AddHolidayRequest
+	25, // 28: securities.SecuritiesService.DeleteHoliday:input_type -> securities.DeleteHolidayRequest
+	27, // 29: securities.SecuritiesService.IsExchangeOpen:input_type -> securities.IsExchangeOpenRequest
+	29, // 30: securities.SecuritiesService.GetTestMode:input_type -> securities.GetTestModeRequest
+	31, // 31: securities.SecuritiesService.SetTestMode:input_type -> securities.SetTestModeRequest
+	33, // 32: securities.SecuritiesService.GetListings:input_type -> securities.GetListingsRequest
+	36, // 33: securities.SecuritiesService.GetListingById:input_type -> securities.GetListingByIdRequest
+	43, // 34: securities.SecuritiesService.GetListingHistory:input_type -> securities.GetListingHistoryRequest
+	1,  // 35: securities.SecuritiesService.Ping:output_type -> securities.PingResponse
+	4,  // 36: securities.SecuritiesService.GetStockExchanges:output_type -> securities.GetStockExchangesResponse
+	6,  // 37: securities.SecuritiesService.GetStockExchangeByMIC:output_type -> securities.GetStockExchangeByMICResponse
+	8,  // 38: securities.SecuritiesService.GetStockExchangeById:output_type -> securities.GetStockExchangeByIdResponse
+	10, // 39: securities.SecuritiesService.CreateStockExchange:output_type -> securities.CreateStockExchangeResponse
+	12, // 40: securities.SecuritiesService.UpdateStockExchange:output_type -> securities.UpdateStockExchangeResponse
+	14, // 41: securities.SecuritiesService.DeleteStockExchange:output_type -> securities.DeleteStockExchangeResponse
+	17, // 42: securities.SecuritiesService.GetWorkingHours:output_type -> securities.GetWorkingHoursResponse
+	19, // 43: securities.SecuritiesService.SetWorkingHours:output_type -> securities.SetWorkingHoursResponse
+	22, // 44: securities.SecuritiesService.GetHolidays:output_type -> securities.GetHolidaysResponse
+	24, // 45: securities.SecuritiesService.AddHoliday:output_type -> securities.AddHolidayResponse
+	26, // 46: securities.SecuritiesService.DeleteHoliday:output_type -> securities.DeleteHolidayResponse
+	28, // 47: securities.SecuritiesService.IsExchangeOpen:output_type -> securities.IsExchangeOpenResponse
+	30, // 48: securities.SecuritiesService.GetTestMode:output_type -> securities.GetTestModeResponse
+	32, // 49: securities.SecuritiesService.SetTestMode:output_type -> securities.SetTestModeResponse
+	35, // 50: securities.SecuritiesService.GetListings:output_type -> securities.GetListingsResponse
+	42, // 51: securities.SecuritiesService.GetListingById:output_type -> securities.GetListingByIdResponse
+	44, // 52: securities.SecuritiesService.GetListingHistory:output_type -> securities.GetListingHistoryResponse
+	35, // [35:53] is the sub-list for method output_type
+	17, // [17:35] is the sub-list for method input_type
+	17, // [17:17] is the sub-list for extension type_name
+	17, // [17:17] is the sub-list for extension extendee
+	0,  // [0:17] is the sub-list for field type_name
 }
 
 func init() { file_securities_proto_init() }
@@ -1937,13 +2976,19 @@ func file_securities_proto_init() {
 	if File_securities_proto != nil {
 		return
 	}
+	file_securities_proto_msgTypes[42].OneofWrappers = []any{
+		(*GetListingByIdResponse_Stock)(nil),
+		(*GetListingByIdResponse_Forex)(nil),
+		(*GetListingByIdResponse_Futures)(nil),
+		(*GetListingByIdResponse_Option)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_securities_proto_rawDesc), len(file_securities_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   33,
+			NumMessages:   45,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/shared/pb/securities/securities_grpc.pb.go
+++ b/shared/pb/securities/securities_grpc.pb.go
@@ -34,6 +34,9 @@ const (
 	SecuritiesService_IsExchangeOpen_FullMethodName        = "/securities.SecuritiesService/IsExchangeOpen"
 	SecuritiesService_GetTestMode_FullMethodName           = "/securities.SecuritiesService/GetTestMode"
 	SecuritiesService_SetTestMode_FullMethodName           = "/securities.SecuritiesService/SetTestMode"
+	SecuritiesService_GetListings_FullMethodName           = "/securities.SecuritiesService/GetListings"
+	SecuritiesService_GetListingById_FullMethodName        = "/securities.SecuritiesService/GetListingById"
+	SecuritiesService_GetListingHistory_FullMethodName     = "/securities.SecuritiesService/GetListingHistory"
 )
 
 // SecuritiesServiceClient is the client API for SecuritiesService service.
@@ -60,6 +63,10 @@ type SecuritiesServiceClient interface {
 	// Test Mode
 	GetTestMode(ctx context.Context, in *GetTestModeRequest, opts ...grpc.CallOption) (*GetTestModeResponse, error)
 	SetTestMode(ctx context.Context, in *SetTestModeRequest, opts ...grpc.CallOption) (*SetTestModeResponse, error)
+	// Listings
+	GetListings(ctx context.Context, in *GetListingsRequest, opts ...grpc.CallOption) (*GetListingsResponse, error)
+	GetListingById(ctx context.Context, in *GetListingByIdRequest, opts ...grpc.CallOption) (*GetListingByIdResponse, error)
+	GetListingHistory(ctx context.Context, in *GetListingHistoryRequest, opts ...grpc.CallOption) (*GetListingHistoryResponse, error)
 }
 
 type securitiesServiceClient struct {
@@ -220,6 +227,36 @@ func (c *securitiesServiceClient) SetTestMode(ctx context.Context, in *SetTestMo
 	return out, nil
 }
 
+func (c *securitiesServiceClient) GetListings(ctx context.Context, in *GetListingsRequest, opts ...grpc.CallOption) (*GetListingsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetListingsResponse)
+	err := c.cc.Invoke(ctx, SecuritiesService_GetListings_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *securitiesServiceClient) GetListingById(ctx context.Context, in *GetListingByIdRequest, opts ...grpc.CallOption) (*GetListingByIdResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetListingByIdResponse)
+	err := c.cc.Invoke(ctx, SecuritiesService_GetListingById_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *securitiesServiceClient) GetListingHistory(ctx context.Context, in *GetListingHistoryRequest, opts ...grpc.CallOption) (*GetListingHistoryResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetListingHistoryResponse)
+	err := c.cc.Invoke(ctx, SecuritiesService_GetListingHistory_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // SecuritiesServiceServer is the server API for SecuritiesService service.
 // All implementations must embed UnimplementedSecuritiesServiceServer
 // for forward compatibility.
@@ -244,6 +281,10 @@ type SecuritiesServiceServer interface {
 	// Test Mode
 	GetTestMode(context.Context, *GetTestModeRequest) (*GetTestModeResponse, error)
 	SetTestMode(context.Context, *SetTestModeRequest) (*SetTestModeResponse, error)
+	// Listings
+	GetListings(context.Context, *GetListingsRequest) (*GetListingsResponse, error)
+	GetListingById(context.Context, *GetListingByIdRequest) (*GetListingByIdResponse, error)
+	GetListingHistory(context.Context, *GetListingHistoryRequest) (*GetListingHistoryResponse, error)
 	mustEmbedUnimplementedSecuritiesServiceServer()
 }
 
@@ -298,6 +339,15 @@ func (UnimplementedSecuritiesServiceServer) GetTestMode(context.Context, *GetTes
 }
 func (UnimplementedSecuritiesServiceServer) SetTestMode(context.Context, *SetTestModeRequest) (*SetTestModeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method SetTestMode not implemented")
+}
+func (UnimplementedSecuritiesServiceServer) GetListings(context.Context, *GetListingsRequest) (*GetListingsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetListings not implemented")
+}
+func (UnimplementedSecuritiesServiceServer) GetListingById(context.Context, *GetListingByIdRequest) (*GetListingByIdResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetListingById not implemented")
+}
+func (UnimplementedSecuritiesServiceServer) GetListingHistory(context.Context, *GetListingHistoryRequest) (*GetListingHistoryResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetListingHistory not implemented")
 }
 func (UnimplementedSecuritiesServiceServer) mustEmbedUnimplementedSecuritiesServiceServer() {}
 func (UnimplementedSecuritiesServiceServer) testEmbeddedByValue()                           {}
@@ -590,6 +640,60 @@ func _SecuritiesService_SetTestMode_Handler(srv interface{}, ctx context.Context
 	return interceptor(ctx, in, info, handler)
 }
 
+func _SecuritiesService_GetListings_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetListingsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SecuritiesServiceServer).GetListings(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SecuritiesService_GetListings_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SecuritiesServiceServer).GetListings(ctx, req.(*GetListingsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _SecuritiesService_GetListingById_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetListingByIdRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SecuritiesServiceServer).GetListingById(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SecuritiesService_GetListingById_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SecuritiesServiceServer).GetListingById(ctx, req.(*GetListingByIdRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _SecuritiesService_GetListingHistory_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetListingHistoryRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SecuritiesServiceServer).GetListingHistory(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SecuritiesService_GetListingHistory_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SecuritiesServiceServer).GetListingHistory(ctx, req.(*GetListingHistoryRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // SecuritiesService_ServiceDesc is the grpc.ServiceDesc for SecuritiesService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -656,6 +760,18 @@ var SecuritiesService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "SetTestMode",
 			Handler:    _SecuritiesService_SetTestMode_Handler,
+		},
+		{
+			MethodName: "GetListings",
+			Handler:    _SecuritiesService_GetListings_Handler,
+		},
+		{
+			MethodName: "GetListingById",
+			Handler:    _SecuritiesService_GetListingById_Handler,
+		},
+		{
+			MethodName: "GetListingHistory",
+			Handler:    _SecuritiesService_GetListingHistory_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/shared/proto/securities.proto
+++ b/shared/proto/securities.proto
@@ -124,6 +124,101 @@ message GetTestModeResponse { bool enabled = 1; }
 message SetTestModeRequest  { bool enabled = 1; }
 message SetTestModeResponse { bool enabled = 1; }
 
+// ── Listings ──────────────────────────────────────────────────────────────────
+
+message GetListingsRequest {
+  string type          = 1; // STOCK, FOREX_PAIR, FUTURES_CONTRACT, OPTION — empty = all
+  int64  exchange_id   = 2; // 0 = all exchanges
+  string ticker_prefix = 3;
+  string name_search   = 4;
+  int32  page          = 5; // 1-based, default 1
+  int32  page_size     = 6; // default 10
+  string sort_by       = 7; // price, volume, change_percent, maintenance_margin
+  string sort_order    = 8; // ASC, DESC
+}
+
+message ListingSummary {
+  int64  id                  = 1;
+  string ticker              = 2;
+  string name                = 3;
+  string type                = 4;
+  string exchange_acronym    = 5;
+  double price               = 6;
+  double ask                 = 7;
+  double bid                 = 8;
+  int64  volume              = 9;
+  double change_percent      = 10;
+  double maintenance_margin  = 11;
+  double initial_margin_cost = 12;
+  double nominal_value       = 13;
+}
+
+message GetListingsResponse {
+  repeated ListingSummary listings = 1;
+  int32 total_pages                = 2;
+  int64 total_elements             = 3;
+}
+
+message GetListingByIdRequest { int64 id = 1; }
+
+message DailyPriceInfo {
+  string date   = 1; // "YYYY-MM-DD"
+  double price  = 2;
+  double ask    = 3;
+  double bid    = 4;
+  double change = 5;
+  int64  volume = 6;
+}
+
+message StockDetail {
+  int64  outstanding_shares = 1;
+  double dividend_yield     = 2;
+  double market_cap         = 3; // derived: outstanding_shares × price
+}
+
+message ForexDetail {
+  string base_currency  = 1;
+  string quote_currency = 2;
+  string liquidity      = 3;
+  double nominal_value  = 4; // derived: 1000 × price
+}
+
+message FuturesDetail {
+  double contract_size   = 1;
+  string contract_unit   = 2;
+  string settlement_date = 3; // "YYYY-MM-DD"
+}
+
+message OptionDetail {
+  int64  stock_listing_id   = 1;
+  string option_type        = 2; // CALL, PUT
+  double strike_price       = 3;
+  double implied_volatility = 4;
+  int64  open_interest      = 5;
+  string settlement_date    = 6; // "YYYY-MM-DD"
+}
+
+message GetListingByIdResponse {
+  ListingSummary          summary       = 1;
+  repeated DailyPriceInfo price_history = 2; // last 30 days, descending
+  oneof detail {
+    StockDetail   stock   = 3;
+    ForexDetail   forex   = 4;
+    FuturesDetail futures = 5;
+    OptionDetail  option  = 6;
+  }
+}
+
+message GetListingHistoryRequest {
+  int64  id        = 1;
+  string from_date = 2; // "YYYY-MM-DD"
+  string to_date   = 3; // "YYYY-MM-DD"
+}
+
+message GetListingHistoryResponse {
+  repeated DailyPriceInfo history = 1;
+}
+
 // ── Service ───────────────────────────────────────────────────────────────────
 
 service SecuritiesService {
@@ -152,4 +247,9 @@ service SecuritiesService {
   // Test Mode
   rpc GetTestMode           (GetTestModeRequest)           returns (GetTestModeResponse);
   rpc SetTestMode           (SetTestModeRequest)           returns (SetTestModeResponse);
+
+  // Listings
+  rpc GetListings           (GetListingsRequest)           returns (GetListingsResponse);
+  rpc GetListingById        (GetListingByIdRequest)        returns (GetListingByIdResponse);
+  rpc GetListingHistory     (GetListingHistoryRequest)     returns (GetListingHistoryResponse);
 }


### PR DESCRIPTION
…59, #160)

- Extend db/schema.sql with listing, listing_daily_price_info, and 4 subtype tables (listing_stock, listing_forex_pair, listing_futures_contract, listing_option) with ENUMs
- Add GetListings, GetListingById, GetListingHistory RPCs to securities.proto and regenerate pb bindings
- Implement all three handlers with derived field computation (maintenance margin, change%, nominal value) per listing type
- Add 46 tests covering all handlers and helper functions; coverage up from 54.6% to 91.5%