### PR TITLE
feat(securities-service): data import + scheduled price refresh (#150)

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -39,6 +39,10 @@ echo "Starting card-db..."
 echo "Starting loan-db..."
 (cd "$REPO_ROOT/services/loan-service" && docker compose up -d)
 
+# Start securities DB
+echo "Starting securities-db..."
+(cd "$REPO_ROOT/services/securities-service" && docker compose up -d)
+
 # Wait for PostgreSQL to accept connections
 echo "Waiting for employee-db to be ready..."
 until docker exec $(docker compose -f "$REPO_ROOT/services/employee-service/docker-compose.yml" ps -q employee-db) \
@@ -96,6 +100,13 @@ until docker exec $(docker compose -f "$REPO_ROOT/services/loan-service/docker-c
 done
 echo "loan-db ready."
 
+echo "Waiting for securities-db to be ready..."
+until docker exec $(docker compose -f "$REPO_ROOT/services/securities-service/docker-compose.yml" ps -q securities-db) \
+    pg_isready -U securities_user -d securities_db -q 2>/dev/null; do
+  sleep 1
+done
+echo "securities-db ready."
+
 # Wait for RabbitMQ to be ready
 echo "Waiting for email-rabbitmq to be ready..."
 until bash -c 'echo > /dev/tcp/localhost/5672' 2>/dev/null; do
@@ -138,6 +149,9 @@ CARD_PID=$!
 go run "$REPO_ROOT/services/loan-service/" &
 LOAN_PID=$!
 
+go run "$REPO_ROOT/services/securities-service/" &
+SEC_PID=$!
+
 echo ""
 echo "All services started."
 echo "  employee-service  PID $EMP_PID   (:50051)"
@@ -148,7 +162,8 @@ echo "  client-service    PID $CLIENT_PID   (:50056)"
 echo "  exchange-service  PID $EXCHANGE_PID (:50057)"
 echo "  payment-service   PID $PAYMENT_PID  (:50055)"
 echo "  card-service      PID $CARD_PID     (:50059)"
-echo "  loan-service      PID $LOAN_PID     (:50058)"
+echo "  loan-service        PID $LOAN_PID     (:50058)
+  securities-service  PID $SEC_PID      (:50060)"
 echo "  api-gateway       PID $GW_PID       (:8083)"
 echo ""
 echo "Press Ctrl+C to stop all services."
@@ -162,9 +177,10 @@ echo "        cd services/client-service && docker compose down"
 echo "        cd services/exchange-service && docker compose down"
 echo "        cd services/payment-service && docker compose down"
 echo "        cd services/card-service && docker compose down"
-echo "        cd services/loan-service && docker compose down"
+echo "        cd services/loan-service && docker compose down
+        cd services/securities-service && docker compose down"
 
 # On Ctrl+C, kill Go services only — containers are intentionally left running
-trap "echo ''; echo 'Stopping Go services...'; kill $EMP_PID $AUTH_PID $GW_PID $EMAIL_PID $ACC_PID $CLIENT_PID $EXCHANGE_PID $PAYMENT_PID $CARD_PID $LOAN_PID 2>/dev/null; exit 0" INT
+trap "echo ''; echo 'Stopping Go services...'; kill $EMP_PID $AUTH_PID $GW_PID $EMAIL_PID $ACC_PID $CLIENT_PID $EXCHANGE_PID $PAYMENT_PID $CARD_PID $LOAN_PID $SEC_PID 2>/dev/null; exit 0" INT
 
 wait

--- a/services/employee-service/handlers/grpc_server.go
+++ b/services/employee-service/handlers/grpc_server.go
@@ -485,3 +485,11 @@ func (s *EmployeeServer) SetNeedApproval(ctx context.Context, req *pb.SetNeedApp
 	}
 	return &pb.SetNeedApprovalResponse{}, nil
 }
+
+func (s *EmployeeServer) ResetAllActuaryUsedLimits(ctx context.Context, _ *pb.ResetAllActuaryUsedLimitsRequest) (*pb.ResetAllActuaryUsedLimitsResponse, error) {
+	_, err := s.DB.ExecContext(ctx, `UPDATE actuary_info SET used_limit = 0`)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "reset all actuary used limits: %v", err)
+	}
+	return &pb.ResetAllActuaryUsedLimitsResponse{}, nil
+}

--- a/services/securities-service/assets/exchange_1.csv
+++ b/services/securities-service/assets/exchange_1.csv
@@ -1,0 +1,91 @@
+Exchange Name,Exchange Acronym,Exchange MIC Code,Country,Currency,Time Zone,Open Time,Close Time
+New York Stock Exchange,NYSE,XNYS,United States,USD,America/New_York,09:30,16:00
+NASDAQ,NASDAQ,XNAS,United States,USD,America/New_York,09:30,16:00
+NYSE American,AMEX,XASE,United States,USD,America/New_York,09:30,16:00
+Chicago Board Options Exchange,CBOE,XCBO,United States,USD,America/Chicago,08:30,15:15
+Chicago Mercantile Exchange,CME,XCME,United States,USD,America/Chicago,08:30,15:15
+New York Mercantile Exchange,NYMEX,XNYM,United States,USD,America/New_York,09:00,17:30
+Intercontinental Exchange,ICE,XICE,United States,USD,America/New_York,08:00,18:00
+London Stock Exchange,LSE,XLON,United Kingdom,GBP,Europe/London,08:00,16:30
+London Metal Exchange,LME,XLME,United Kingdom,GBP,Europe/London,08:00,17:00
+Euronext Paris,EPA,XPAR,France,EUR,Europe/Paris,09:00,17:35
+Euronext Amsterdam,AEX,XAMS,Netherlands,EUR,Europe/Amsterdam,09:00,17:35
+Euronext Brussels,EBR,XBRU,Belgium,EUR,Europe/Brussels,09:00,17:35
+Euronext Lisbon,ELI,XLIS,Portugal,EUR,Europe/Lisbon,08:00,16:30
+Deutsche Boerse Xetra,XETRA,XETR,Germany,EUR,Europe/Berlin,09:00,17:30
+Frankfurt Stock Exchange,FSE,XFRA,Germany,EUR,Europe/Berlin,09:00,17:30
+Borsa Italiana,BIT,XMIL,Italy,EUR,Europe/Rome,09:00,17:35
+Bolsa de Madrid,BME,XMAD,Spain,EUR,Europe/Madrid,09:00,17:35
+SIX Swiss Exchange,SIX,XSWX,Switzerland,CHF,Europe/Zurich,09:00,17:30
+Oslo Bors,OSE,XOSL,Norway,NOK,Europe/Oslo,09:00,16:20
+Nasdaq Stockholm,STO,XSTO,Sweden,SEK,Europe/Stockholm,09:00,17:30
+Nasdaq Copenhagen,CPH,XCSE,Denmark,DKK,Europe/Copenhagen,09:00,17:00
+Nasdaq Helsinki,HEL,XHEL,Finland,EUR,Europe/Helsinki,10:00,18:30
+Nasdaq Iceland,ICE,XICE,Iceland,ISK,Atlantic/Reykjavik,09:30,15:30
+Wiener Boerse,WBAG,XWBO,Austria,EUR,Europe/Vienna,09:00,17:35
+Prague Stock Exchange,PSE,XPRA,Czech Republic,CZK,Europe/Prague,09:00,16:20
+Budapest Stock Exchange,BSE,XBUD,Hungary,HUF,Europe/Budapest,09:00,17:00
+Warsaw Stock Exchange,WSE,XWAR,Poland,PLN,Europe/Warsaw,09:00,17:05
+Bucharest Stock Exchange,BVB,XBSE,Romania,RON,Europe/Bucharest,10:00,18:00
+Athens Stock Exchange,ATHEX,ASEX,Greece,EUR,Europe/Athens,10:00,17:20
+Borsa Istanbul,BIST,XIST,Turkey,TRY,Europe/Istanbul,09:30,18:00
+Moscow Exchange,MOEX,MISX,Russia,RUB,Europe/Moscow,10:00,18:45
+Tokyo Stock Exchange,TSE,XTKS,Japan,JPY,Asia/Tokyo,09:00,15:30
+Osaka Exchange,OSE,XOSE,Japan,JPY,Asia/Tokyo,09:00,15:30
+Shanghai Stock Exchange,SSE,XSHG,China,CNY,Asia/Shanghai,09:30,15:00
+Shenzhen Stock Exchange,SZSE,XSHE,China,CNY,Asia/Shanghai,09:30,15:00
+Hong Kong Stock Exchange,HKEX,XHKG,Hong Kong,HKD,Asia/Hong_Kong,09:30,16:00
+Korea Exchange,KRX,XKRX,South Korea,KRW,Asia/Seoul,09:00,15:30
+Taiwan Stock Exchange,TWSE,XTAI,Taiwan,TWD,Asia/Taipei,09:00,13:30
+Singapore Exchange,SGX,XSES,Singapore,SGD,Asia/Singapore,09:00,17:00
+Bursa Malaysia,KLSE,XKLS,Malaysia,MYR,Asia/Kuala_Lumpur,09:00,17:00
+Indonesia Stock Exchange,IDX,XIDX,Indonesia,IDR,Asia/Jakarta,09:30,15:50
+Philippine Stock Exchange,PSEi,XPHS,Philippines,PHP,Asia/Manila,09:30,15:30
+Stock Exchange of Thailand,SET,XBKK,Thailand,THB,Asia/Bangkok,10:00,16:30
+Ho Chi Minh Stock Exchange,HOSE,XSTC,Vietnam,VND,Asia/Ho_Chi_Minh,09:00,15:00
+Bombay Stock Exchange,BSE,XBOM,India,INR,Asia/Kolkata,09:15,15:30
+National Stock Exchange of India,NSE,XNSE,India,INR,Asia/Kolkata,09:15,15:30
+Karachi Stock Exchange,KSE,XKAR,Pakistan,PKR,Asia/Karachi,09:30,15:30
+Colombo Stock Exchange,CSE,XCOL,Sri Lanka,LKR,Asia/Colombo,09:30,14:30
+Dhaka Stock Exchange,DSE,XDHA,Bangladesh,BDT,Asia/Dhaka,10:00,14:30
+Nepal Stock Exchange,NEPSE,XNEP,Nepal,NPR,Asia/Kathmandu,11:00,15:00
+Tel Aviv Stock Exchange,TASE,XTAE,Israel,ILS,Asia/Jerusalem,09:59,17:25
+Saudi Exchange,Tadawul,XSAU,Saudi Arabia,SAR,Asia/Riyadh,10:00,15:00
+Abu Dhabi Securities Exchange,ADX,XADS,United Arab Emirates,AED,Asia/Dubai,10:00,14:00
+Dubai Financial Market,DFM,XDFM,United Arab Emirates,AED,Asia/Dubai,10:00,14:00
+Qatar Stock Exchange,QSE,XQAT,Qatar,QAR,Asia/Qatar,09:30,13:00
+Kuwait Stock Exchange,KSE,XKUW,Kuwait,KWD,Asia/Kuwait,09:30,12:30
+Bahrain Bourse,BSE,XBAH,Bahrain,BHD,Asia/Bahrain,09:00,13:00
+Muscat Securities Market,MSM,XMUS,Oman,OMR,Asia/Muscat,09:30,13:00
+Amman Stock Exchange,ASE,XAMM,Jordan,JOD,Asia/Amman,10:00,12:00
+Beirut Stock Exchange,BSE,XBEY,Lebanon,LBP,Asia/Beirut,09:30,12:30
+Egyptian Exchange,EGX,XCAI,Egypt,EGP,Africa/Cairo,10:00,14:30
+Casablanca Stock Exchange,CSE,XCAS,Morocco,MAD,Africa/Casablanca,09:30,15:30
+Tunis Stock Exchange,BVMT,XTUN,Tunisia,TND,Africa/Tunis,09:00,13:30
+Nairobi Securities Exchange,NSE,XNAI,Kenya,KES,Africa/Nairobi,09:30,15:00
+Nigerian Stock Exchange,NGX,XLAG,Nigeria,NGN,Africa/Lagos,10:00,14:30
+Johannesburg Stock Exchange,JSE,XJSE,South Africa,ZAR,Africa/Johannesburg,09:00,17:00
+Zimbabwe Stock Exchange,ZSE,XZIM,Zimbabwe,ZWL,Africa/Harare,10:00,12:00
+Ghana Stock Exchange,GSE,XGHA,Ghana,GHS,Africa/Accra,09:30,15:00
+Dar es Salaam Stock Exchange,DSE,XDAR,Tanzania,TZS,Africa/Dar_es_Salaam,10:00,15:00
+Uganda Securities Exchange,USE,XUGA,Uganda,UGX,Africa/Kampala,09:00,14:00
+Rwanda Stock Exchange,RSE,XRWA,Rwanda,RWF,Africa/Kigali,09:00,12:00
+Lusaka Securities Exchange,LuSE,XLUS,Zambia,ZMW,Africa/Lusaka,10:00,14:00
+Botswana Stock Exchange,BSE,XBOT,Botswana,BWP,Africa/Gaborone,09:00,17:00
+Stock Exchange of Mauritius,SEM,XMAU,Mauritius,MUR,Indian/Mauritius,09:00,13:30
+Toronto Stock Exchange,TSX,XTSE,Canada,CAD,America/Toronto,09:30,16:00
+TSX Venture Exchange,TSXV,XTSX,Canada,CAD,America/Toronto,09:30,16:00
+Mexican Stock Exchange,BMV,XMEX,Mexico,MXN,America/Mexico_City,08:30,15:00
+B3 Brazil,B3,BVMF,Brazil,BRL,America/Sao_Paulo,10:00,17:30
+Buenos Aires Stock Exchange,BCBA,XBUE,Argentina,ARS,America/Argentina/Buenos_Aires,11:00,17:00
+Santiago Stock Exchange,SSE,XSGO,Chile,CLP,America/Santiago,09:30,17:30
+Bolsa de Valores de Colombia,BVC,XBOG,Colombia,COP,America/Bogota,09:00,16:00
+Lima Stock Exchange,BVL,XLIM,Peru,PEN,America/Lima,09:00,17:00
+Caracas Stock Exchange,BVC,XCAR,Venezuela,VES,America/Caracas,09:30,13:00
+Australian Securities Exchange,ASX,XASX,Australia,AUD,Australia/Sydney,10:00,16:00
+New Zealand Exchange,NZX,XNZE,New Zealand,NZD,Pacific/Auckland,10:00,17:00
+Papua New Guinea Exchange,POMSoX,XPOM,Papua New Guinea,PGK,Pacific/Port_Moresby,10:00,12:00
+Jamaica Stock Exchange,JSE,XJAM,Jamaica,JMD,America/Jamaica,09:30,12:30
+Trinidad and Tobago Stock Exchange,TTSE,XTRN,Trinidad and Tobago,TTD,America/Port_of_Spain,09:30,12:00
+Bermuda Stock Exchange,BSX,XBER,Bermuda,USD,Atlantic/Bermuda,09:00,17:00
+Cayman Islands Stock Exchange,CSX,XCAY,Cayman Islands,KYD,America/Cayman,09:00,17:00

--- a/services/securities-service/assets/future_data.csv
+++ b/services/securities-service/assets/future_data.csv
@@ -1,0 +1,21 @@
+contract_name,contract_size,contract_unit,maintenance_margin,type
+Corn,5000,bushels,700,AGRICULTURE
+Wheat,5000,bushels,1000,AGRICULTURE
+Soybeans,5000,bushels,1500,AGRICULTURE
+Live Cattle,40000,pounds,1500,MEATS
+Lean Hogs,40000,pounds,1200,MEATS
+Feeder Cattle,50000,pounds,2000,MEATS
+Crude Oil (WTI),1000,barrels,5000,ENERGY
+Natural Gas,10000,mmBtu,2000,ENERGY
+Heating Oil,42000,gallons,4000,ENERGY
+RBOB Gasoline,42000,gallons,4000,ENERGY
+Gold,100,troy oz,8000,METALS
+Silver,5000,troy oz,5000,METALS
+Copper,25000,pounds,3000,METALS
+Platinum,50,troy oz,2500,METALS
+Palladium,100,troy oz,10000,METALS
+Coffee,37500,pounds,2000,SOFTS
+Sugar #11,112000,pounds,1000,SOFTS
+Cocoa,10,metric tons,1500,SOFTS
+Cotton #2,50000,pounds,1500,SOFTS
+Orange Juice,15000,pounds,1200,SOFTS

--- a/services/securities-service/main.go
+++ b/services/securities-service/main.go
@@ -1,15 +1,25 @@
 package main
 
 import (
+	_ "embed"
 	"log"
 	"net"
 	"os"
+	"time"
 
 	secdb "github.com/RAF-SI-2025/EXBanka-4-Backend/services/securities-service/db"
 	"github.com/RAF-SI-2025/EXBanka-4-Backend/services/securities-service/handlers"
+	"github.com/RAF-SI-2025/EXBanka-4-Backend/services/securities-service/scheduler"
+	"github.com/RAF-SI-2025/EXBanka-4-Backend/services/securities-service/seeder"
 	pb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/securities"
 	"google.golang.org/grpc"
 )
+
+//go:embed assets/exchange_1.csv
+var exchangeCSV []byte
+
+//go:embed assets/future_data.csv
+var futureDataCSV []byte
 
 const grpcPort = ":50060"
 
@@ -29,6 +39,15 @@ func main() {
 	pb.RegisterSecuritiesServiceServer(srv, &handlers.SecuritiesServer{
 		DB: securitiesDB,
 	})
+
+	// Seed data on startup (runs in background, does not block gRPC server).
+	go seeder.Seed(securitiesDB, os.Getenv("ALPACA_API_KEY"), os.Getenv("ALPHAVANTAGE_API_KEY"), exchangeCSV, futureDataCSV)
+
+	// Refresh prices every 15 minutes.
+	scheduler.StartPriceRefresh(securitiesDB, os.Getenv("ALPHAVANTAGE_API_KEY"), 15*time.Minute)
+
+	// Snapshot daily prices + reset actuary limits at 23:59 every day.
+	scheduler.ScheduleEOD(securitiesDB, os.Getenv("EMPLOYEE_SERVICE_ADDR"))
 
 	log.Printf("securities-service gRPC server listening on %s", grpcPort)
 	if err := srv.Serve(lis); err != nil {

--- a/services/securities-service/scheduler/eod.go
+++ b/services/securities-service/scheduler/eod.go
@@ -1,0 +1,69 @@
+package scheduler
+
+import (
+	"context"
+	"database/sql"
+	"log"
+	"time"
+
+	pb_emp "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/employee"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// ScheduleEOD schedules a job that runs every day at 23:59 to:
+//  1. Snapshot each listing's current price into listing_daily_price_info.
+//  2. Reset all actuary used_limit values to 0 via the employee-service.
+func ScheduleEOD(db *sql.DB, employeeServiceAddr string) {
+	scheduleNext(db, employeeServiceAddr)
+	log.Println("eod: scheduled daily job at 23:59")
+}
+
+func scheduleNext(db *sql.DB, employeeServiceAddr string) {
+	now := time.Now()
+	next := time.Date(now.Year(), now.Month(), now.Day(), 23, 59, 0, 0, now.Location())
+	if !now.Before(next) {
+		next = next.Add(24 * time.Hour)
+	}
+	time.AfterFunc(time.Until(next), func() {
+		runEOD(db, employeeServiceAddr)
+		scheduleNext(db, employeeServiceAddr)
+	})
+}
+
+func runEOD(db *sql.DB, employeeServiceAddr string) {
+	log.Println("eod: running end-of-day job")
+
+	// 1. Snapshot current prices.
+	_, err := db.Exec(`
+		INSERT INTO listing_daily_price_info (listing_id, date, price, ask, bid, change, volume)
+		SELECT id, CURRENT_DATE, price, ask, bid, change, volume FROM listing
+		ON CONFLICT (listing_id, date) DO NOTHING`)
+	if err != nil {
+		log.Printf("eod: snapshot prices: %v", err)
+	} else {
+		log.Println("eod: price snapshot complete")
+	}
+
+	// 2. Reset actuary used_limit via employee-service.
+	if employeeServiceAddr == "" {
+		log.Println("eod: EMPLOYEE_SERVICE_ADDR not set, skipping actuary reset")
+		return
+	}
+	conn, err := grpc.NewClient(employeeServiceAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		log.Printf("eod: dial employee-service: %v", err)
+		return
+	}
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	client := pb_emp.NewEmployeeServiceClient(conn)
+	if _, err := client.ResetAllActuaryUsedLimits(ctx, &pb_emp.ResetAllActuaryUsedLimitsRequest{}); err != nil {
+		log.Printf("eod: reset actuary used limits: %v", err)
+	} else {
+		log.Println("eod: actuary used limits reset")
+	}
+}

--- a/services/securities-service/scheduler/price_refresh.go
+++ b/services/securities-service/scheduler/price_refresh.go
@@ -1,0 +1,115 @@
+package scheduler
+
+import (
+	"database/sql"
+	"log"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-4-Backend/services/securities-service/seeder"
+)
+
+// StartPriceRefresh launches a background goroutine that refreshes listing prices
+// every interval using AlphaVantage. The first tick fires after one full interval.
+func StartPriceRefresh(db *sql.DB, avKey string, interval time.Duration) {
+	if avKey == "" {
+		log.Println("price_refresh: ALPHAVANTAGE_API_KEY not set, price refresh disabled")
+		return
+	}
+	ticker := time.NewTicker(interval)
+	go func() {
+		for range ticker.C {
+			log.Println("price_refresh: running")
+			refreshPrices(db, avKey)
+			log.Println("price_refresh: done")
+		}
+	}()
+	log.Printf("price_refresh: scheduled every %s", interval)
+}
+
+func refreshPrices(db *sql.DB, avKey string) {
+	refreshStocks(db, avKey)
+	refreshForex(db, avKey)
+}
+
+func refreshStocks(db *sql.DB, avKey string) {
+	rows, err := db.Query(`SELECT id, ticker FROM listing WHERE type = 'STOCK'`)
+	if err != nil {
+		log.Printf("price_refresh: query stocks: %v", err)
+		return
+	}
+	defer rows.Close()
+
+	type stockRow struct {
+		id     int64
+		ticker string
+	}
+	var stocks []stockRow
+	for rows.Next() {
+		var s stockRow
+		if err := rows.Scan(&s.id, &s.ticker); err == nil {
+			stocks = append(stocks, s)
+		}
+	}
+
+	for _, s := range stocks {
+		q, err := seeder.FetchGlobalQuote(s.ticker, avKey)
+		if err != nil {
+			log.Printf("price_refresh: global quote %s: %v", s.ticker, err)
+			continue
+		}
+		if q == nil {
+			continue // rate-limit hit, skip
+		}
+		_, err = db.Exec(`
+			UPDATE listing SET price=$2, ask=$3, bid=$4, change=$5, volume=$6, last_refresh=$7
+			WHERE id=$1`,
+			s.id, q.Price, q.Ask, q.Bid, q.Change, q.Volume, time.Now())
+		if err != nil {
+			log.Printf("price_refresh: update stock %s: %v", s.ticker, err)
+		}
+	}
+}
+
+func refreshForex(db *sql.DB, avKey string) {
+	rows, err := db.Query(`
+		SELECT l.id, fp.base_currency, fp.quote_currency
+		FROM listing l
+		JOIN listing_forex_pair fp ON fp.listing_id = l.id
+		WHERE l.type = 'FOREX_PAIR'`)
+	if err != nil {
+		log.Printf("price_refresh: query forex: %v", err)
+		return
+	}
+	defer rows.Close()
+
+	type fxRow struct {
+		id   int64
+		from string
+		to   string
+	}
+	var pairs []fxRow
+	for rows.Next() {
+		var f fxRow
+		if err := rows.Scan(&f.id, &f.from, &f.to); err == nil {
+			pairs = append(pairs, f)
+		}
+	}
+
+	for _, p := range pairs {
+		rate, err := seeder.FetchFXRate(p.from, p.to, avKey)
+		if err != nil {
+			log.Printf("price_refresh: fx rate %s/%s: %v", p.from, p.to, err)
+			continue
+		}
+		if rate == nil {
+			continue
+		}
+		_, err = db.Exec(`
+			UPDATE listing SET price=$2, ask=$3, bid=$4, last_refresh=$5
+			WHERE id=$1`,
+			p.id, rate.Price, rate.Ask, rate.Bid, time.Now())
+		if err != nil {
+			log.Printf("price_refresh: update forex %s/%s: %v", p.from, p.to, err)
+		}
+	}
+}

--- a/services/securities-service/seeder/alpaca.go
+++ b/services/securities-service/seeder/alpaca.go
@@ -1,0 +1,58 @@
+package seeder
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const alpacaMaxTickers = 100
+
+// alpacaAsset is the subset of Alpaca's asset object we care about.
+type alpacaAsset struct {
+	Symbol   string `json:"symbol"`
+	Name     string `json:"name"`
+	Exchange string `json:"exchange"`
+	Tradable bool   `json:"tradable"`
+}
+
+// FetchTickers fetches up to alpacaMaxTickers tradable US equity tickers from Alpaca Markets.
+// Endpoint: GET https://data.alpaca.markets/v2/assets?status=active&asset_class=us_equity
+func FetchTickers(apiKey string) ([]alpacaAsset, error) {
+	req, err := http.NewRequest(http.MethodGet, "https://paper-api.alpaca.markets/v2/assets", nil)
+	if err != nil {
+		return nil, fmt.Errorf("alpaca: build request: %w", err)
+	}
+	q := req.URL.Query()
+	q.Set("status", "active")
+	q.Set("asset_class", "us_equity")
+	req.URL.RawQuery = q.Encode()
+	req.Header.Set("APCA-API-KEY-ID", apiKey)
+	req.Header.Set("APCA-API-SECRET-KEY", "") // secret not needed for paper broker asset list
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("alpaca: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("alpaca: unexpected status %d", resp.StatusCode)
+	}
+
+	var assets []alpacaAsset
+	if err := json.NewDecoder(resp.Body).Decode(&assets); err != nil {
+		return nil, fmt.Errorf("alpaca: decode response: %w", err)
+	}
+
+	// Keep only tradable assets and cap to alpacaMaxTickers
+	var result []alpacaAsset
+	for _, a := range assets {
+		if a.Tradable && len(result) < alpacaMaxTickers {
+			result = append(result, a)
+		}
+	}
+	return result, nil
+}

--- a/services/securities-service/seeder/alphavantage.go
+++ b/services/securities-service/seeder/alphavantage.go
@@ -1,0 +1,293 @@
+package seeder
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const avBase = "https://www.alphavantage.co/query"
+
+// avRateLimit is the minimum delay between AlphaVantage calls on the free tier (5 req/min).
+const avRateLimit = 12 * time.Second
+
+var avClient = &http.Client{Timeout: 30 * time.Second}
+
+// avGet performs a GET against AlphaVantage and decodes the JSON response into dst.
+// Returns false (and logs) if the response contains a rate-limit "Note" or "Information" key.
+func avGet(params map[string]string, dst interface{}) (ok bool, err error) {
+	req, err := http.NewRequest(http.MethodGet, avBase, nil)
+	if err != nil {
+		return false, fmt.Errorf("av: build request: %w", err)
+	}
+	q := req.URL.Query()
+	for k, v := range params {
+		q.Set(k, v)
+	}
+	req.URL.RawQuery = q.Encode()
+
+	resp, err := avClient.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("av: request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusTooManyRequests {
+		log.Printf("alphavantage: rate limit hit (429), skipping")
+		return false, nil
+	}
+
+	// Decode into a raw map first to check for Note / Information fields.
+	var raw map[string]json.RawMessage
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		return false, fmt.Errorf("av: decode: %w", err)
+	}
+	if note, ok := raw["Note"]; ok {
+		log.Printf("alphavantage: rate-limit note: %s", note)
+		return false, nil
+	}
+	if info, ok := raw["Information"]; ok {
+		log.Printf("alphavantage: information message: %s", info)
+		return false, nil
+	}
+
+	// Re-encode and decode into the target struct.
+	b, _ := json.Marshal(raw)
+	if err := json.Unmarshal(b, dst); err != nil {
+		return false, fmt.Errorf("av: unmarshal into target: %w", err)
+	}
+	return true, nil
+}
+
+// Quote holds the fields we extract from GLOBAL_QUOTE.
+type Quote struct {
+	Price  float64
+	Ask    float64 // AlphaVantage calls this "high"
+	Bid    float64 // "low"
+	Change float64
+	Volume int64
+}
+
+type avGlobalQuoteResp struct {
+	GlobalQuote struct {
+		Price  string `json:"05. price"`
+		High   string `json:"03. high"`
+		Low    string `json:"04. low"`
+		Change string `json:"09. change"`
+		Volume string `json:"06. volume"`
+	} `json:"Global Quote"`
+}
+
+// FetchGlobalQuote fetches the latest price snapshot for a stock ticker.
+// Sleeps avRateLimit before the call.
+func FetchGlobalQuote(ticker, apiKey string) (*Quote, error) {
+	time.Sleep(avRateLimit)
+	var resp avGlobalQuoteResp
+	ok, err := avGet(map[string]string{
+		"function": "GLOBAL_QUOTE",
+		"symbol":   ticker,
+		"apikey":   apiKey,
+	}, &resp)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, nil
+	}
+	q := &Quote{}
+	q.Price, _ = strconv.ParseFloat(resp.GlobalQuote.Price, 64)
+	q.Ask, _ = strconv.ParseFloat(resp.GlobalQuote.High, 64)
+	q.Bid, _ = strconv.ParseFloat(resp.GlobalQuote.Low, 64)
+	q.Change, _ = strconv.ParseFloat(resp.GlobalQuote.Change, 64)
+	q.Volume, _ = strconv.ParseInt(strings.ReplaceAll(resp.GlobalQuote.Volume, ",", ""), 10, 64)
+	return q, nil
+}
+
+// Overview holds the fields we extract from COMPANY_OVERVIEW.
+type Overview struct {
+	Name              string
+	Exchange          string
+	OutstandingShares int64
+	DividendYield     float64
+}
+
+type avOverviewResp struct {
+	Name              string `json:"Name"`
+	Exchange          string `json:"Exchange"`
+	SharesOutstanding string `json:"SharesOutstanding"`
+	DividendYield     string `json:"DividendYield"`
+}
+
+// FetchCompanyOverview fetches company metadata for a stock ticker.
+// Sleeps avRateLimit before the call.
+func FetchCompanyOverview(ticker, apiKey string) (*Overview, error) {
+	time.Sleep(avRateLimit)
+	var resp avOverviewResp
+	ok, err := avGet(map[string]string{
+		"function": "OVERVIEW",
+		"symbol":   ticker,
+		"apikey":   apiKey,
+	}, &resp)
+	if err != nil {
+		return nil, err
+	}
+	if !ok || resp.Name == "" {
+		return nil, nil
+	}
+	ov := &Overview{
+		Name:     resp.Name,
+		Exchange: resp.Exchange,
+	}
+	ov.OutstandingShares, _ = strconv.ParseInt(resp.SharesOutstanding, 10, 64)
+	ov.DividendYield, _ = strconv.ParseFloat(resp.DividendYield, 64)
+	return ov, nil
+}
+
+// DailyBar is one row of OHLCV data for a single calendar day.
+type DailyBar struct {
+	Date   time.Time
+	Price  float64
+	Ask    float64
+	Bid    float64
+	Change float64
+	Volume int64
+}
+
+type avDailyResp struct {
+	TimeSeries map[string]struct {
+		Close  string `json:"4. close"`
+		High   string `json:"2. high"`
+		Low    string `json:"3. low"`
+		Volume string `json:"5. volume"`
+	} `json:"Time Series (Daily)"`
+}
+
+// FetchDailySeries fetches full daily price history for a stock.
+// Sleeps avRateLimit before the call.
+func FetchDailySeries(ticker, apiKey string) ([]DailyBar, error) {
+	time.Sleep(avRateLimit)
+	var resp avDailyResp
+	ok, err := avGet(map[string]string{
+		"function":   "TIME_SERIES_DAILY",
+		"symbol":     ticker,
+		"outputsize": "full",
+		"apikey":     apiKey,
+	}, &resp)
+	if err != nil {
+		return nil, err
+	}
+	if !ok || resp.TimeSeries == nil {
+		return nil, nil
+	}
+	bars := make([]DailyBar, 0, len(resp.TimeSeries))
+	for dateStr, v := range resp.TimeSeries {
+		t, err := time.Parse("2006-01-02", dateStr)
+		if err != nil {
+			continue
+		}
+		bar := DailyBar{Date: t}
+		bar.Price, _ = strconv.ParseFloat(v.Close, 64)
+		bar.Ask, _ = strconv.ParseFloat(v.High, 64)
+		bar.Bid, _ = strconv.ParseFloat(v.Low, 64)
+		bar.Volume, _ = strconv.ParseInt(strings.ReplaceAll(v.Volume, ",", ""), 10, 64)
+		if len(bars) > 0 {
+			bar.Change = bar.Price - bars[len(bars)-1].Price
+		}
+		bars = append(bars, bar)
+	}
+	// Sort ascending by date so Change can be computed properly.
+	sort.Slice(bars, func(i, j int) bool { return bars[i].Date.Before(bars[j].Date) })
+	for i := 1; i < len(bars); i++ {
+		bars[i].Change = bars[i].Price - bars[i-1].Price
+	}
+	return bars, nil
+}
+
+// FXRate holds the current exchange rate returned by CURRENCY_EXCHANGE_RATE.
+type FXRate struct {
+	Price float64
+	Ask   float64
+	Bid   float64
+}
+
+type avFXRateResp struct {
+	RealtimeCurrencyExchangeRate struct {
+		ExchangeRate string `json:"5. Exchange Rate"`
+		AskPrice     string `json:"9. Ask Price"`
+		BidPrice     string `json:"8. Bid Price"`
+	} `json:"Realtime Currency Exchange Rate"`
+}
+
+// FetchFXRate fetches the current exchange rate between two ISO currency codes.
+// Sleeps avRateLimit before the call.
+func FetchFXRate(fromCurrency, toCurrency, apiKey string) (*FXRate, error) {
+	time.Sleep(avRateLimit)
+	var resp avFXRateResp
+	ok, err := avGet(map[string]string{
+		"function":      "CURRENCY_EXCHANGE_RATE",
+		"from_currency": fromCurrency,
+		"to_currency":   toCurrency,
+		"apikey":        apiKey,
+	}, &resp)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, nil
+	}
+	r := &FXRate{}
+	r.Price, _ = strconv.ParseFloat(resp.RealtimeCurrencyExchangeRate.ExchangeRate, 64)
+	r.Ask, _ = strconv.ParseFloat(resp.RealtimeCurrencyExchangeRate.AskPrice, 64)
+	r.Bid, _ = strconv.ParseFloat(resp.RealtimeCurrencyExchangeRate.BidPrice, 64)
+	return r, nil
+}
+
+type avFXDailyResp struct {
+	TimeSeries map[string]struct {
+		Close string `json:"4. close"`
+		High  string `json:"2. high"`
+		Low   string `json:"3. low"`
+	} `json:"Time Series FX (Daily)"`
+}
+
+// FetchFXDaily fetches full daily price history for a forex pair.
+// Sleeps avRateLimit before the call.
+func FetchFXDaily(fromCurrency, toCurrency, apiKey string) ([]DailyBar, error) {
+	time.Sleep(avRateLimit)
+	var resp avFXDailyResp
+	ok, err := avGet(map[string]string{
+		"function":      "FX_DAILY",
+		"from_symbol":   fromCurrency,
+		"to_symbol":     toCurrency,
+		"outputsize":    "full",
+		"apikey":        apiKey,
+	}, &resp)
+	if err != nil {
+		return nil, err
+	}
+	if !ok || resp.TimeSeries == nil {
+		return nil, nil
+	}
+	bars := make([]DailyBar, 0, len(resp.TimeSeries))
+	for dateStr, v := range resp.TimeSeries {
+		t, err := time.Parse("2006-01-02", dateStr)
+		if err != nil {
+			continue
+		}
+		bar := DailyBar{Date: t}
+		bar.Price, _ = strconv.ParseFloat(v.Close, 64)
+		bar.Ask, _ = strconv.ParseFloat(v.High, 64)
+		bar.Bid, _ = strconv.ParseFloat(v.Low, 64)
+		bars = append(bars, bar)
+	}
+	sort.Slice(bars, func(i, j int) bool { return bars[i].Date.Before(bars[j].Date) })
+	for i := 1; i < len(bars); i++ {
+		bars[i].Change = bars[i].Price - bars[i-1].Price
+	}
+	return bars, nil
+}

--- a/services/securities-service/seeder/csv.go
+++ b/services/securities-service/seeder/csv.go
@@ -1,0 +1,94 @@
+package seeder
+
+import (
+	"bytes"
+	"encoding/csv"
+	"fmt"
+	"strconv"
+)
+
+// ExchangeRow holds one row from exchange_1.csv.
+type ExchangeRow struct {
+	Name      string
+	Acronym   string
+	MICCode   string
+	Country   string
+	Currency  string
+	Timezone  string
+	OpenTime  string
+	CloseTime string
+}
+
+// FutureRow holds one row from future_data.csv.
+type FutureRow struct {
+	ContractName      string
+	ContractSize      float64
+	ContractUnit      string
+	MaintenanceMargin float64
+	FutureType        string
+}
+
+// ParseExchanges parses exchange_1.csv bytes into ExchangeRow slice.
+// Expected header: Exchange Name,Exchange Acronym,Exchange MIC Code,Country,Currency,Time Zone,Open Time,Close Time
+func ParseExchanges(data []byte) ([]ExchangeRow, error) {
+	r := csv.NewReader(bytes.NewReader(data))
+	records, err := r.ReadAll()
+	if err != nil {
+		return nil, fmt.Errorf("read exchange CSV: %w", err)
+	}
+	if len(records) < 2 {
+		return nil, fmt.Errorf("exchange CSV has no data rows")
+	}
+	rows := make([]ExchangeRow, 0, len(records)-1)
+	for i, rec := range records[1:] {
+		if len(rec) < 8 {
+			return nil, fmt.Errorf("exchange CSV row %d: expected 8 columns, got %d", i+2, len(rec))
+		}
+		rows = append(rows, ExchangeRow{
+			Name:      rec[0],
+			Acronym:   rec[1],
+			MICCode:   rec[2],
+			Country:   rec[3],
+			Currency:  rec[4],
+			Timezone:  rec[5],
+			OpenTime:  rec[6],
+			CloseTime: rec[7],
+		})
+	}
+	return rows, nil
+}
+
+// ParseFutures parses future_data.csv bytes into FutureRow slice.
+// Expected header: contract_name,contract_size,contract_unit,maintenance_margin,type
+func ParseFutures(data []byte) ([]FutureRow, error) {
+	r := csv.NewReader(bytes.NewReader(data))
+	records, err := r.ReadAll()
+	if err != nil {
+		return nil, fmt.Errorf("read futures CSV: %w", err)
+	}
+	if len(records) < 2 {
+		return nil, fmt.Errorf("futures CSV has no data rows")
+	}
+	rows := make([]FutureRow, 0, len(records)-1)
+	for i, rec := range records[1:] {
+		if len(rec) < 5 {
+			return nil, fmt.Errorf("futures CSV row %d: expected 5 columns, got %d", i+2, len(rec))
+		}
+		size, err := strconv.ParseFloat(rec[1], 64)
+		if err != nil {
+			return nil, fmt.Errorf("futures CSV row %d: bad contract_size %q: %w", i+2, rec[1], err)
+		}
+		margin, err := strconv.ParseFloat(rec[3], 64)
+		if err != nil {
+			return nil, fmt.Errorf("futures CSV row %d: bad maintenance_margin %q: %w", i+2, rec[3], err)
+		}
+		rows = append(rows, FutureRow{
+			ContractName:      rec[0],
+			ContractSize:      size,
+			ContractUnit:      rec[2],
+			MaintenanceMargin: margin,
+			FutureType:        rec[4],
+		})
+	}
+	return rows, nil
+}

--- a/services/securities-service/seeder/seeder.go
+++ b/services/securities-service/seeder/seeder.go
@@ -1,0 +1,381 @@
+package seeder
+
+import (
+	"database/sql"
+	"log"
+	"time"
+)
+
+// forexPairs is the fixed list of pairs to seed. Liquidity is assigned statically.
+var forexPairs = []struct {
+	From      string
+	To        string
+	Liquidity string
+}{
+	{"EUR", "USD", "HIGH"},
+	{"GBP", "USD", "HIGH"},
+	{"USD", "JPY", "HIGH"},
+	{"USD", "CHF", "MEDIUM"},
+	{"AUD", "USD", "MEDIUM"},
+	{"USD", "CAD", "MEDIUM"},
+	{"NZD", "USD", "MEDIUM"},
+	{"EUR", "GBP", "MEDIUM"},
+	{"EUR", "JPY", "LOW"},
+	{"GBP", "JPY", "LOW"},
+}
+
+// Seed populates the database with exchanges, stocks, forex pairs, futures, and options.
+// exchangeCSVData and futureCSVData are the raw bytes of exchange_1.csv and future_data.csv.
+// It is idempotent: if listings are already present it returns immediately.
+// Intended to be called in a goroutine so it does not block the gRPC server.
+func Seed(db *sql.DB, alpacaKey, avKey string, exchangeCSV, futureDataCSV []byte) {
+	log.Println("seeder: checking if seed is needed")
+
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM listing`).Scan(&count); err != nil {
+		log.Printf("seeder: count check failed: %v", err)
+		return
+	}
+	if count > 0 {
+		log.Printf("seeder: %d listings already present, skipping", count)
+		return
+	}
+
+	log.Println("seeder: starting full data import")
+
+	// ── 1. Exchanges ─────────────────────────────────────────────────────────────
+	exchanges, err := ParseExchanges(exchangeCSV)
+	if err != nil {
+		log.Printf("seeder: parse exchanges: %v", err)
+		return
+	}
+	log.Printf("seeder: inserting %d exchanges", len(exchanges))
+	for _, ex := range exchanges {
+		_, err := db.Exec(`
+			INSERT INTO stock_exchanges (name, acronym, mic_code, polity, currency, timezone)
+			VALUES ($1, $2, $3, $4, $5, $6)
+			ON CONFLICT (mic_code) DO NOTHING`,
+			ex.Name, ex.Acronym, ex.MICCode, ex.Country, ex.Currency, ex.Timezone,
+		)
+		if err != nil {
+			log.Printf("seeder: insert exchange %s: %v", ex.MICCode, err)
+		}
+	}
+
+	// Get a default exchange ID (NYSE) to associate listings that don't have a better match.
+	var defaultExchangeID int64
+	if err := db.QueryRow(`SELECT id FROM stock_exchanges WHERE mic_code = 'XNYS' LIMIT 1`).Scan(&defaultExchangeID); err != nil {
+		// Fall back to the first available exchange.
+		if err2 := db.QueryRow(`SELECT id FROM stock_exchanges ORDER BY id LIMIT 1`).Scan(&defaultExchangeID); err2 != nil {
+			log.Printf("seeder: no exchanges found after import: %v", err2)
+			return
+		}
+	}
+
+	// ── 2. Stocks ─────────────────────────────────────────────────────────────────
+	if alpacaKey != "" {
+		log.Println("seeder: fetching tickers from Alpaca")
+		assets, err := FetchTickers(alpacaKey)
+		if err != nil {
+			log.Printf("seeder: fetch tickers: %v", err)
+		} else {
+			log.Printf("seeder: seeding %d stocks", len(assets))
+			for _, asset := range assets {
+				seedStock(db, asset.Symbol, asset.Name, defaultExchangeID, avKey)
+			}
+		}
+	} else {
+		log.Println("seeder: ALPACA_API_KEY not set, skipping stock import")
+	}
+
+	// ── 3. Forex pairs ────────────────────────────────────────────────────────────
+	// Reuse the first exchange that uses USD as a proxy for forex listings.
+	var forexExchangeID int64
+	if err := db.QueryRow(`SELECT id FROM stock_exchanges WHERE currency = 'USD' ORDER BY id LIMIT 1`).Scan(&forexExchangeID); err != nil {
+		forexExchangeID = defaultExchangeID
+	}
+
+	if avKey != "" {
+		log.Printf("seeder: seeding %d forex pairs", len(forexPairs))
+		for _, fp := range forexPairs {
+			seedForex(db, fp.From, fp.To, fp.Liquidity, forexExchangeID, avKey)
+		}
+	} else {
+		log.Println("seeder: ALPHAVANTAGE_API_KEY not set, skipping forex import")
+	}
+
+	// ── 4. Futures ────────────────────────────────────────────────────────────────
+	futures, err := ParseFutures(futureDataCSV)
+	if err != nil {
+		log.Printf("seeder: parse futures: %v", err)
+	} else {
+		log.Printf("seeder: seeding %d futures contracts", len(futures))
+		settlement := lastBusinessDayOfMonth(time.Now())
+		for _, f := range futures {
+			seedFuture(db, f, defaultExchangeID, settlement)
+		}
+	}
+
+	// ── 5. Options ────────────────────────────────────────────────────────────────
+	// Fetch all stock listing IDs + their prices and generate/fetch options for each.
+	rows, err := db.Query(`SELECT l.id, l.ticker, l.price FROM listing l JOIN listing_stock ls ON ls.listing_id = l.id`)
+	if err != nil {
+		log.Printf("seeder: query stocks for options: %v", err)
+	} else {
+		defer rows.Close()
+		for rows.Next() {
+			var id int64
+			var ticker string
+			var price float64
+			if err := rows.Scan(&id, &ticker, &price); err != nil {
+				continue
+			}
+			seedOptions(db, id, ticker, price)
+		}
+	}
+
+	log.Println("seeder: data import complete")
+}
+
+// seedStock fetches metadata + history from AlphaVantage and inserts one stock.
+func seedStock(db *sql.DB, ticker, fallbackName string, exchangeID int64, avKey string) {
+	if avKey == "" {
+		return
+	}
+
+	ov, err := FetchCompanyOverview(ticker, avKey)
+	if err != nil {
+		log.Printf("seeder: overview %s: %v", ticker, err)
+		return
+	}
+	name := fallbackName
+	if ov != nil && ov.Name != "" {
+		name = ov.Name
+	}
+	if name == "" {
+		name = ticker
+	}
+
+	// Resolve exchange by acronym if possible.
+	exID := exchangeID
+	if ov != nil && ov.Exchange != "" {
+		var id int64
+		if err := db.QueryRow(`SELECT id FROM stock_exchanges WHERE acronym = $1 LIMIT 1`, ov.Exchange).Scan(&id); err == nil {
+			exID = id
+		}
+	}
+
+	var outstandingShares int64
+	var dividendYield float64
+	if ov != nil {
+		outstandingShares = ov.OutstandingShares
+		dividendYield = ov.DividendYield
+	}
+
+	var listingID int64
+	err = db.QueryRow(`
+		INSERT INTO listing (ticker, name, exchange_id, type, price, ask, bid, volume, change)
+		VALUES ($1, $2, $3, 'STOCK', 0, 0, 0, 0, 0)
+		ON CONFLICT (ticker) DO NOTHING
+		RETURNING id`, ticker, name, exID).Scan(&listingID)
+	if err == sql.ErrNoRows {
+		// Already exists (ON CONFLICT hit); look up the ID.
+		if err2 := db.QueryRow(`SELECT id FROM listing WHERE ticker = $1`, ticker).Scan(&listingID); err2 != nil {
+			log.Printf("seeder: lookup existing listing %s: %v", ticker, err2)
+			return
+		}
+	} else if err != nil {
+		log.Printf("seeder: insert listing %s: %v", ticker, err)
+		return
+	}
+
+	if _, err := db.Exec(`
+		INSERT INTO listing_stock (listing_id, outstanding_shares, dividend_yield)
+		VALUES ($1, $2, $3)
+		ON CONFLICT (listing_id) DO NOTHING`,
+		listingID, outstandingShares, dividendYield); err != nil {
+		log.Printf("seeder: insert listing_stock %s: %v", ticker, err)
+	}
+
+	// Historical prices.
+	bars, err := FetchDailySeries(ticker, avKey)
+	if err != nil {
+		log.Printf("seeder: daily series %s: %v", ticker, err)
+	} else {
+		insertDailyBars(db, listingID, bars)
+	}
+
+	// Current price snapshot.
+	q, err := FetchGlobalQuote(ticker, avKey)
+	if err != nil {
+		log.Printf("seeder: global quote %s: %v", ticker, err)
+	} else if q != nil {
+		_, err = db.Exec(`
+			UPDATE listing SET price=$2, ask=$3, bid=$4, change=$5, volume=$6, last_refresh=$7
+			WHERE id=$1`,
+			listingID, q.Price, q.Ask, q.Bid, q.Change, q.Volume, time.Now())
+		if err != nil {
+			log.Printf("seeder: update price %s: %v", ticker, err)
+		}
+	}
+}
+
+// seedForex inserts a forex pair listing with history and current rate.
+func seedForex(db *sql.DB, from, to, liquidity string, exchangeID int64, avKey string) {
+	ticker := from + to
+	name := from + "/" + to
+
+	var listingID int64
+	err := db.QueryRow(`
+		INSERT INTO listing (ticker, name, exchange_id, type, price, ask, bid, volume, change)
+		VALUES ($1, $2, $3, 'FOREX_PAIR', 0, 0, 0, 0, 0)
+		ON CONFLICT (ticker) DO NOTHING
+		RETURNING id`, ticker, name, exchangeID).Scan(&listingID)
+	if err == sql.ErrNoRows {
+		if err2 := db.QueryRow(`SELECT id FROM listing WHERE ticker = $1`, ticker).Scan(&listingID); err2 != nil {
+			log.Printf("seeder: lookup forex %s: %v", ticker, err2)
+			return
+		}
+	} else if err != nil {
+		log.Printf("seeder: insert forex listing %s: %v", ticker, err)
+		return
+	}
+
+	if _, err := db.Exec(`
+		INSERT INTO listing_forex_pair (listing_id, base_currency, quote_currency, liquidity)
+		VALUES ($1, $2, $3, $4)
+		ON CONFLICT (listing_id) DO NOTHING`,
+		listingID, from, to, liquidity); err != nil {
+		log.Printf("seeder: insert forex pair %s: %v", ticker, err)
+	}
+
+	bars, err := FetchFXDaily(from, to, avKey)
+	if err != nil {
+		log.Printf("seeder: FX daily %s: %v", ticker, err)
+	} else {
+		insertDailyBars(db, listingID, bars)
+	}
+
+	rate, err := FetchFXRate(from, to, avKey)
+	if err != nil {
+		log.Printf("seeder: FX rate %s: %v", ticker, err)
+	} else if rate != nil {
+		_, err = db.Exec(`
+			UPDATE listing SET price=$2, ask=$3, bid=$4, last_refresh=$5
+			WHERE id=$1`,
+			listingID, rate.Price, rate.Ask, rate.Bid, time.Now())
+		if err != nil {
+			log.Printf("seeder: update forex price %s: %v", ticker, err)
+		}
+	}
+}
+
+// seedFuture inserts one futures contract listing.
+func seedFuture(db *sql.DB, f FutureRow, exchangeID int64, settlement time.Time) {
+	ticker := sanitizeTicker(f.ContractName)
+
+	var listingID int64
+	err := db.QueryRow(`
+		INSERT INTO listing (ticker, name, exchange_id, type, price, ask, bid, volume, change)
+		VALUES ($1, $2, $3, 'FUTURES_CONTRACT', 0, 0, 0, 0, 0)
+		ON CONFLICT (ticker) DO NOTHING
+		RETURNING id`, ticker, f.ContractName, exchangeID).Scan(&listingID)
+	if err == sql.ErrNoRows {
+		if err2 := db.QueryRow(`SELECT id FROM listing WHERE ticker = $1`, ticker).Scan(&listingID); err2 != nil {
+			log.Printf("seeder: lookup future %s: %v", ticker, err2)
+			return
+		}
+	} else if err != nil {
+		log.Printf("seeder: insert future listing %s: %v", ticker, err)
+		return
+	}
+
+	if _, err := db.Exec(`
+		INSERT INTO listing_futures_contract (listing_id, contract_size, contract_unit, settlement_date)
+		VALUES ($1, $2, $3, $4)
+		ON CONFLICT (listing_id) DO NOTHING`,
+		listingID, f.ContractSize, f.ContractUnit, settlement); err != nil {
+		log.Printf("seeder: insert futures contract %s: %v", ticker, err)
+	}
+}
+
+// seedOptions generates or fetches options for a stock and inserts them.
+func seedOptions(db *sql.DB, stockListingID int64, ticker string, price float64) {
+	opts, err := FetchOptions(ticker, stockListingID)
+	if err != nil {
+		log.Printf("seeder: yahoo options %s: %v — using generated options", ticker, err)
+	}
+	if len(opts) == 0 {
+		opts = GenerateOptions(stockListingID, price)
+	}
+
+	for _, opt := range opts {
+		// Build a synthetic ticker: e.g. AAPL240119C00150000
+		optTicker := buildOptionTicker(ticker, opt)
+		var optListingID int64
+		err := db.QueryRow(`
+			INSERT INTO listing (ticker, name, exchange_id, type, price, ask, bid, volume, change)
+			SELECT $1, $2, exchange_id, 'OPTION', $3, $3, $3, 0, 0 FROM listing WHERE id = $4
+			ON CONFLICT (ticker) DO NOTHING
+			RETURNING id`, optTicker, optTicker, opt.StrikePrice, stockListingID).Scan(&optListingID)
+		if err == sql.ErrNoRows {
+			continue
+		} else if err != nil {
+			log.Printf("seeder: insert option listing %s: %v", optTicker, err)
+			continue
+		}
+
+		if _, err := db.Exec(`
+			INSERT INTO listing_option (listing_id, stock_listing_id, option_type, strike_price, implied_volatility, open_interest, settlement_date)
+			VALUES ($1, $2, $3, $4, $5, $6, $7)
+			ON CONFLICT (listing_id) DO NOTHING`,
+			optListingID, stockListingID, opt.OptionType, opt.StrikePrice,
+			opt.ImpliedVolatility, opt.OpenInterest, opt.SettlementDate); err != nil {
+			log.Printf("seeder: insert listing_option %s: %v", optTicker, err)
+		}
+	}
+}
+
+// insertDailyBars bulk-inserts OHLCV history rows for a listing.
+func insertDailyBars(db *sql.DB, listingID int64, bars []DailyBar) {
+	for _, bar := range bars {
+		_, err := db.Exec(`
+			INSERT INTO listing_daily_price_info (listing_id, date, price, ask, bid, change, volume)
+			VALUES ($1, $2, $3, $4, $5, $6, $7)
+			ON CONFLICT (listing_id, date) DO NOTHING`,
+			listingID, bar.Date, bar.Price, bar.Ask, bar.Bid, bar.Change, bar.Volume)
+		if err != nil {
+			log.Printf("seeder: insert daily bar listing %d date %s: %v", listingID, bar.Date.Format("2006-01-02"), err)
+		}
+	}
+}
+
+// lastBusinessDayOfMonth returns the last Mon–Fri of the given month.
+func lastBusinessDayOfMonth(t time.Time) time.Time {
+	// Start from last day of month.
+	d := time.Date(t.Year(), t.Month()+1, 0, 0, 0, 0, 0, time.UTC)
+	for d.Weekday() == time.Saturday || d.Weekday() == time.Sunday {
+		d = d.AddDate(0, 0, -1)
+	}
+	return d
+}
+
+// sanitizeTicker converts a contract name to an uppercase alphanumeric ticker.
+func sanitizeTicker(name string) string {
+	b := make([]byte, 0, len(name))
+	for i := 0; i < len(name) && len(b) < 20; i++ {
+		c := name[i]
+		if (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') {
+			b = append(b, c)
+		} else if c >= 'a' && c <= 'z' {
+			b = append(b, c-32)
+		}
+	}
+	return string(b)
+}
+
+// buildOptionTicker creates a unique ticker for an option, e.g. AAPL_C_150_20240119.
+func buildOptionTicker(underlying string, opt OptionRow) string {
+	return underlying + "_" + opt.OptionType[:1] + "_" +
+		opt.SettlementDate.Format("20060102")
+}

--- a/services/securities-service/seeder/yahoo.go
+++ b/services/securities-service/seeder/yahoo.go
@@ -1,0 +1,142 @@
+package seeder
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"math"
+	"net/http"
+	"time"
+)
+
+// OptionRow is one option contract to be inserted.
+type OptionRow struct {
+	StockListingID    int64
+	OptionType        string // "CALL" or "PUT"
+	StrikePrice       float64
+	ImpliedVolatility float64
+	OpenInterest      int64
+	SettlementDate    time.Time
+}
+
+// yahooOptionChain is the minimal structure we need from Yahoo Finance.
+type yahooOptionChain struct {
+	OptionChain struct {
+		Result []struct {
+			Options []struct {
+				Calls []yahooContract `json:"calls"`
+				Puts  []yahooContract `json:"puts"`
+			} `json:"options"`
+		} `json:"result"`
+		Error interface{} `json:"error"`
+	} `json:"optionChain"`
+}
+
+type yahooContract struct {
+	Strike            float64 `json:"strike"`
+	ImpliedVolatility float64 `json:"impliedVolatility"`
+	OpenInterest      int64   `json:"openInterest"`
+	Expiration        int64   `json:"expiration"` // Unix timestamp
+}
+
+// FetchOptions attempts to fetch option contracts for a ticker from Yahoo Finance.
+// Returns nil, nil when the request fails or no data is available (caller should fall back).
+func FetchOptions(ticker string, stockListingID int64) ([]OptionRow, error) {
+	url := fmt.Sprintf("https://query1.finance.yahoo.com/v6/finance/options/%s", ticker)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("yahoo options: build request: %w", err)
+	}
+	req.Header.Set("User-Agent", "Mozilla/5.0")
+
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Printf("yahoo options: request failed for %s: %v — falling back to generated options", ticker, err)
+		return nil, nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		log.Printf("yahoo options: status %d for %s — falling back", resp.StatusCode, ticker)
+		return nil, nil
+	}
+
+	var chain yahooOptionChain
+	if err := json.NewDecoder(resp.Body).Decode(&chain); err != nil {
+		log.Printf("yahoo options: decode error for %s: %v — falling back", ticker, err)
+		return nil, nil
+	}
+
+	if len(chain.OptionChain.Result) == 0 || len(chain.OptionChain.Result[0].Options) == 0 {
+		return nil, nil
+	}
+
+	var rows []OptionRow
+	for _, opt := range chain.OptionChain.Result[0].Options {
+		for _, c := range opt.Calls {
+			rows = append(rows, OptionRow{
+				StockListingID:    stockListingID,
+				OptionType:        "CALL",
+				StrikePrice:       c.Strike,
+				ImpliedVolatility: c.ImpliedVolatility,
+				OpenInterest:      c.OpenInterest,
+				SettlementDate:    time.Unix(c.Expiration, 0).UTC(),
+			})
+		}
+		for _, p := range opt.Puts {
+			rows = append(rows, OptionRow{
+				StockListingID:    stockListingID,
+				OptionType:        "PUT",
+				StrikePrice:       p.Strike,
+				ImpliedVolatility: p.ImpliedVolatility,
+				OpenInterest:      p.OpenInterest,
+				SettlementDate:    time.Unix(p.Expiration, 0).UTC(),
+			})
+		}
+	}
+	return rows, nil
+}
+
+// GenerateOptions creates synthetic option contracts for a stock when Yahoo Finance is unavailable.
+//
+// Settlement dates:
+//   - 6, 12, 18, 24, 30 days from today
+//   - then 30, 60, 90, 120, 150, 180 days from today
+//
+// Strike prices: round(stockPrice) ± 5 at $1 increments.
+// For each (settlement × strike): one CALL and one PUT with impliedVolatility = 1.0.
+func GenerateOptions(stockListingID int64, stockPrice float64) []OptionRow {
+	today := time.Now().UTC().Truncate(24 * time.Hour)
+
+	// Build settlement date list.
+	var settlements []time.Time
+	for i := 1; i <= 5; i++ {
+		settlements = append(settlements, today.Add(time.Duration(i*6)*24*time.Hour))
+	}
+	for i := 1; i <= 6; i++ {
+		settlements = append(settlements, today.Add(time.Duration(i*30)*24*time.Hour))
+	}
+
+	baseStrike := math.Round(stockPrice)
+	var rows []OptionRow
+	for _, sd := range settlements {
+		for delta := -5; delta <= 5; delta++ {
+			strike := baseStrike + float64(delta)
+			if strike <= 0 {
+				continue
+			}
+			for _, optType := range []string{"CALL", "PUT"} {
+				rows = append(rows, OptionRow{
+					StockListingID:    stockListingID,
+					OptionType:        optType,
+					StrikePrice:       strike,
+					ImpliedVolatility: 1.0,
+					OpenInterest:      0,
+					SettlementDate:    sd,
+				})
+			}
+		}
+	}
+	return rows
+}

--- a/shared/pb/employee/employee.pb.go
+++ b/shared/pb/employee/employee.pb.go
@@ -1717,6 +1717,78 @@ func (*SetNeedApprovalResponse) Descriptor() ([]byte, []int) {
 	return file_employee_proto_rawDescGZIP(), []int{27}
 }
 
+type ResetAllActuaryUsedLimitsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ResetAllActuaryUsedLimitsRequest) Reset() {
+	*x = ResetAllActuaryUsedLimitsRequest{}
+	mi := &file_employee_proto_msgTypes[28]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ResetAllActuaryUsedLimitsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ResetAllActuaryUsedLimitsRequest) ProtoMessage() {}
+
+func (x *ResetAllActuaryUsedLimitsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_employee_proto_msgTypes[28]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ResetAllActuaryUsedLimitsRequest.ProtoReflect.Descriptor instead.
+func (*ResetAllActuaryUsedLimitsRequest) Descriptor() ([]byte, []int) {
+	return file_employee_proto_rawDescGZIP(), []int{28}
+}
+
+type ResetAllActuaryUsedLimitsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ResetAllActuaryUsedLimitsResponse) Reset() {
+	*x = ResetAllActuaryUsedLimitsResponse{}
+	mi := &file_employee_proto_msgTypes[29]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ResetAllActuaryUsedLimitsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ResetAllActuaryUsedLimitsResponse) ProtoMessage() {}
+
+func (x *ResetAllActuaryUsedLimitsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_employee_proto_msgTypes[29]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ResetAllActuaryUsedLimitsResponse.ProtoReflect.Descriptor instead.
+func (*ResetAllActuaryUsedLimitsResponse) Descriptor() ([]byte, []int) {
+	return file_employee_proto_rawDescGZIP(), []int{29}
+}
+
 var File_employee_proto protoreflect.FileDescriptor
 
 const file_employee_proto_rawDesc = "" +
@@ -1860,7 +1932,10 @@ const file_employee_proto_rawDesc = "" +
 	"\vemployee_id\x18\x01 \x01(\x03R\n" +
 	"employeeId\x12#\n" +
 	"\rneed_approval\x18\x02 \x01(\bR\fneedApproval\"\x19\n" +
-	"\x17SetNeedApprovalResponse2\x9e\t\n" +
+	"\x17SetNeedApprovalResponse\"\"\n" +
+	" ResetAllActuaryUsedLimitsRequest\"#\n" +
+	"!ResetAllActuaryUsedLimitsResponse2\x94\n" +
+	"\n" +
 	"\x0fEmployeeService\x12V\n" +
 	"\x0fGetAllEmployees\x12 .employee.GetAllEmployeesRequest\x1a!.employee.GetAllEmployeesResponse\x12V\n" +
 	"\x0fSearchEmployees\x12 .employee.SearchEmployeesRequest\x1a!.employee.SearchEmployeesResponse\x12k\n" +
@@ -1874,7 +1949,8 @@ const file_employee_proto_rawDesc = "" +
 	"\fGetActuaries\x12\x1d.employee.GetActuariesRequest\x1a\x1e.employee.GetActuariesResponse\x12P\n" +
 	"\rSetAgentLimit\x12\x1e.employee.SetAgentLimitRequest\x1a\x1f.employee.SetAgentLimitResponse\x12b\n" +
 	"\x13ResetAgentUsedLimit\x12$.employee.ResetAgentUsedLimitRequest\x1a%.employee.ResetAgentUsedLimitResponse\x12V\n" +
-	"\x0fSetNeedApproval\x12 .employee.SetNeedApprovalRequest\x1a!.employee.SetNeedApprovalResponseB=Z;github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/employeeb\x06proto3"
+	"\x0fSetNeedApproval\x12 .employee.SetNeedApprovalRequest\x1a!.employee.SetNeedApprovalResponse\x12t\n" +
+	"\x19ResetAllActuaryUsedLimits\x12*.employee.ResetAllActuaryUsedLimitsRequest\x1a+.employee.ResetAllActuaryUsedLimitsResponseB=Z;github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/employeeb\x06proto3"
 
 var (
 	file_employee_proto_rawDescOnce sync.Once
@@ -1888,36 +1964,38 @@ func file_employee_proto_rawDescGZIP() []byte {
 	return file_employee_proto_rawDescData
 }
 
-var file_employee_proto_msgTypes = make([]protoimpl.MessageInfo, 28)
+var file_employee_proto_msgTypes = make([]protoimpl.MessageInfo, 30)
 var file_employee_proto_goTypes = []any{
-	(*Employee)(nil),                       // 0: employee.Employee
-	(*GetAllEmployeesRequest)(nil),         // 1: employee.GetAllEmployeesRequest
-	(*GetAllEmployeesResponse)(nil),        // 2: employee.GetAllEmployeesResponse
-	(*SearchEmployeesRequest)(nil),         // 3: employee.SearchEmployeesRequest
-	(*SearchEmployeesResponse)(nil),        // 4: employee.SearchEmployeesResponse
-	(*GetEmployeeCredentialsRequest)(nil),  // 5: employee.GetEmployeeCredentialsRequest
-	(*GetEmployeeCredentialsResponse)(nil), // 6: employee.GetEmployeeCredentialsResponse
-	(*CreateEmployeeRequest)(nil),          // 7: employee.CreateEmployeeRequest
-	(*CreateEmployeeResponse)(nil),         // 8: employee.CreateEmployeeResponse
-	(*GetEmployeeByIdRequest)(nil),         // 9: employee.GetEmployeeByIdRequest
-	(*GetEmployeeByIdResponse)(nil),        // 10: employee.GetEmployeeByIdResponse
-	(*UpdateEmployeeRequest)(nil),          // 11: employee.UpdateEmployeeRequest
-	(*UpdateEmployeeResponse)(nil),         // 12: employee.UpdateEmployeeResponse
-	(*ActivateEmployeeRequest)(nil),        // 13: employee.ActivateEmployeeRequest
-	(*ActivateEmployeeResponse)(nil),       // 14: employee.ActivateEmployeeResponse
-	(*GetEmployeeByEmailRequest)(nil),      // 15: employee.GetEmployeeByEmailRequest
-	(*GetEmployeeByEmailResponse)(nil),     // 16: employee.GetEmployeeByEmailResponse
-	(*UpdatePasswordRequest)(nil),          // 17: employee.UpdatePasswordRequest
-	(*UpdatePasswordResponse)(nil),         // 18: employee.UpdatePasswordResponse
-	(*ActuaryInfo)(nil),                    // 19: employee.ActuaryInfo
-	(*GetActuariesRequest)(nil),            // 20: employee.GetActuariesRequest
-	(*GetActuariesResponse)(nil),           // 21: employee.GetActuariesResponse
-	(*SetAgentLimitRequest)(nil),           // 22: employee.SetAgentLimitRequest
-	(*SetAgentLimitResponse)(nil),          // 23: employee.SetAgentLimitResponse
-	(*ResetAgentUsedLimitRequest)(nil),     // 24: employee.ResetAgentUsedLimitRequest
-	(*ResetAgentUsedLimitResponse)(nil),    // 25: employee.ResetAgentUsedLimitResponse
-	(*SetNeedApprovalRequest)(nil),         // 26: employee.SetNeedApprovalRequest
-	(*SetNeedApprovalResponse)(nil),        // 27: employee.SetNeedApprovalResponse
+	(*Employee)(nil),                          // 0: employee.Employee
+	(*GetAllEmployeesRequest)(nil),            // 1: employee.GetAllEmployeesRequest
+	(*GetAllEmployeesResponse)(nil),           // 2: employee.GetAllEmployeesResponse
+	(*SearchEmployeesRequest)(nil),            // 3: employee.SearchEmployeesRequest
+	(*SearchEmployeesResponse)(nil),           // 4: employee.SearchEmployeesResponse
+	(*GetEmployeeCredentialsRequest)(nil),     // 5: employee.GetEmployeeCredentialsRequest
+	(*GetEmployeeCredentialsResponse)(nil),    // 6: employee.GetEmployeeCredentialsResponse
+	(*CreateEmployeeRequest)(nil),             // 7: employee.CreateEmployeeRequest
+	(*CreateEmployeeResponse)(nil),            // 8: employee.CreateEmployeeResponse
+	(*GetEmployeeByIdRequest)(nil),            // 9: employee.GetEmployeeByIdRequest
+	(*GetEmployeeByIdResponse)(nil),           // 10: employee.GetEmployeeByIdResponse
+	(*UpdateEmployeeRequest)(nil),             // 11: employee.UpdateEmployeeRequest
+	(*UpdateEmployeeResponse)(nil),            // 12: employee.UpdateEmployeeResponse
+	(*ActivateEmployeeRequest)(nil),           // 13: employee.ActivateEmployeeRequest
+	(*ActivateEmployeeResponse)(nil),          // 14: employee.ActivateEmployeeResponse
+	(*GetEmployeeByEmailRequest)(nil),         // 15: employee.GetEmployeeByEmailRequest
+	(*GetEmployeeByEmailResponse)(nil),        // 16: employee.GetEmployeeByEmailResponse
+	(*UpdatePasswordRequest)(nil),             // 17: employee.UpdatePasswordRequest
+	(*UpdatePasswordResponse)(nil),            // 18: employee.UpdatePasswordResponse
+	(*ActuaryInfo)(nil),                       // 19: employee.ActuaryInfo
+	(*GetActuariesRequest)(nil),               // 20: employee.GetActuariesRequest
+	(*GetActuariesResponse)(nil),              // 21: employee.GetActuariesResponse
+	(*SetAgentLimitRequest)(nil),              // 22: employee.SetAgentLimitRequest
+	(*SetAgentLimitResponse)(nil),             // 23: employee.SetAgentLimitResponse
+	(*ResetAgentUsedLimitRequest)(nil),        // 24: employee.ResetAgentUsedLimitRequest
+	(*ResetAgentUsedLimitResponse)(nil),       // 25: employee.ResetAgentUsedLimitResponse
+	(*SetNeedApprovalRequest)(nil),            // 26: employee.SetNeedApprovalRequest
+	(*SetNeedApprovalResponse)(nil),           // 27: employee.SetNeedApprovalResponse
+	(*ResetAllActuaryUsedLimitsRequest)(nil),  // 28: employee.ResetAllActuaryUsedLimitsRequest
+	(*ResetAllActuaryUsedLimitsResponse)(nil), // 29: employee.ResetAllActuaryUsedLimitsResponse
 }
 var file_employee_proto_depIdxs = []int32{
 	0,  // 0: employee.GetAllEmployeesResponse.employees:type_name -> employee.Employee
@@ -1939,21 +2017,23 @@ var file_employee_proto_depIdxs = []int32{
 	22, // 16: employee.EmployeeService.SetAgentLimit:input_type -> employee.SetAgentLimitRequest
 	24, // 17: employee.EmployeeService.ResetAgentUsedLimit:input_type -> employee.ResetAgentUsedLimitRequest
 	26, // 18: employee.EmployeeService.SetNeedApproval:input_type -> employee.SetNeedApprovalRequest
-	2,  // 19: employee.EmployeeService.GetAllEmployees:output_type -> employee.GetAllEmployeesResponse
-	4,  // 20: employee.EmployeeService.SearchEmployees:output_type -> employee.SearchEmployeesResponse
-	6,  // 21: employee.EmployeeService.GetEmployeeCredentials:output_type -> employee.GetEmployeeCredentialsResponse
-	8,  // 22: employee.EmployeeService.CreateEmployee:output_type -> employee.CreateEmployeeResponse
-	10, // 23: employee.EmployeeService.GetEmployeeById:output_type -> employee.GetEmployeeByIdResponse
-	12, // 24: employee.EmployeeService.UpdateEmployee:output_type -> employee.UpdateEmployeeResponse
-	14, // 25: employee.EmployeeService.ActivateEmployee:output_type -> employee.ActivateEmployeeResponse
-	16, // 26: employee.EmployeeService.GetEmployeeByEmail:output_type -> employee.GetEmployeeByEmailResponse
-	18, // 27: employee.EmployeeService.UpdatePassword:output_type -> employee.UpdatePasswordResponse
-	21, // 28: employee.EmployeeService.GetActuaries:output_type -> employee.GetActuariesResponse
-	23, // 29: employee.EmployeeService.SetAgentLimit:output_type -> employee.SetAgentLimitResponse
-	25, // 30: employee.EmployeeService.ResetAgentUsedLimit:output_type -> employee.ResetAgentUsedLimitResponse
-	27, // 31: employee.EmployeeService.SetNeedApproval:output_type -> employee.SetNeedApprovalResponse
-	19, // [19:32] is the sub-list for method output_type
-	6,  // [6:19] is the sub-list for method input_type
+	28, // 19: employee.EmployeeService.ResetAllActuaryUsedLimits:input_type -> employee.ResetAllActuaryUsedLimitsRequest
+	2,  // 20: employee.EmployeeService.GetAllEmployees:output_type -> employee.GetAllEmployeesResponse
+	4,  // 21: employee.EmployeeService.SearchEmployees:output_type -> employee.SearchEmployeesResponse
+	6,  // 22: employee.EmployeeService.GetEmployeeCredentials:output_type -> employee.GetEmployeeCredentialsResponse
+	8,  // 23: employee.EmployeeService.CreateEmployee:output_type -> employee.CreateEmployeeResponse
+	10, // 24: employee.EmployeeService.GetEmployeeById:output_type -> employee.GetEmployeeByIdResponse
+	12, // 25: employee.EmployeeService.UpdateEmployee:output_type -> employee.UpdateEmployeeResponse
+	14, // 26: employee.EmployeeService.ActivateEmployee:output_type -> employee.ActivateEmployeeResponse
+	16, // 27: employee.EmployeeService.GetEmployeeByEmail:output_type -> employee.GetEmployeeByEmailResponse
+	18, // 28: employee.EmployeeService.UpdatePassword:output_type -> employee.UpdatePasswordResponse
+	21, // 29: employee.EmployeeService.GetActuaries:output_type -> employee.GetActuariesResponse
+	23, // 30: employee.EmployeeService.SetAgentLimit:output_type -> employee.SetAgentLimitResponse
+	25, // 31: employee.EmployeeService.ResetAgentUsedLimit:output_type -> employee.ResetAgentUsedLimitResponse
+	27, // 32: employee.EmployeeService.SetNeedApproval:output_type -> employee.SetNeedApprovalResponse
+	29, // 33: employee.EmployeeService.ResetAllActuaryUsedLimits:output_type -> employee.ResetAllActuaryUsedLimitsResponse
+	20, // [20:34] is the sub-list for method output_type
+	6,  // [6:20] is the sub-list for method input_type
 	6,  // [6:6] is the sub-list for extension type_name
 	6,  // [6:6] is the sub-list for extension extendee
 	0,  // [0:6] is the sub-list for field type_name
@@ -1970,7 +2050,7 @@ func file_employee_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_employee_proto_rawDesc), len(file_employee_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   28,
+			NumMessages:   30,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/shared/pb/employee/employee_grpc.pb.go
+++ b/shared/pb/employee/employee_grpc.pb.go
@@ -19,19 +19,20 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	EmployeeService_GetAllEmployees_FullMethodName        = "/employee.EmployeeService/GetAllEmployees"
-	EmployeeService_SearchEmployees_FullMethodName        = "/employee.EmployeeService/SearchEmployees"
-	EmployeeService_GetEmployeeCredentials_FullMethodName = "/employee.EmployeeService/GetEmployeeCredentials"
-	EmployeeService_CreateEmployee_FullMethodName         = "/employee.EmployeeService/CreateEmployee"
-	EmployeeService_GetEmployeeById_FullMethodName        = "/employee.EmployeeService/GetEmployeeById"
-	EmployeeService_UpdateEmployee_FullMethodName         = "/employee.EmployeeService/UpdateEmployee"
-	EmployeeService_ActivateEmployee_FullMethodName       = "/employee.EmployeeService/ActivateEmployee"
-	EmployeeService_GetEmployeeByEmail_FullMethodName     = "/employee.EmployeeService/GetEmployeeByEmail"
-	EmployeeService_UpdatePassword_FullMethodName         = "/employee.EmployeeService/UpdatePassword"
-	EmployeeService_GetActuaries_FullMethodName           = "/employee.EmployeeService/GetActuaries"
-	EmployeeService_SetAgentLimit_FullMethodName          = "/employee.EmployeeService/SetAgentLimit"
-	EmployeeService_ResetAgentUsedLimit_FullMethodName    = "/employee.EmployeeService/ResetAgentUsedLimit"
-	EmployeeService_SetNeedApproval_FullMethodName        = "/employee.EmployeeService/SetNeedApproval"
+	EmployeeService_GetAllEmployees_FullMethodName           = "/employee.EmployeeService/GetAllEmployees"
+	EmployeeService_SearchEmployees_FullMethodName           = "/employee.EmployeeService/SearchEmployees"
+	EmployeeService_GetEmployeeCredentials_FullMethodName    = "/employee.EmployeeService/GetEmployeeCredentials"
+	EmployeeService_CreateEmployee_FullMethodName            = "/employee.EmployeeService/CreateEmployee"
+	EmployeeService_GetEmployeeById_FullMethodName           = "/employee.EmployeeService/GetEmployeeById"
+	EmployeeService_UpdateEmployee_FullMethodName            = "/employee.EmployeeService/UpdateEmployee"
+	EmployeeService_ActivateEmployee_FullMethodName          = "/employee.EmployeeService/ActivateEmployee"
+	EmployeeService_GetEmployeeByEmail_FullMethodName        = "/employee.EmployeeService/GetEmployeeByEmail"
+	EmployeeService_UpdatePassword_FullMethodName            = "/employee.EmployeeService/UpdatePassword"
+	EmployeeService_GetActuaries_FullMethodName              = "/employee.EmployeeService/GetActuaries"
+	EmployeeService_SetAgentLimit_FullMethodName             = "/employee.EmployeeService/SetAgentLimit"
+	EmployeeService_ResetAgentUsedLimit_FullMethodName       = "/employee.EmployeeService/ResetAgentUsedLimit"
+	EmployeeService_SetNeedApproval_FullMethodName           = "/employee.EmployeeService/SetNeedApproval"
+	EmployeeService_ResetAllActuaryUsedLimits_FullMethodName = "/employee.EmployeeService/ResetAllActuaryUsedLimits"
 )
 
 // EmployeeServiceClient is the client API for EmployeeService service.
@@ -51,6 +52,7 @@ type EmployeeServiceClient interface {
 	SetAgentLimit(ctx context.Context, in *SetAgentLimitRequest, opts ...grpc.CallOption) (*SetAgentLimitResponse, error)
 	ResetAgentUsedLimit(ctx context.Context, in *ResetAgentUsedLimitRequest, opts ...grpc.CallOption) (*ResetAgentUsedLimitResponse, error)
 	SetNeedApproval(ctx context.Context, in *SetNeedApprovalRequest, opts ...grpc.CallOption) (*SetNeedApprovalResponse, error)
+	ResetAllActuaryUsedLimits(ctx context.Context, in *ResetAllActuaryUsedLimitsRequest, opts ...grpc.CallOption) (*ResetAllActuaryUsedLimitsResponse, error)
 }
 
 type employeeServiceClient struct {
@@ -191,6 +193,16 @@ func (c *employeeServiceClient) SetNeedApproval(ctx context.Context, in *SetNeed
 	return out, nil
 }
 
+func (c *employeeServiceClient) ResetAllActuaryUsedLimits(ctx context.Context, in *ResetAllActuaryUsedLimitsRequest, opts ...grpc.CallOption) (*ResetAllActuaryUsedLimitsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ResetAllActuaryUsedLimitsResponse)
+	err := c.cc.Invoke(ctx, EmployeeService_ResetAllActuaryUsedLimits_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // EmployeeServiceServer is the server API for EmployeeService service.
 // All implementations must embed UnimplementedEmployeeServiceServer
 // for forward compatibility.
@@ -208,6 +220,7 @@ type EmployeeServiceServer interface {
 	SetAgentLimit(context.Context, *SetAgentLimitRequest) (*SetAgentLimitResponse, error)
 	ResetAgentUsedLimit(context.Context, *ResetAgentUsedLimitRequest) (*ResetAgentUsedLimitResponse, error)
 	SetNeedApproval(context.Context, *SetNeedApprovalRequest) (*SetNeedApprovalResponse, error)
+	ResetAllActuaryUsedLimits(context.Context, *ResetAllActuaryUsedLimitsRequest) (*ResetAllActuaryUsedLimitsResponse, error)
 	mustEmbedUnimplementedEmployeeServiceServer()
 }
 
@@ -256,6 +269,9 @@ func (UnimplementedEmployeeServiceServer) ResetAgentUsedLimit(context.Context, *
 }
 func (UnimplementedEmployeeServiceServer) SetNeedApproval(context.Context, *SetNeedApprovalRequest) (*SetNeedApprovalResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method SetNeedApproval not implemented")
+}
+func (UnimplementedEmployeeServiceServer) ResetAllActuaryUsedLimits(context.Context, *ResetAllActuaryUsedLimitsRequest) (*ResetAllActuaryUsedLimitsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ResetAllActuaryUsedLimits not implemented")
 }
 func (UnimplementedEmployeeServiceServer) mustEmbedUnimplementedEmployeeServiceServer() {}
 func (UnimplementedEmployeeServiceServer) testEmbeddedByValue()                         {}
@@ -512,6 +528,24 @@ func _EmployeeService_SetNeedApproval_Handler(srv interface{}, ctx context.Conte
 	return interceptor(ctx, in, info, handler)
 }
 
+func _EmployeeService_ResetAllActuaryUsedLimits_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ResetAllActuaryUsedLimitsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(EmployeeServiceServer).ResetAllActuaryUsedLimits(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: EmployeeService_ResetAllActuaryUsedLimits_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(EmployeeServiceServer).ResetAllActuaryUsedLimits(ctx, req.(*ResetAllActuaryUsedLimitsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // EmployeeService_ServiceDesc is the grpc.ServiceDesc for EmployeeService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -570,6 +604,10 @@ var EmployeeService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "SetNeedApproval",
 			Handler:    _EmployeeService_SetNeedApproval_Handler,
+		},
+		{
+			MethodName: "ResetAllActuaryUsedLimits",
+			Handler:    _EmployeeService_ResetAllActuaryUsedLimits_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/shared/proto/employee.proto
+++ b/shared/proto/employee.proto
@@ -165,6 +165,9 @@ message SetNeedApprovalRequest {
 }
 message SetNeedApprovalResponse {}
 
+message ResetAllActuaryUsedLimitsRequest {}
+message ResetAllActuaryUsedLimitsResponse {}
+
 service EmployeeService {
   rpc GetAllEmployees(GetAllEmployeesRequest) returns (GetAllEmployeesResponse);
   rpc SearchEmployees(SearchEmployeesRequest) returns (SearchEmployeesResponse);
@@ -179,4 +182,5 @@ service EmployeeService {
   rpc SetAgentLimit(SetAgentLimitRequest) returns (SetAgentLimitResponse);
   rpc ResetAgentUsedLimit(ResetAgentUsedLimitRequest) returns (ResetAgentUsedLimitResponse);
   rpc SetNeedApproval(SetNeedApprovalRequest) returns (SetNeedApprovalResponse);
+  rpc ResetAllActuaryUsedLimits(ResetAllActuaryUsedLimitsRequest) returns (ResetAllActuaryUsedLimitsResponse);
 }


### PR DESCRIPTION
- Add seeder package: idempotent startup import for exchanges (CSV), stocks (Alpaca + AlphaVantage), forex pairs (AlphaVantage), futures (CSV), and options (Yahoo Finance with programmatic fallback)
- Add scheduler package: 15-min price refresh via AlphaVantage; daily 23:59 EOD job that snapshots listing_daily_price_info and resets actuary used_limit via employee-service gRPC
- Add ResetAllActuaryUsedLimits RPC to employee proto + implementation
- Wire seeder + schedulers in main.go; embed CSV assets at build time
- Update dev.sh to start securities-db and securities-service