### PR TITLE
feat(order-service): wire ExchangeServiceClient for lazy rate seeding

### DIFF
--- a/services/order-service/execution/scheduler.go
+++ b/services/order-service/execution/scheduler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/RAF-SI-2025/EXBanka-4-Backend/services/order-service/models"
 	"github.com/RAF-SI-2025/EXBanka-4-Backend/services/order-service/repository"
 	pb_emp "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/employee"
+	pb_exchange "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/exchange"
 	pb_loan "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/loan"
 	pb_portfolio "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/portfolio"
 	pb_sec "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/securities"
@@ -29,6 +30,7 @@ type Scheduler struct {
 	LoanClient       pb_loan.LoanServiceClient
 	EmployeeClient   pb_emp.EmployeeServiceClient
 	PortfolioClient  pb_portfolio.PortfolioServiceClient
+	ExchangeClient   pb_exchange.ExchangeServiceClient
 
 	inProgress sync.Map // map[int64]bool — orders currently being executed
 }
@@ -295,6 +297,13 @@ func (s *Scheduler) listingCurrency(ctx context.Context, listingID int64) (strin
 // commission; EMPLOYEE (agent) orders do not.
 func (s *Scheduler) settleAccountAndCommission(ctx context.Context, order models.Order, totalPrice, commission float64, currencyCode string) error {
 	const exchangeCommRate = 0.005
+
+	// 0. Ensure today's exchange rates are seeded (lazy population via exchange-service).
+	if s.ExchangeClient != nil {
+		if _, err := s.ExchangeClient.GetExchangeRates(ctx, &pb_exchange.GetExchangeRatesRequest{}); err != nil {
+			log.Printf("order-scheduler: ensureTodayRates warning: %v", err)
+		}
+	}
 
 	// 1. Look up account currency.
 	var accountCurrencyID int64

--- a/services/order-service/main.go
+++ b/services/order-service/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/RAF-SI-2025/EXBanka-4-Backend/services/order-service/execution"
 	"github.com/RAF-SI-2025/EXBanka-4-Backend/services/order-service/handlers"
 	pb_emp "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/employee"
+	pb_exchange "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/exchange"
 	pb_loan "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/loan"
 	pb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/order"
 	pb_portfolio "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/portfolio"
@@ -68,6 +69,12 @@ func main() {
 	}
 	defer func() { _ = empConn.Close() }()
 
+	exchangeConn, err := grpc.NewClient(os.Getenv("EXCHANGE_SERVICE_ADDR"), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		log.Fatalf("failed to connect to exchange-service: %v", err)
+	}
+	defer func() { _ = exchangeConn.Close() }()
+
 	portfolioConn, err := grpc.NewClient(os.Getenv("PORTFOLIO_SERVICE_ADDR"), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		log.Fatalf("failed to connect to portfolio-service: %v", err)
@@ -77,6 +84,7 @@ func main() {
 	securitiesClient := pb_sec.NewSecuritiesServiceClient(secConn)
 	loanClient := pb_loan.NewLoanServiceClient(loanConn)
 	employeeClient := pb_emp.NewEmployeeServiceClient(empConn)
+	exchangeClient := pb_exchange.NewExchangeServiceClient(exchangeConn)
 	portfolioClient := pb_portfolio.NewPortfolioServiceClient(portfolioConn)
 
 	lis, err := net.Listen("tcp", grpcPort)
@@ -107,6 +115,7 @@ func main() {
 		LoanClient:       loanClient,
 		EmployeeClient:   employeeClient,
 		PortfolioClient:  portfolioClient,
+		ExchangeClient:   exchangeClient,
 	}
 	scheduler.Start()
 


### PR DESCRIPTION
Connect order-service to exchange-service via gRPC and call GetExchangeRates before account settlement to ensure today's exchange rates are populated.