### PR TITLE
feat: add role guard to portfolio routes

### DIFF
--- a/services/api-gateway/main.go
+++ b/services/api-gateway/main.go
@@ -204,8 +204,8 @@ func main() {
 	r.PUT("/orders/:id/decline", middleware.RequireRole("SUPERVISOR"), handlers.DeclineOrder(orderClient))
 	r.DELETE("/orders/:id/portions", middleware.RequireRole("AGENT", "SUPERVISOR"), handlers.CancelOrderPortions(orderClient))
 	r.DELETE("/orders/:id", middleware.RequireRole("AGENT", "SUPERVISOR"), handlers.CancelOrder(orderClient))
-	r.GET("/portfolio", handlers.GetPortfolio(portfolioClient))
-	r.GET("/portfolio/profit", handlers.GetProfit(portfolioClient))
+	r.GET("/portfolio", middleware.RequireRole("AGENT", "SUPERVISOR"), handlers.GetPortfolio(portfolioClient))
+	r.GET("/portfolio/profit", middleware.RequireRole("AGENT", "SUPERVISOR"), handlers.GetProfit(portfolioClient))
 	r.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 	if err := r.Run(":8083"); err != nil {
 		log.Fatalf("server error: %v", err)


### PR DESCRIPTION
## Summary
- Restrict `GET /portfolio` and `GET /portfolio/profit` to `AGENT` and `SUPERVISOR` roles, consistent with orders and stock exchange routes
- Previously these routes had no role check, so any authenticated employee (including admins) could call them and receive a 500 since they have no holdings

## Test plan
- [ ] Agent/supervisor can access `/portfolio` — returns holdings or empty list
- [ ] Admin gets 403 on `/portfolio`
- [ ] Unauthenticated request gets 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)