### PR TITLE
fix(portfolio): include user_type in unique constraint and ON CONFLICT clause

### DIFF
--- a/services/portfolio-service/db/schema.sql
+++ b/services/portfolio-service/db/schema.sql
@@ -9,5 +9,5 @@ CREATE TABLE portfolio_entry (
     is_public     BOOLEAN       NOT NULL DEFAULT FALSE,
     public_amount INT           NOT NULL DEFAULT 0,
     account_id    BIGINT        NOT NULL,
-    UNIQUE(user_id, listing_id)
+    UNIQUE(user_id, user_type, listing_id)
 );

--- a/services/portfolio-service/repository/portfolio_repo.go
+++ b/services/portfolio-service/repository/portfolio_repo.go
@@ -15,7 +15,7 @@ func UpsertHolding(ctx context.Context, db *sql.DB, userID int64, userType strin
 		_, err := db.ExecContext(ctx, `
 			INSERT INTO portfolio_entry (user_id, user_type, listing_id, amount, buy_price, account_id, last_modified)
 			VALUES ($1, $2, $3, $4, $5, $6, NOW())
-			ON CONFLICT (user_id, listing_id) DO UPDATE SET
+			ON CONFLICT (user_id, user_type, listing_id) DO UPDATE SET
 				buy_price     = (portfolio_entry.amount * portfolio_entry.buy_price + $4 * $5) / (portfolio_entry.amount + $4),
 				amount        = portfolio_entry.amount + $4,
 				last_modified = NOW()`,


### PR DESCRIPTION
## Summary

- The `UNIQUE(user_id, listing_id)` constraint on `portfolio_entry` was missing `user_type`, causing CLIENT and EMPLOYEE holdings for the same `user_id` + `listing_id` to collide
- When the conflict fired, the `ON CONFLICT DO UPDATE` silently overwrote the wrong user type's row
- `GetHoldings` filters by `user_type`, so the affected user's portfolio appeared empty
- Fixed by changing the constraint to `UNIQUE(user_id, user_type, listing_id)` and updating the `ON CONFLICT` clause to match

## Test plan

- [ ] Reset the portfolio DB to apply the schema change
- [ ] Client places a BUY order → holding appears in client portfolio page
- [ ] Employee/agent with the same numeric ID holding the same asset is unaffected
- [ ] SELL order correctly decrements the right user type's holding

🤖 Generated with [Claude Code](https://claude.com/claude-code)