### PR TITLE
feat: shared employee portfolio and fix supervisor approval

### DIFF
--- a/services/employee-service/db/schema.sql
+++ b/services/employee-service/db/schema.sql
@@ -68,10 +68,9 @@ CREATE TABLE IF NOT EXISTS actuary_info (
     need_approval BOOLEAN NOT NULL DEFAULT false
 );
 
--- Seed actuary_info for all employees that already have AGENT or SUPERVISOR permissions.
--- Without this, GetActuaries INNER JOIN returns empty even though employees exist.
+-- Seed actuary_info for agents only. Supervisors are identified by absence of a row here.
 INSERT INTO actuary_info (employee_id, limit_amount, used_limit, need_approval)
 SELECT id, 100000, 0, false
 FROM employees
-WHERE 'AGENT' = ANY(permissions) OR 'SUPERVISOR' = ANY(permissions)
+WHERE 'AGENT' = ANY(permissions)
 ON CONFLICT (employee_id) DO NOTHING;

--- a/services/portfolio-service/repository/portfolio_repo.go
+++ b/services/portfolio-service/repository/portfolio_repo.go
@@ -7,10 +7,19 @@ import (
 	"github.com/RAF-SI-2025/EXBanka-4-Backend/services/portfolio-service/models"
 )
 
+// sharedUserID returns 0 for EMPLOYEE-type users so all actuaries share one portfolio.
+func sharedUserID(userID int64, userType string) int64 {
+	if userType == "EMPLOYEE" {
+		return 0
+	}
+	return userID
+}
+
 // UpsertHolding updates portfolio holdings on each order fill.
 // BUY: creates or updates entry with weighted average buy price.
 // SELL: decrements amount; deletes entry if amount reaches zero.
 func UpsertHolding(ctx context.Context, db *sql.DB, userID int64, userType string, listingID, accountID int64, qty int32, price float64, direction string) error {
+	uid := sharedUserID(userID, userType)
 	if direction == "BUY" {
 		_, err := db.ExecContext(ctx, `
 			INSERT INTO portfolio_entry (user_id, user_type, listing_id, amount, buy_price, account_id, last_modified)
@@ -19,7 +28,7 @@ func UpsertHolding(ctx context.Context, db *sql.DB, userID int64, userType strin
 				buy_price     = (portfolio_entry.amount * portfolio_entry.buy_price + $4 * $5) / (portfolio_entry.amount + $4),
 				amount        = portfolio_entry.amount + $4,
 				last_modified = NOW()`,
-			userID, userType, listingID, qty, price, accountID,
+			uid, userType, listingID, qty, price, accountID,
 		)
 		return err
 	}
@@ -29,7 +38,7 @@ func UpsertHolding(ctx context.Context, db *sql.DB, userID int64, userType strin
 		UPDATE portfolio_entry
 		SET amount = amount - $1, last_modified = NOW()
 		WHERE user_id = $2 AND user_type = $3 AND listing_id = $4`,
-		qty, userID, userType, listingID,
+		qty, uid, userType, listingID,
 	)
 	if err != nil {
 		return err
@@ -39,7 +48,7 @@ func UpsertHolding(ctx context.Context, db *sql.DB, userID int64, userType strin
 	_, err = db.ExecContext(ctx, `
 		DELETE FROM portfolio_entry
 		WHERE user_id = $1 AND user_type = $2 AND listing_id = $3 AND amount <= 0`,
-		userID, userType, listingID,
+		uid, userType, listingID,
 	)
 	return err
 }
@@ -51,7 +60,7 @@ func GetHoldings(ctx context.Context, db *sql.DB, userID int64, userType string)
 		FROM portfolio_entry
 		WHERE user_id = $1 AND user_type = $2 AND amount > 0
 		ORDER BY last_modified DESC`,
-		userID, userType,
+		sharedUserID(userID, userType), userType,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
- portfolio-service: all EMPLOYEE-type users (agents + supervisors) now share one portfolio by mapping their user_id to 0 in the repository layer; client portfolios are unaffected
- employee-service: seed script no longer inserts supervisors into actuary_info; supervisors are identified by the absence of a row there, so their orders auto-approve without a limit check

## To apply after pulling

Rebuild and restart the portfolio-service:
  docker compose up -d --build portfolio-service

The employee-service schema change only affects fresh DB initializations. If you need to fix an existing DB (e.g. a supervisor stuck in actuary_info):
  docker exec -i <employee-db-container> psql -U employee_user -d employee_db     -c "DELETE FROM actuary_info WHERE employee_id IN (SELECT id FROM employees WHERE 'SUPERVISOR' = ANY(permissions));"