### PR TITLE
feat(order): only BUY orders count against agent limit; validate holdings on SELL

### DIFF
--- a/services/order-service/approval/approval.go
+++ b/services/order-service/approval/approval.go
@@ -4,9 +4,14 @@ import "time"
 
 // NeedsApproval reports whether an agent order requires supervisor approval.
 // orderTotal is contractSize × pricePerUnit × quantity.
-func NeedsApproval(needApprovalFlag bool, usedLimit, limitAmount, orderTotal float64) bool {
+// Only BUY orders are gated by the limit; SELL orders bypass the limit checks
+// (the needApprovalFlag still applies to all directions).
+func NeedsApproval(needApprovalFlag bool, usedLimit, limitAmount, orderTotal float64, direction string) bool {
 	if needApprovalFlag {
 		return true
+	}
+	if direction != "BUY" {
+		return false
 	}
 	if usedLimit >= limitAmount {
 		return true

--- a/services/order-service/approval/approval_test.go
+++ b/services/order-service/approval/approval_test.go
@@ -10,30 +10,40 @@ import (
 // --- NeedsApproval ---
 
 func TestNeedsApproval_FlagTrue(t *testing.T) {
-	assert.True(t, NeedsApproval(true, 0, 10000, 500))
+	assert.True(t, NeedsApproval(true, 0, 10000, 500, "BUY"))
 }
 
 func TestNeedsApproval_UsedLimitExceeded(t *testing.T) {
-	assert.True(t, NeedsApproval(false, 10000, 10000, 1))
+	assert.True(t, NeedsApproval(false, 10000, 10000, 1, "BUY"))
 }
 
 func TestNeedsApproval_UsedLimitOverLimit(t *testing.T) {
-	assert.True(t, NeedsApproval(false, 11000, 10000, 1))
+	assert.True(t, NeedsApproval(false, 11000, 10000, 1, "BUY"))
 }
 
 func TestNeedsApproval_OrderExceedsRemaining(t *testing.T) {
 	// usedLimit=8000, limit=10000, remaining=2000, orderTotal=3000 → exceeds
-	assert.True(t, NeedsApproval(false, 8000, 10000, 3000))
+	assert.True(t, NeedsApproval(false, 8000, 10000, 3000, "BUY"))
 }
 
 func TestNeedsApproval_AllClear(t *testing.T) {
 	// usedLimit=0, limit=10000, orderTotal=500 → no approval needed
-	assert.False(t, NeedsApproval(false, 0, 10000, 500))
+	assert.False(t, NeedsApproval(false, 0, 10000, 500, "BUY"))
 }
 
 func TestNeedsApproval_ExactlyAtRemainingLimit(t *testing.T) {
 	// orderTotal == remaining limit → does not exceed → no approval
-	assert.False(t, NeedsApproval(false, 5000, 10000, 5000))
+	assert.False(t, NeedsApproval(false, 5000, 10000, 5000, "BUY"))
+}
+
+func TestNeedsApproval_SellNeverLimitGated(t *testing.T) {
+	// Even with an exhausted limit, SELL orders bypass the limit check
+	assert.False(t, NeedsApproval(false, 10000, 10000, 5000, "SELL"))
+}
+
+func TestNeedsApproval_SellFlagStillApplies(t *testing.T) {
+	// need_approval flag still gates SELL orders regardless of limits
+	assert.True(t, NeedsApproval(true, 0, 10000, 5000, "SELL"))
 }
 
 // --- DetermineInitialStatus ---

--- a/services/order-service/approval/service.go
+++ b/services/order-service/approval/service.go
@@ -26,8 +26,9 @@ func ApproveOrder(ctx context.Context, orderDB, employeeDB *sql.DB, orderID, sup
 		return err
 	}
 
-	// Deduct from agent's used limit if placed by an actuary
-	if order.UserType == "EMPLOYEE" && employeeDB != nil {
+	// Deduct from agent's used limit if placed by an actuary on a BUY order.
+	// SELL orders do not count against the limit.
+	if order.UserType == "EMPLOYEE" && order.Direction == "BUY" && employeeDB != nil {
 		isActuary := repository.IsActuary(ctx, employeeDB, order.UserID)
 		if isActuary {
 			orderTotal := float64(order.ContractSize) * order.PricePerUnit * float64(order.Quantity)

--- a/services/order-service/approval/service_test.go
+++ b/services/order-service/approval/service_test.go
@@ -29,11 +29,15 @@ func newMocks(t *testing.T) (*sql.DB, sqlmock.Sqlmock, *sql.DB, sqlmock.Sqlmock)
 }
 
 func addOrderRow(rows *sqlmock.Rows, id, userID int64, userType, status string, contractSize int32, pricePerUnit float64, quantity int32) *sqlmock.Rows {
+	return addOrderRowDir(rows, id, userID, userType, status, contractSize, pricePerUnit, quantity, "BUY")
+}
+
+func addOrderRowDir(rows *sqlmock.Rows, id, userID int64, userType, status string, contractSize int32, pricePerUnit float64, quantity int32, direction string) *sqlmock.Rows {
 	ts := time.Now()
 	return rows.AddRow(
 		id, userID, userType, int64(5), "MARKET",
 		quantity, contractSize, pricePerUnit, nil, nil,
-		"BUY", status, nil, false, ts,
+		direction, status, nil, false, ts,
 		quantity, false, false, false, int64(42),
 	)
 }
@@ -116,6 +120,20 @@ func TestApproveOrder_Happy_EmployeeSupervisor(t *testing.T) {
 
 	err := ApproveOrder(context.Background(), orderDB, empDB, 1, 5)
 	require.NoError(t, err)
+}
+
+func TestApproveOrder_Happy_EmployeeActuary_Sell(t *testing.T) {
+	// SELL orders: status is approved but used_limit must NOT be deducted.
+	orderDB, orderMock, empDB, empMock := newMocks(t)
+	rows := sqlmock.NewRows(orderCols)
+	addOrderRowDir(rows, 1, 20, "EMPLOYEE", "PENDING", 2, 150.0, 5, "SELL")
+	orderMock.ExpectQuery("SELECT id").WillReturnRows(rows)
+	orderMock.ExpectExec("UPDATE orders SET status").WillReturnResult(sqlmock.NewResult(1, 1))
+	// IsActuary and DeductActuaryUsedLimit must NOT be called for SELL orders.
+
+	err := ApproveOrder(context.Background(), orderDB, empDB, 1, 5)
+	require.NoError(t, err)
+	require.NoError(t, empMock.ExpectationsWereMet())
 }
 
 // ── DeclineOrder ─────────────────────────────────────────────────────────────

--- a/services/order-service/handlers/grpc_server.go
+++ b/services/order-service/handlers/grpc_server.go
@@ -13,6 +13,7 @@ import (
 	pb_emp "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/employee"
 	pb_loan "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/loan"
 	pb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/order"
+	pb_portfolio "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/portfolio"
 	pb_sec "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/securities"
 	"google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
@@ -28,6 +29,7 @@ type OrderServer struct {
 	SecuritiesClient pb_sec.SecuritiesServiceClient
 	LoanClient       pb_loan.LoanServiceClient
 	EmployeeClient   pb_emp.EmployeeServiceClient
+	PortfolioClient  pb_portfolio.PortfolioServiceClient
 }
 
 func (s *OrderServer) Ping(ctx context.Context, req *pb.PingRequest) (*pb.PingResponse, error) {
@@ -67,6 +69,27 @@ func (s *OrderServer) CreateOrder(ctx context.Context, req *pb.CreateOrderReques
 		}
 	}
 
+	// 3c. For SELL orders, reject if the user holds fewer securities than requested.
+	if req.Direction == "SELL" {
+		portfolioResp, err := s.PortfolioClient.GetPortfolio(ctx, &pb_portfolio.GetPortfolioRequest{
+			UserId:   req.UserId,
+			UserType: req.UserType,
+		})
+		if err != nil {
+			return nil, grpcstatus.Errorf(codes.Internal, "failed to fetch portfolio: %v", err)
+		}
+		var held int32
+		for _, entry := range portfolioResp.Entries {
+			if entry.ListingId == req.AssetId {
+				held = entry.Amount
+				break
+			}
+		}
+		if held < req.Quantity {
+			return nil, grpcstatus.Errorf(codes.FailedPrecondition, "insufficient holdings: have %d, need %d", held, req.Quantity)
+		}
+	}
+
 	// 4. After-hours check via working hours
 	afterHours := s.checkAfterHours(ctx, listingResp)
 
@@ -77,7 +100,7 @@ func (s *OrderServer) CreateOrder(ctx context.Context, req *pb.CreateOrderReques
 		limitAmount, usedLimit, needApprovalFlag, err := repository.GetActuaryInfo(ctx, s.EmployeeDB, req.UserId)
 		if err == nil {
 			isActuary = true
-			needsApproval = approval.NeedsApproval(needApprovalFlag, usedLimit, limitAmount, approxPrice)
+			needsApproval = approval.NeedsApproval(needApprovalFlag, usedLimit, limitAmount, approxPrice, req.Direction)
 		}
 		// sql.ErrNoRows → supervisor, isActuary stays false
 	}
@@ -118,9 +141,10 @@ func (s *OrderServer) CreateOrder(ctx context.Context, req *pb.CreateOrderReques
 		return nil, grpcstatus.Errorf(codes.Internal, "failed to insert order: %v", err)
 	}
 
-	// Deduct from agent's used limit for auto-approved orders.
+	// Deduct from agent's used limit for auto-approved BUY orders.
+	// SELL orders do not count against the limit.
 	// PENDING orders are deducted in ApproveOrder when the supervisor approves.
-	if isActuary && initialStatus == "APPROVED" {
+	if isActuary && initialStatus == "APPROVED" && req.Direction == "BUY" {
 		_ = repository.DeductActuaryUsedLimit(ctx, s.EmployeeDB, req.UserId, approxPrice)
 	}
 

--- a/services/order-service/handlers/grpc_server_test.go
+++ b/services/order-service/handlers/grpc_server_test.go
@@ -10,6 +10,7 @@ import (
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/RAF-SI-2025/EXBanka-4-Backend/services/order-service/handlers"
 	pb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/order"
+	pb_portfolio "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/portfolio"
 	pb_sec "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/securities"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -33,7 +34,7 @@ func newOrderServer(t *testing.T) (*handlers.OrderServer, sqlmock.Sqlmock, sqlmo
 	return srv, dbMock, empMock
 }
 
-func newOrderServerWithSecDB(t *testing.T) (*handlers.OrderServer, sqlmock.Sqlmock, sqlmock.Sqlmock, sqlmock.Sqlmock) {
+func newOrderServerWithSecDB(t *testing.T) (*handlers.OrderServer, sqlmock.Sqlmock, sqlmock.Sqlmock, sqlmock.Sqlmock, sqlmock.Sqlmock) {
 	t.Helper()
 	db, dbMock, err := sqlmock.New()
 	require.NoError(t, err)
@@ -41,9 +42,11 @@ func newOrderServerWithSecDB(t *testing.T) (*handlers.OrderServer, sqlmock.Sqlmo
 	require.NoError(t, err)
 	secDB, secMock, err := sqlmock.New()
 	require.NoError(t, err)
-	srv := &handlers.OrderServer{DB: db, EmployeeDB: employeeDB, SecuritiesDB: secDB}
-	t.Cleanup(func() { _ = db.Close(); _ = employeeDB.Close(); _ = secDB.Close() })
-	return srv, dbMock, empMock, secMock
+	accountDB, accMock, err := sqlmock.New()
+	require.NoError(t, err)
+	srv := &handlers.OrderServer{DB: db, EmployeeDB: employeeDB, SecuritiesDB: secDB, AccountDB: accountDB, PortfolioClient: &mockPortfolioClient{}}
+	t.Cleanup(func() { _ = db.Close(); _ = employeeDB.Close(); _ = secDB.Close(); _ = accountDB.Close() })
+	return srv, dbMock, empMock, secMock, accMock
 }
 
 // orderCols is the ordered list of columns returned by all order SELECT queries.
@@ -136,6 +139,27 @@ func (m *mockSecClient) GetListingById(ctx context.Context, in *pb_sec.GetListin
 	return nil, fmt.Errorf("not mocked")
 }
 func (m *mockSecClient) GetListingHistory(ctx context.Context, in *pb_sec.GetListingHistoryRequest, opts ...grpc.CallOption) (*pb_sec.GetListingHistoryResponse, error) {
+	return nil, fmt.Errorf("not mocked")
+}
+
+// mockPortfolioClient is a configurable mock for pb_portfolio.PortfolioServiceClient.
+type mockPortfolioClient struct {
+	getPortfolio func(ctx context.Context, in *pb_portfolio.GetPortfolioRequest, opts ...grpc.CallOption) (*pb_portfolio.GetPortfolioResponse, error)
+}
+
+func (m *mockPortfolioClient) UpdateHolding(ctx context.Context, in *pb_portfolio.UpdateHoldingRequest, opts ...grpc.CallOption) (*pb_portfolio.UpdateHoldingResponse, error) {
+	return nil, fmt.Errorf("not mocked")
+}
+func (m *mockPortfolioClient) GetPortfolio(ctx context.Context, in *pb_portfolio.GetPortfolioRequest, opts ...grpc.CallOption) (*pb_portfolio.GetPortfolioResponse, error) {
+	if m.getPortfolio != nil {
+		return m.getPortfolio(ctx, in, opts...)
+	}
+	return nil, fmt.Errorf("not mocked")
+}
+func (m *mockPortfolioClient) GetProfit(ctx context.Context, in *pb_portfolio.GetProfitRequest, opts ...grpc.CallOption) (*pb_portfolio.GetProfitResponse, error) {
+	return nil, fmt.Errorf("not mocked")
+}
+func (m *mockPortfolioClient) SetPublicAmount(ctx context.Context, in *pb_portfolio.SetPublicAmountRequest, opts ...grpc.CallOption) (*pb_portfolio.SetPublicAmountResponse, error) {
 	return nil, fmt.Errorf("not mocked")
 }
 
@@ -469,7 +493,7 @@ func TestCreateOrder_SecuritiesClientError(t *testing.T) {
 }
 
 func TestCreateOrder_InsertError(t *testing.T) {
-	srv, dbMock, _, secMock := newOrderServerWithSecDB(t)
+	srv, dbMock, _, secMock, accMock := newOrderServerWithSecDB(t)
 	srv.SecuritiesClient = &mockSecClient{
 		getListingById: func(ctx context.Context, in *pb_sec.GetListingByIdRequest, opts ...grpc.CallOption) (*pb_sec.GetListingByIdResponse, error) {
 			return &pb_sec.GetListingByIdResponse{
@@ -477,6 +501,10 @@ func TestCreateOrder_InsertError(t *testing.T) {
 			}, nil
 		},
 	}
+	// CLIENT BUY → balance check passes
+	accMock.ExpectQuery("SELECT available_balance FROM accounts").WillReturnRows(
+		sqlmock.NewRows([]string{"available_balance"}).AddRow(float64(999999)),
+	)
 	// After-hours check: mic_code lookup fails → afterHours=false (non-fatal)
 	secMock.ExpectQuery("SELECT mic_code FROM stock_exchanges").WillReturnError(sql.ErrNoRows)
 	// INSERT fails
@@ -490,7 +518,7 @@ func TestCreateOrder_InsertError(t *testing.T) {
 }
 
 func TestCreateOrder_Happy_Client_Market(t *testing.T) {
-	srv, dbMock, _, secMock := newOrderServerWithSecDB(t)
+	srv, dbMock, _, secMock, accMock := newOrderServerWithSecDB(t)
 	srv.SecuritiesClient = &mockSecClient{
 		getListingById: func(ctx context.Context, in *pb_sec.GetListingByIdRequest, opts ...grpc.CallOption) (*pb_sec.GetListingByIdResponse, error) {
 			return &pb_sec.GetListingByIdResponse{
@@ -498,6 +526,10 @@ func TestCreateOrder_Happy_Client_Market(t *testing.T) {
 			}, nil
 		},
 	}
+	// CLIENT BUY → balance check passes
+	accMock.ExpectQuery("SELECT available_balance FROM accounts").WillReturnRows(
+		sqlmock.NewRows([]string{"available_balance"}).AddRow(float64(999999)),
+	)
 	// After-hours: MIC lookup fails → non-fatal
 	secMock.ExpectQuery("SELECT mic_code FROM stock_exchanges").WillReturnError(sql.ErrNoRows)
 	// CLIENT user → no actuary query
@@ -516,7 +548,7 @@ func TestCreateOrder_Happy_Client_Market(t *testing.T) {
 }
 
 func TestCreateOrder_Happy_Employee_Actuary_Pending(t *testing.T) {
-	srv, dbMock, empMock, secMock := newOrderServerWithSecDB(t)
+	srv, dbMock, empMock, secMock, _ := newOrderServerWithSecDB(t)
 	srv.SecuritiesClient = &mockSecClient{
 		getListingById: func(ctx context.Context, in *pb_sec.GetListingByIdRequest, opts ...grpc.CallOption) (*pb_sec.GetListingByIdResponse, error) {
 			return &pb_sec.GetListingByIdResponse{
@@ -544,7 +576,7 @@ func TestCreateOrder_Happy_Employee_Actuary_Pending(t *testing.T) {
 }
 
 func TestCreateOrder_Happy_Employee_Supervisor_Approved(t *testing.T) {
-	srv, dbMock, empMock, secMock := newOrderServerWithSecDB(t)
+	srv, dbMock, empMock, secMock, _ := newOrderServerWithSecDB(t)
 	srv.SecuritiesClient = &mockSecClient{
 		getListingById: func(ctx context.Context, in *pb_sec.GetListingByIdRequest, opts ...grpc.CallOption) (*pb_sec.GetListingByIdResponse, error) {
 			return &pb_sec.GetListingByIdResponse{
@@ -570,7 +602,7 @@ func TestCreateOrder_Happy_Employee_Supervisor_Approved(t *testing.T) {
 // determineOrderType coverage: LIMIT, STOP, STOP_LIMIT variants
 
 func TestCreateOrder_LimitOrder(t *testing.T) {
-	srv, dbMock, _, secMock := newOrderServerWithSecDB(t)
+	srv, dbMock, _, secMock, accMock := newOrderServerWithSecDB(t)
 	srv.SecuritiesClient = &mockSecClient{
 		getListingById: func(ctx context.Context, in *pb_sec.GetListingByIdRequest, opts ...grpc.CallOption) (*pb_sec.GetListingByIdResponse, error) {
 			return &pb_sec.GetListingByIdResponse{
@@ -578,6 +610,9 @@ func TestCreateOrder_LimitOrder(t *testing.T) {
 			}, nil
 		},
 	}
+	accMock.ExpectQuery("SELECT available_balance FROM accounts").WillReturnRows(
+		sqlmock.NewRows([]string{"available_balance"}).AddRow(float64(999999)),
+	)
 	secMock.ExpectQuery("SELECT mic_code FROM stock_exchanges").WillReturnError(sql.ErrNoRows)
 	dbMock.ExpectQuery("INSERT INTO orders").WillReturnRows(
 		sqlmock.NewRows([]string{"id"}).AddRow(int64(10)),
@@ -592,7 +627,7 @@ func TestCreateOrder_LimitOrder(t *testing.T) {
 }
 
 func TestCreateOrder_StopOrder(t *testing.T) {
-	srv, dbMock, _, secMock := newOrderServerWithSecDB(t)
+	srv, dbMock, _, secMock, accMock := newOrderServerWithSecDB(t)
 	srv.SecuritiesClient = &mockSecClient{
 		getListingById: func(ctx context.Context, in *pb_sec.GetListingByIdRequest, opts ...grpc.CallOption) (*pb_sec.GetListingByIdResponse, error) {
 			return &pb_sec.GetListingByIdResponse{
@@ -600,6 +635,9 @@ func TestCreateOrder_StopOrder(t *testing.T) {
 			}, nil
 		},
 	}
+	accMock.ExpectQuery("SELECT available_balance FROM accounts").WillReturnRows(
+		sqlmock.NewRows([]string{"available_balance"}).AddRow(float64(999999)),
+	)
 	secMock.ExpectQuery("SELECT mic_code FROM stock_exchanges").WillReturnError(sql.ErrNoRows)
 	dbMock.ExpectQuery("INSERT INTO orders").WillReturnRows(
 		sqlmock.NewRows([]string{"id"}).AddRow(int64(11)),
@@ -614,11 +652,18 @@ func TestCreateOrder_StopOrder(t *testing.T) {
 }
 
 func TestCreateOrder_StopLimitOrder(t *testing.T) {
-	srv, dbMock, _, secMock := newOrderServerWithSecDB(t)
+	srv, dbMock, _, secMock, _ := newOrderServerWithSecDB(t)
 	srv.SecuritiesClient = &mockSecClient{
 		getListingById: func(ctx context.Context, in *pb_sec.GetListingByIdRequest, opts ...grpc.CallOption) (*pb_sec.GetListingByIdResponse, error) {
 			return &pb_sec.GetListingByIdResponse{
 				Summary: &pb_sec.ListingSummary{Ask: 150.0, Bid: 148.0, ExchangeAcronym: "NYSE"},
+			}, nil
+		},
+	}
+	srv.PortfolioClient = &mockPortfolioClient{
+		getPortfolio: func(ctx context.Context, in *pb_portfolio.GetPortfolioRequest, opts ...grpc.CallOption) (*pb_portfolio.GetPortfolioResponse, error) {
+			return &pb_portfolio.GetPortfolioResponse{
+				Entries: []*pb_portfolio.PortfolioEntry{{ListingId: 5, Amount: 100}},
 			}, nil
 		},
 	}
@@ -635,10 +680,62 @@ func TestCreateOrder_StopLimitOrder(t *testing.T) {
 	assert.Equal(t, "STOP_LIMIT", resp.OrderType)
 }
 
+func TestCreateOrder_InsufficientHoldings(t *testing.T) {
+	srv, _, _, _, _ := newOrderServerWithSecDB(t)
+	srv.SecuritiesClient = &mockSecClient{
+		getListingById: func(ctx context.Context, in *pb_sec.GetListingByIdRequest, opts ...grpc.CallOption) (*pb_sec.GetListingByIdResponse, error) {
+			return &pb_sec.GetListingByIdResponse{
+				Summary: &pb_sec.ListingSummary{Ask: 150.0, Bid: 148.0, ExchangeAcronym: "NYSE"},
+			}, nil
+		},
+	}
+	srv.PortfolioClient = &mockPortfolioClient{
+		getPortfolio: func(ctx context.Context, in *pb_portfolio.GetPortfolioRequest, opts ...grpc.CallOption) (*pb_portfolio.GetPortfolioResponse, error) {
+			// Asset 5 not held at all
+			return &pb_portfolio.GetPortfolioResponse{Entries: nil}, nil
+		},
+	}
+
+	_, err := srv.CreateOrder(context.Background(), &pb.CreateOrderRequest{
+		UserId: 1, UserType: "CLIENT", AssetId: 5, Quantity: 10, AccountId: 42, Direction: "SELL",
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
+}
+
+func TestCreateOrder_Happy_Client_Sell(t *testing.T) {
+	srv, dbMock, _, secMock, _ := newOrderServerWithSecDB(t)
+	srv.SecuritiesClient = &mockSecClient{
+		getListingById: func(ctx context.Context, in *pb_sec.GetListingByIdRequest, opts ...grpc.CallOption) (*pb_sec.GetListingByIdResponse, error) {
+			return &pb_sec.GetListingByIdResponse{
+				Summary: &pb_sec.ListingSummary{Ask: 150.0, Bid: 148.0, ExchangeAcronym: "NYSE"},
+			}, nil
+		},
+	}
+	srv.PortfolioClient = &mockPortfolioClient{
+		getPortfolio: func(ctx context.Context, in *pb_portfolio.GetPortfolioRequest, opts ...grpc.CallOption) (*pb_portfolio.GetPortfolioResponse, error) {
+			return &pb_portfolio.GetPortfolioResponse{
+				Entries: []*pb_portfolio.PortfolioEntry{{ListingId: 5, Amount: 50}},
+			}, nil
+		},
+	}
+	secMock.ExpectQuery("SELECT mic_code FROM stock_exchanges").WillReturnError(sql.ErrNoRows)
+	dbMock.ExpectQuery("INSERT INTO orders").WillReturnRows(
+		sqlmock.NewRows([]string{"id"}).AddRow(int64(16)),
+	)
+
+	resp, err := srv.CreateOrder(context.Background(), &pb.CreateOrderRequest{
+		UserId: 1, UserType: "CLIENT", AssetId: 5, Quantity: 10, AccountId: 42, Direction: "SELL",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(16), resp.OrderId)
+	assert.Equal(t, "APPROVED", resp.Status)
+}
+
 // checkAfterHours coverage: MIC found but working hours call fails / no regular segment / exchange error
 
 func TestCreateOrder_AfterHours_WorkingHoursError(t *testing.T) {
-	srv, dbMock, _, secMock := newOrderServerWithSecDB(t)
+	srv, dbMock, _, secMock, accMock := newOrderServerWithSecDB(t)
 	srv.SecuritiesClient = &mockSecClient{
 		getListingById: func(ctx context.Context, in *pb_sec.GetListingByIdRequest, opts ...grpc.CallOption) (*pb_sec.GetListingByIdResponse, error) {
 			return &pb_sec.GetListingByIdResponse{
@@ -649,6 +746,10 @@ func TestCreateOrder_AfterHours_WorkingHoursError(t *testing.T) {
 			return nil, fmt.Errorf("working hours unavailable")
 		},
 	}
+	// CLIENT BUY → balance check passes
+	accMock.ExpectQuery("SELECT available_balance FROM accounts").WillReturnRows(
+		sqlmock.NewRows([]string{"available_balance"}).AddRow(float64(999999)),
+	)
 	// MIC lookup succeeds
 	secMock.ExpectQuery("SELECT mic_code FROM stock_exchanges").WillReturnRows(
 		sqlmock.NewRows([]string{"mic_code"}).AddRow("XNYS"),
@@ -665,7 +766,7 @@ func TestCreateOrder_AfterHours_WorkingHoursError(t *testing.T) {
 }
 
 func TestCreateOrder_AfterHours_NoRegularSegment(t *testing.T) {
-	srv, dbMock, _, secMock := newOrderServerWithSecDB(t)
+	srv, dbMock, _, secMock, accMock := newOrderServerWithSecDB(t)
 	srv.SecuritiesClient = &mockSecClient{
 		getListingById: func(ctx context.Context, in *pb_sec.GetListingByIdRequest, opts ...grpc.CallOption) (*pb_sec.GetListingByIdResponse, error) {
 			return &pb_sec.GetListingByIdResponse{
@@ -680,6 +781,9 @@ func TestCreateOrder_AfterHours_NoRegularSegment(t *testing.T) {
 			}, nil
 		},
 	}
+	accMock.ExpectQuery("SELECT available_balance FROM accounts").WillReturnRows(
+		sqlmock.NewRows([]string{"available_balance"}).AddRow(float64(999999)),
+	)
 	secMock.ExpectQuery("SELECT mic_code FROM stock_exchanges").WillReturnRows(
 		sqlmock.NewRows([]string{"mic_code"}).AddRow("XNYS"),
 	)
@@ -695,7 +799,7 @@ func TestCreateOrder_AfterHours_NoRegularSegment(t *testing.T) {
 }
 
 func TestCreateOrder_AfterHours_ExchangeByMICError(t *testing.T) {
-	srv, dbMock, _, secMock := newOrderServerWithSecDB(t)
+	srv, dbMock, _, secMock, accMock := newOrderServerWithSecDB(t)
 	srv.SecuritiesClient = &mockSecClient{
 		getListingById: func(ctx context.Context, in *pb_sec.GetListingByIdRequest, opts ...grpc.CallOption) (*pb_sec.GetListingByIdResponse, error) {
 			return &pb_sec.GetListingByIdResponse{
@@ -713,6 +817,9 @@ func TestCreateOrder_AfterHours_ExchangeByMICError(t *testing.T) {
 			return nil, fmt.Errorf("exchange lookup failed")
 		},
 	}
+	accMock.ExpectQuery("SELECT available_balance FROM accounts").WillReturnRows(
+		sqlmock.NewRows([]string{"available_balance"}).AddRow(float64(999999)),
+	)
 	secMock.ExpectQuery("SELECT mic_code FROM stock_exchanges").WillReturnRows(
 		sqlmock.NewRows([]string{"mic_code"}).AddRow("XNYS"),
 	)

--- a/services/order-service/handlers/grpc_server_test.go
+++ b/services/order-service/handlers/grpc_server_test.go
@@ -73,9 +73,9 @@ func addOrderRow(rows *sqlmock.Rows, id, userID int64, userType string, assetID 
 
 // mockSecClient is a configurable mock for pb_sec.SecuritiesServiceClient.
 type mockSecClient struct {
-	getListingById    func(ctx context.Context, in *pb_sec.GetListingByIdRequest, opts ...grpc.CallOption) (*pb_sec.GetListingByIdResponse, error)
-	getWorkingHours   func(ctx context.Context, in *pb_sec.GetWorkingHoursRequest, opts ...grpc.CallOption) (*pb_sec.GetWorkingHoursResponse, error)
-	getExchangeByMIC  func(ctx context.Context, in *pb_sec.GetStockExchangeByMICRequest, opts ...grpc.CallOption) (*pb_sec.GetStockExchangeByMICResponse, error)
+	getListingById   func(ctx context.Context, in *pb_sec.GetListingByIdRequest, opts ...grpc.CallOption) (*pb_sec.GetListingByIdResponse, error)
+	getWorkingHours  func(ctx context.Context, in *pb_sec.GetWorkingHoursRequest, opts ...grpc.CallOption) (*pb_sec.GetWorkingHoursResponse, error)
+	getExchangeByMIC func(ctx context.Context, in *pb_sec.GetStockExchangeByMICRequest, opts ...grpc.CallOption) (*pb_sec.GetStockExchangeByMICResponse, error)
 }
 
 func (m *mockSecClient) Ping(ctx context.Context, in *pb_sec.PingRequest, opts ...grpc.CallOption) (*pb_sec.PingResponse, error) {

--- a/services/order-service/main.go
+++ b/services/order-service/main.go
@@ -94,6 +94,7 @@ func main() {
 		SecuritiesClient: securitiesClient,
 		LoanClient:       loanClient,
 		EmployeeClient:   employeeClient,
+		PortfolioClient:  portfolioClient,
 	}
 	pb.RegisterOrderServiceServer(srv, orderServer)
 


### PR DESCRIPTION
## Summary

- Agent `used_limit` is now only consumed by BUY orders — SELL orders bypass the limit check entirely (the `need_approval` flag still applies to both directions)
- Added holdings validation on SELL orders: `CreateOrder` now rejects a SELL if the user holds fewer securities than requested, mirroring the existing CLIENT BUY balance check
- `PortfolioClient` wired into `OrderServer` to support the holdings lookup
- Fixed a pre-existing nil `AccountDB` panic in handler tests; all CLIENT BUY test cases now set up the account balance mock

## Test plan

- [ ] `go test ./...` in `services/order-service/` passes (all packages green)
- [ ] Place a BUY order as an agent → `used_limit` increases
- [ ] Place a SELL order as an agent → `used_limit` unchanged
- [ ] Agent at their daily limit can still place SELL orders (unless `need_approval` flag is set)
- [ ] Place a SELL order for an asset not in portfolio → rejected with `FailedPrecondition`
- [ ] Place a SELL order for an asset held in sufficient quantity → accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)