### PR TITLE
feat: implement capital gains tax (#157) and tax REST API (#158)

### DIFF
--- a/services/api-gateway/handlers/orders_test.go
+++ b/services/api-gateway/handlers/orders_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"testing"
 
-	pb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/order"
 	pb_emp "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/employee"
+	pb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/order"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -17,13 +17,13 @@ import (
 // ---- stub client ----
 
 type stubOrderClient struct {
-	createOrderFn        func(context.Context, *pb.CreateOrderRequest, ...grpc.CallOption) (*pb.CreateOrderResponse, error)
-	listOrdersFn         func(context.Context, *pb.ListOrdersRequest, ...grpc.CallOption) (*pb.ListOrdersResponse, error)
-	getOrderByIdFn       func(context.Context, *pb.GetOrderByIdRequest, ...grpc.CallOption) (*pb.GetOrderByIdResponse, error)
-	approveOrderFn       func(context.Context, *pb.ApproveOrderRequest, ...grpc.CallOption) (*pb.ApproveOrderResponse, error)
-	declineOrderFn       func(context.Context, *pb.DeclineOrderRequest, ...grpc.CallOption) (*pb.DeclineOrderResponse, error)
-	cancelOrderFn        func(context.Context, *pb.CancelOrderRequest, ...grpc.CallOption) (*pb.CancelOrderResponse, error)
-	cancelPortionsFn     func(context.Context, *pb.CancelOrderPortionsRequest, ...grpc.CallOption) (*pb.CancelOrderPortionsResponse, error)
+	createOrderFn    func(context.Context, *pb.CreateOrderRequest, ...grpc.CallOption) (*pb.CreateOrderResponse, error)
+	listOrdersFn     func(context.Context, *pb.ListOrdersRequest, ...grpc.CallOption) (*pb.ListOrdersResponse, error)
+	getOrderByIdFn   func(context.Context, *pb.GetOrderByIdRequest, ...grpc.CallOption) (*pb.GetOrderByIdResponse, error)
+	approveOrderFn   func(context.Context, *pb.ApproveOrderRequest, ...grpc.CallOption) (*pb.ApproveOrderResponse, error)
+	declineOrderFn   func(context.Context, *pb.DeclineOrderRequest, ...grpc.CallOption) (*pb.DeclineOrderResponse, error)
+	cancelOrderFn    func(context.Context, *pb.CancelOrderRequest, ...grpc.CallOption) (*pb.CancelOrderResponse, error)
+	cancelPortionsFn func(context.Context, *pb.CancelOrderPortionsRequest, ...grpc.CallOption) (*pb.CancelOrderPortionsResponse, error)
 }
 
 func (s *stubOrderClient) Ping(ctx context.Context, in *pb.PingRequest, opts ...grpc.CallOption) (*pb.PingResponse, error) {

--- a/services/api-gateway/handlers/portfolio_test.go
+++ b/services/api-gateway/handlers/portfolio_test.go
@@ -14,12 +14,12 @@ import (
 // ---- stub client ----
 
 type stubPortfolioClient struct {
-	getPortfolioFn       func(context.Context, *pb.GetPortfolioRequest, ...grpc.CallOption) (*pb.GetPortfolioResponse, error)
-	getProfitFn          func(context.Context, *pb.GetProfitRequest, ...grpc.CallOption) (*pb.GetProfitResponse, error)
-	getMyTaxFn           func(context.Context, *pb.GetMyTaxRequest, ...grpc.CallOption) (*pb.GetMyTaxResponse, error)
-	getTaxListFn         func(context.Context, *pb.GetTaxListRequest, ...grpc.CallOption) (*pb.GetTaxListResponse, error)
-	collectTaxFn         func(context.Context, *pb.CollectTaxRequest, ...grpc.CallOption) (*pb.CollectTaxResponse, error)
-	collectTaxForUserFn  func(context.Context, *pb.CollectTaxForUserRequest, ...grpc.CallOption) (*pb.CollectTaxForUserResponse, error)
+	getPortfolioFn      func(context.Context, *pb.GetPortfolioRequest, ...grpc.CallOption) (*pb.GetPortfolioResponse, error)
+	getProfitFn         func(context.Context, *pb.GetProfitRequest, ...grpc.CallOption) (*pb.GetProfitResponse, error)
+	getMyTaxFn          func(context.Context, *pb.GetMyTaxRequest, ...grpc.CallOption) (*pb.GetMyTaxResponse, error)
+	getTaxListFn        func(context.Context, *pb.GetTaxListRequest, ...grpc.CallOption) (*pb.GetTaxListResponse, error)
+	collectTaxFn        func(context.Context, *pb.CollectTaxRequest, ...grpc.CallOption) (*pb.CollectTaxResponse, error)
+	collectTaxForUserFn func(context.Context, *pb.CollectTaxForUserRequest, ...grpc.CallOption) (*pb.CollectTaxForUserResponse, error)
 }
 
 func (s *stubPortfolioClient) UpdateHolding(ctx context.Context, in *pb.UpdateHoldingRequest, opts ...grpc.CallOption) (*pb.UpdateHoldingResponse, error) {

--- a/services/api-gateway/handlers/portfolio_test.go
+++ b/services/api-gateway/handlers/portfolio_test.go
@@ -14,8 +14,12 @@ import (
 // ---- stub client ----
 
 type stubPortfolioClient struct {
-	getPortfolioFn    func(context.Context, *pb.GetPortfolioRequest, ...grpc.CallOption) (*pb.GetPortfolioResponse, error)
-	getProfitFn       func(context.Context, *pb.GetProfitRequest, ...grpc.CallOption) (*pb.GetProfitResponse, error)
+	getPortfolioFn       func(context.Context, *pb.GetPortfolioRequest, ...grpc.CallOption) (*pb.GetPortfolioResponse, error)
+	getProfitFn          func(context.Context, *pb.GetProfitRequest, ...grpc.CallOption) (*pb.GetProfitResponse, error)
+	getMyTaxFn           func(context.Context, *pb.GetMyTaxRequest, ...grpc.CallOption) (*pb.GetMyTaxResponse, error)
+	getTaxListFn         func(context.Context, *pb.GetTaxListRequest, ...grpc.CallOption) (*pb.GetTaxListResponse, error)
+	collectTaxFn         func(context.Context, *pb.CollectTaxRequest, ...grpc.CallOption) (*pb.CollectTaxResponse, error)
+	collectTaxForUserFn  func(context.Context, *pb.CollectTaxForUserRequest, ...grpc.CallOption) (*pb.CollectTaxForUserResponse, error)
 }
 
 func (s *stubPortfolioClient) UpdateHolding(ctx context.Context, in *pb.UpdateHoldingRequest, opts ...grpc.CallOption) (*pb.UpdateHoldingResponse, error) {
@@ -34,6 +38,30 @@ func (s *stubPortfolioClient) GetProfit(ctx context.Context, in *pb.GetProfitReq
 	return nil, fmt.Errorf("not implemented")
 }
 func (s *stubPortfolioClient) SetPublicAmount(ctx context.Context, in *pb.SetPublicAmountRequest, opts ...grpc.CallOption) (*pb.SetPublicAmountResponse, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+func (s *stubPortfolioClient) GetMyTax(ctx context.Context, in *pb.GetMyTaxRequest, opts ...grpc.CallOption) (*pb.GetMyTaxResponse, error) {
+	if s.getMyTaxFn != nil {
+		return s.getMyTaxFn(ctx, in, opts...)
+	}
+	return nil, fmt.Errorf("not implemented")
+}
+func (s *stubPortfolioClient) GetTaxList(ctx context.Context, in *pb.GetTaxListRequest, opts ...grpc.CallOption) (*pb.GetTaxListResponse, error) {
+	if s.getTaxListFn != nil {
+		return s.getTaxListFn(ctx, in, opts...)
+	}
+	return nil, fmt.Errorf("not implemented")
+}
+func (s *stubPortfolioClient) CollectTax(ctx context.Context, in *pb.CollectTaxRequest, opts ...grpc.CallOption) (*pb.CollectTaxResponse, error) {
+	if s.collectTaxFn != nil {
+		return s.collectTaxFn(ctx, in, opts...)
+	}
+	return nil, fmt.Errorf("not implemented")
+}
+func (s *stubPortfolioClient) CollectTaxForUser(ctx context.Context, in *pb.CollectTaxForUserRequest, opts ...grpc.CallOption) (*pb.CollectTaxForUserResponse, error) {
+	if s.collectTaxForUserFn != nil {
+		return s.collectTaxForUserFn(ctx, in, opts...)
+	}
 	return nil, fmt.Errorf("not implemented")
 }
 

--- a/services/api-gateway/handlers/tax.go
+++ b/services/api-gateway/handlers/tax.go
@@ -1,0 +1,140 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-4-Backend/services/api-gateway/middleware"
+	pb_client "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/client"
+	pb_emp "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/employee"
+	pb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/portfolio"
+	"github.com/gin-gonic/gin"
+	"google.golang.org/grpc/metadata"
+)
+
+type taxListEntry struct {
+	UserID   int64   `json:"userId"`
+	FullName string  `json:"fullName"`
+	Type     string  `json:"type"`
+	DebtRSD  float64 `json:"debtRsd"`
+}
+
+// GetTaxList handles GET /tax — supervisor only.
+// Returns all users with unpaid tax, enriched with full names.
+func GetTaxList(portfolioClient pb.PortfolioServiceClient, employeeClient pb_emp.EmployeeServiceClient, clientClient pb_client.ClientServiceClient) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 10*time.Second)
+		defer cancel()
+
+		resp, err := portfolioClient.GetTaxList(ctx, &pb.GetTaxListRequest{
+			UserTypeFilter: c.Query("type"),
+			NameFilter:     c.Query("name"),
+		})
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+
+		entries := make([]taxListEntry, 0, len(resp.Entries))
+		for _, e := range resp.Entries {
+			fullName := resolveName(c.Request.Context(), e.UserId, e.Type, employeeClient, clientClient)
+			entries = append(entries, taxListEntry{
+				UserID:   e.UserId,
+				FullName: fullName,
+				Type:     e.Type,
+				DebtRSD:  e.DebtRsd,
+			})
+		}
+
+		c.JSON(http.StatusOK, entries)
+	}
+}
+
+// GetMyTax handles GET /tax/my (employee) and GET /client/tax/my (client).
+func GetMyTax(portfolioClient pb.PortfolioServiceClient, userType string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		userID, err := middleware.GetUserIDFromToken(c)
+		if err != nil {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "could not extract identity from token"})
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 10*time.Second)
+		defer cancel()
+		ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs("user-type", userType))
+
+		resp, err := portfolioClient.GetMyTax(ctx, &pb.GetMyTaxRequest{UserId: userID, UserType: userType})
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{
+			"paidThisYear":    resp.PaidThisYear,
+			"unpaidThisMonth": resp.UnpaidThisMonth,
+		})
+	}
+}
+
+// CollectTax handles POST /tax/collect — supervisor only.
+// Triggers tax collection for all users with unpaid tax.
+func CollectTax(portfolioClient pb.PortfolioServiceClient) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 30*time.Second)
+		defer cancel()
+
+		if _, err := portfolioClient.CollectTax(ctx, &pb.CollectTaxRequest{}); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{"message": "tax collection completed"})
+	}
+}
+
+// CollectTaxForUser handles POST /tax/collect/:userId — supervisor only.
+func CollectTaxForUser(portfolioClient pb.PortfolioServiceClient) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		userID, err := strconv.ParseInt(c.Param("userId"), 10, 64)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid userId"})
+			return
+		}
+
+		userType := c.DefaultQuery("userType", "CLIENT")
+
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 30*time.Second)
+		defer cancel()
+
+		if _, err := portfolioClient.CollectTaxForUser(ctx, &pb.CollectTaxForUserRequest{
+			UserId:   userID,
+			UserType: userType,
+		}); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{"message": fmt.Sprintf("tax collection completed for user %d", userID)})
+	}
+}
+
+func resolveName(ctx context.Context, userID int64, userType string, empClient pb_emp.EmployeeServiceClient, cliClient pb_client.ClientServiceClient) string {
+	rCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	if userType == "EMPLOYEE" {
+		resp, err := empClient.GetEmployeeById(rCtx, &pb_emp.GetEmployeeByIdRequest{Id: userID})
+		if err == nil && resp.Employee != nil {
+			return fmt.Sprintf("%s %s", resp.Employee.FirstName, resp.Employee.LastName)
+		}
+	} else {
+		resp, err := cliClient.GetClientById(rCtx, &pb_client.GetClientByIdRequest{Id: userID})
+		if err == nil && resp.Client != nil {
+			return fmt.Sprintf("%s %s", resp.Client.FirstName, resp.Client.LastName)
+		}
+	}
+	return ""
+}

--- a/services/api-gateway/handlers/tax_test.go
+++ b/services/api-gateway/handlers/tax_test.go
@@ -1,0 +1,140 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	clientpb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/client"
+	pb_emp "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/employee"
+	pb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/portfolio"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+)
+
+// ── GetMyTax ──────────────────────────────────────────────────────────────────
+
+func TestGetMyTax_NoToken(t *testing.T) {
+	w := serveHandlerFull(GetMyTax(&stubPortfolioClient{}, "EMPLOYEE"), "GET", "/tax/my", "/tax/my", "", "")
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestGetMyTax_GrpcError(t *testing.T) {
+	client := &stubPortfolioClient{
+		getMyTaxFn: func(_ context.Context, _ *pb.GetMyTaxRequest, _ ...grpc.CallOption) (*pb.GetMyTaxResponse, error) {
+			return nil, fmt.Errorf("portfolio service down")
+		},
+	}
+	w := serveHandlerFull(GetMyTax(client, "EMPLOYEE"), "GET", "/tax/my", "/tax/my", "", makeClientToken())
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestGetMyTax_Happy(t *testing.T) {
+	client := &stubPortfolioClient{
+		getMyTaxFn: func(_ context.Context, _ *pb.GetMyTaxRequest, _ ...grpc.CallOption) (*pb.GetMyTaxResponse, error) {
+			return &pb.GetMyTaxResponse{PaidThisYear: 4500.0, UnpaidThisMonth: 2250.0}, nil
+		},
+	}
+	w := serveHandlerFull(GetMyTax(client, "EMPLOYEE"), "GET", "/tax/my", "/tax/my", "", makeClientToken())
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "paidThisYear")
+	assert.Contains(t, w.Body.String(), "unpaidThisMonth")
+}
+
+// ── GetTaxList ────────────────────────────────────────────────────────────────
+
+func TestGetTaxList_GrpcError(t *testing.T) {
+	portfolioClient := &stubPortfolioClient{
+		getTaxListFn: func(_ context.Context, _ *pb.GetTaxListRequest, _ ...grpc.CallOption) (*pb.GetTaxListResponse, error) {
+			return nil, fmt.Errorf("service down")
+		},
+	}
+	w := serveHandlerFull(
+		GetTaxList(portfolioClient, &stubEmpClient{getByIdFn: func(_ context.Context, _ *pb_emp.GetEmployeeByIdRequest, _ ...grpc.CallOption) (*pb_emp.GetEmployeeByIdResponse, error) {
+			return nil, fmt.Errorf("not found")
+		}}, &stubClientSvcClient{}),
+		"GET", "/tax", "/tax", "", makeClientToken(),
+	)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestGetTaxList_Happy_ClientEntry(t *testing.T) {
+	portfolioClient := &stubPortfolioClient{
+		getTaxListFn: func(_ context.Context, _ *pb.GetTaxListRequest, _ ...grpc.CallOption) (*pb.GetTaxListResponse, error) {
+			return &pb.GetTaxListResponse{
+				Entries: []*pb.TaxDebtEntry{
+					{UserId: 10, Type: "CLIENT", DebtRsd: 1500.0},
+				},
+			}, nil
+		},
+	}
+	empClient := &stubEmpClient{
+		getByIdFn: func(_ context.Context, _ *pb_emp.GetEmployeeByIdRequest, _ ...grpc.CallOption) (*pb_emp.GetEmployeeByIdResponse, error) {
+			return nil, fmt.Errorf("not found")
+		},
+	}
+	cliClient := &stubClientSvcClient{
+		getByIdFn: func(_ context.Context, _ *clientpb.GetClientByIdRequest, _ ...grpc.CallOption) (*clientpb.GetClientByIdResponse, error) {
+			return &clientpb.GetClientByIdResponse{
+				Client: &clientpb.Client{FirstName: "Ana", LastName: "Anić"},
+			}, nil
+		},
+	}
+	w := serveHandlerFull(GetTaxList(portfolioClient, empClient, cliClient), "GET", "/tax", "/tax", "", makeClientToken())
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "Ana Anić")
+	assert.Contains(t, w.Body.String(), "1500")
+}
+
+// ── CollectTax ────────────────────────────────────────────────────────────────
+
+func TestCollectTax_GrpcError(t *testing.T) {
+	client := &stubPortfolioClient{
+		collectTaxFn: func(_ context.Context, _ *pb.CollectTaxRequest, _ ...grpc.CallOption) (*pb.CollectTaxResponse, error) {
+			return nil, fmt.Errorf("collection failed")
+		},
+	}
+	w := serveHandlerFull(CollectTax(client), "POST", "/tax/collect", "/tax/collect", "", makeClientToken())
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestCollectTax_Happy(t *testing.T) {
+	client := &stubPortfolioClient{
+		collectTaxFn: func(_ context.Context, _ *pb.CollectTaxRequest, _ ...grpc.CallOption) (*pb.CollectTaxResponse, error) {
+			return &pb.CollectTaxResponse{}, nil
+		},
+	}
+	w := serveHandlerFull(CollectTax(client), "POST", "/tax/collect", "/tax/collect", "", makeClientToken())
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// ── CollectTaxForUser ─────────────────────────────────────────────────────────
+
+func TestCollectTaxForUser_BadID(t *testing.T) {
+	w := serveHandlerFull(CollectTaxForUser(&stubPortfolioClient{}), "POST", "/tax/collect/:userId", "/tax/collect/abc", "", makeClientToken())
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestCollectTaxForUser_GrpcError(t *testing.T) {
+	client := &stubPortfolioClient{
+		collectTaxForUserFn: func(_ context.Context, _ *pb.CollectTaxForUserRequest, _ ...grpc.CallOption) (*pb.CollectTaxForUserResponse, error) {
+			return nil, fmt.Errorf("user not found")
+		},
+	}
+	w := serveHandlerFull(CollectTaxForUser(client), "POST", "/tax/collect/:userId", "/tax/collect/5", "", makeClientToken())
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestCollectTaxForUser_Happy(t *testing.T) {
+	client := &stubPortfolioClient{
+		collectTaxForUserFn: func(_ context.Context, req *pb.CollectTaxForUserRequest, _ ...grpc.CallOption) (*pb.CollectTaxForUserResponse, error) {
+			if req.UserId != 5 {
+				return nil, fmt.Errorf("wrong user")
+			}
+			return &pb.CollectTaxForUserResponse{}, nil
+		},
+	}
+	w := serveHandlerFull(CollectTaxForUser(client), "POST", "/tax/collect/:userId", "/tax/collect/5", "", makeClientToken())
+	assert.Equal(t, http.StatusOK, w.Code)
+}

--- a/services/api-gateway/main.go
+++ b/services/api-gateway/main.go
@@ -212,6 +212,11 @@ func main() {
 	r.GET("/portfolio/profit", middleware.RequireRole("AGENT", "SUPERVISOR"), handlers.GetProfit(portfolioClient, "EMPLOYEE"))
 	r.GET("/client/portfolio", handlers.GetPortfolio(portfolioClient, "CLIENT"))
 	r.GET("/client/portfolio/profit", handlers.GetProfit(portfolioClient, "CLIENT"))
+	r.GET("/tax", middleware.RequireRole("SUPERVISOR"), handlers.GetTaxList(portfolioClient, employeeClient, clientClient))
+	r.GET("/tax/my", middleware.RequireRole("AGENT", "SUPERVISOR"), handlers.GetMyTax(portfolioClient, "EMPLOYEE"))
+	r.GET("/client/tax/my", handlers.GetMyTax(portfolioClient, "CLIENT"))
+	r.POST("/tax/collect", middleware.RequireRole("SUPERVISOR"), handlers.CollectTax(portfolioClient))
+	r.POST("/tax/collect/:userId", middleware.RequireRole("SUPERVISOR"), handlers.CollectTaxForUser(portfolioClient))
 	r.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 	if err := r.Run(":8083"); err != nil {
 		log.Fatalf("server error: %v", err)

--- a/services/order-service/execution/scheduler.go
+++ b/services/order-service/execution/scheduler.go
@@ -212,6 +212,7 @@ func (s *Scheduler) executeOrder(order models.Order) {
 				Price:     pricePerUnit,
 				Direction: order.Direction,
 				AccountId: order.AccountID,
+				AssetType: listing.Type,
 			})
 			if err != nil {
 				log.Printf("order-scheduler: portfolio update error for order %d: %v", order.ID, err)

--- a/services/order-service/handlers/grpc_server_test.go
+++ b/services/order-service/handlers/grpc_server_test.go
@@ -166,6 +166,18 @@ func (m *mockPortfolioClient) GetProfit(ctx context.Context, in *pb_portfolio.Ge
 func (m *mockPortfolioClient) SetPublicAmount(ctx context.Context, in *pb_portfolio.SetPublicAmountRequest, opts ...grpc.CallOption) (*pb_portfolio.SetPublicAmountResponse, error) {
 	return nil, fmt.Errorf("not mocked")
 }
+func (m *mockPortfolioClient) GetMyTax(ctx context.Context, in *pb_portfolio.GetMyTaxRequest, opts ...grpc.CallOption) (*pb_portfolio.GetMyTaxResponse, error) {
+	return nil, fmt.Errorf("not mocked")
+}
+func (m *mockPortfolioClient) GetTaxList(ctx context.Context, in *pb_portfolio.GetTaxListRequest, opts ...grpc.CallOption) (*pb_portfolio.GetTaxListResponse, error) {
+	return nil, fmt.Errorf("not mocked")
+}
+func (m *mockPortfolioClient) CollectTax(ctx context.Context, in *pb_portfolio.CollectTaxRequest, opts ...grpc.CallOption) (*pb_portfolio.CollectTaxResponse, error) {
+	return nil, fmt.Errorf("not mocked")
+}
+func (m *mockPortfolioClient) CollectTaxForUser(ctx context.Context, in *pb_portfolio.CollectTaxForUserRequest, opts ...grpc.CallOption) (*pb_portfolio.CollectTaxForUserResponse, error) {
+	return nil, fmt.Errorf("not mocked")
+}
 
 // ─────────────────────────────────────────────
 // Ping

--- a/services/portfolio-service/db/schema.sql
+++ b/services/portfolio-service/db/schema.sql
@@ -11,3 +11,14 @@ CREATE TABLE portfolio_entry (
     account_id    BIGINT        NOT NULL,
     UNIQUE(user_id, user_type, listing_id)
 );
+
+CREATE TABLE tax_record (
+    id         BIGSERIAL     PRIMARY KEY,
+    user_id    BIGINT        NOT NULL,
+    user_type  VARCHAR(10)   NOT NULL DEFAULT 'CLIENT',
+    amount_rsd NUMERIC(20,6) NOT NULL,
+    month      INT           NOT NULL,
+    year       INT           NOT NULL,
+    is_paid    BOOLEAN       NOT NULL DEFAULT FALSE,
+    paid_at    TIMESTAMP
+);

--- a/services/portfolio-service/handlers/grpc_server.go
+++ b/services/portfolio-service/handlers/grpc_server.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/RAF-SI-2025/EXBanka-4-Backend/services/portfolio-service/repository"
 	taxcalc "github.com/RAF-SI-2025/EXBanka-4-Backend/services/portfolio-service/tax"
-	pb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/portfolio"
 	pb_ex "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/exchange"
+	pb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/portfolio"
 	pb_sec "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/securities"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -42,7 +42,7 @@ func (s *PortfolioServer) UpdateHolding(ctx context.Context, req *pb.UpdateHoldi
 		return nil, status.Errorf(codes.Internal, "upsert holding: %v", err)
 	}
 
-	if req.Direction == "SELL" && buyPrice > 0 {
+	if req.Direction == "SELL" && req.AssetType == "STOCK" && buyPrice > 0 {
 		profit := (req.Price - buyPrice) * float64(req.Quantity)
 		if taxOwed := taxcalc.CalculateTax(profit); taxOwed > 0 {
 			now := time.Now()

--- a/services/portfolio-service/handlers/grpc_server.go
+++ b/services/portfolio-service/handlers/grpc_server.go
@@ -3,9 +3,12 @@ package handlers
 import (
 	"context"
 	"database/sql"
+	"time"
 
 	"github.com/RAF-SI-2025/EXBanka-4-Backend/services/portfolio-service/repository"
+	taxcalc "github.com/RAF-SI-2025/EXBanka-4-Backend/services/portfolio-service/tax"
 	pb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/portfolio"
+	pb_ex "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/exchange"
 	pb_sec "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/securities"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -21,7 +24,9 @@ type SecurityPriceFetcher interface {
 type PortfolioServer struct {
 	pb.UnimplementedPortfolioServiceServer
 	DB               *sql.DB
+	AccountDB        *sql.DB
 	SecuritiesClient SecurityPriceFetcher
+	ExchangeClient   pb_ex.ExchangeServiceClient
 }
 
 func (s *PortfolioServer) UpdateHolding(ctx context.Context, req *pb.UpdateHoldingRequest) (*pb.UpdateHoldingResponse, error) {
@@ -32,10 +37,19 @@ func (s *PortfolioServer) UpdateHolding(ctx context.Context, req *pb.UpdateHoldi
 		return nil, status.Error(codes.InvalidArgument, "direction must be BUY or SELL")
 	}
 
-	err := repository.UpsertHolding(ctx, s.DB, req.UserId, req.UserType, req.ListingId, req.AccountId, req.Quantity, req.Price, req.Direction)
+	buyPrice, err := repository.UpsertHolding(ctx, s.DB, req.UserId, req.UserType, req.ListingId, req.AccountId, req.Quantity, req.Price, req.Direction)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "upsert holding: %v", err)
 	}
+
+	if req.Direction == "SELL" && buyPrice > 0 {
+		profit := (req.Price - buyPrice) * float64(req.Quantity)
+		if taxOwed := taxcalc.CalculateTax(profit); taxOwed > 0 {
+			now := time.Now()
+			_ = repository.InsertTaxRecord(ctx, s.DB, req.UserId, req.UserType, taxOwed, int(now.Month()), now.Year())
+		}
+	}
+
 	return &pb.UpdateHoldingResponse{}, nil
 }
 
@@ -111,4 +125,51 @@ func (s *PortfolioServer) GetProfit(ctx context.Context, req *pb.GetProfitReques
 
 func (s *PortfolioServer) SetPublicAmount(_ context.Context, _ *pb.SetPublicAmountRequest) (*pb.SetPublicAmountResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "implemented in issue #147")
+}
+
+func (s *PortfolioServer) GetMyTax(ctx context.Context, req *pb.GetMyTaxRequest) (*pb.GetMyTaxResponse, error) {
+	userType := req.UserType
+	if userType == "" {
+		userType = userTypeFromCtx(ctx)
+	}
+	now := time.Now()
+	paid, unpaid, err := repository.GetMyTax(ctx, s.DB, req.UserId, userType, now.Year(), int(now.Month()))
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "get my tax: %v", err)
+	}
+	return &pb.GetMyTaxResponse{PaidThisYear: paid, UnpaidThisMonth: unpaid}, nil
+}
+
+func (s *PortfolioServer) GetTaxList(ctx context.Context, _ *pb.GetTaxListRequest) (*pb.GetTaxListResponse, error) {
+	debts, err := repository.GetTaxDebtList(ctx, s.DB)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "get tax list: %v", err)
+	}
+	entries := make([]*pb.TaxDebtEntry, 0, len(debts))
+	for _, d := range debts {
+		entries = append(entries, &pb.TaxDebtEntry{
+			UserId:  d.UserID,
+			Type:    d.UserType,
+			DebtRsd: d.DebtRSD,
+		})
+	}
+	return &pb.GetTaxListResponse{Entries: entries}, nil
+}
+
+func (s *PortfolioServer) CollectTax(ctx context.Context, _ *pb.CollectTaxRequest) (*pb.CollectTaxResponse, error) {
+	if err := taxcalc.CollectUnpaid(ctx, s.DB, s.AccountDB, s.ExchangeClient, 0, ""); err != nil {
+		return nil, status.Errorf(codes.Internal, "collect tax: %v", err)
+	}
+	return &pb.CollectTaxResponse{}, nil
+}
+
+func (s *PortfolioServer) CollectTaxForUser(ctx context.Context, req *pb.CollectTaxForUserRequest) (*pb.CollectTaxForUserResponse, error) {
+	userType := req.UserType
+	if userType == "" {
+		userType = userTypeFromCtx(ctx)
+	}
+	if err := taxcalc.CollectUnpaid(ctx, s.DB, s.AccountDB, s.ExchangeClient, req.UserId, userType); err != nil {
+		return nil, status.Errorf(codes.Internal, "collect tax for user: %v", err)
+	}
+	return &pb.CollectTaxForUserResponse{}, nil
 }

--- a/services/portfolio-service/handlers/grpc_server_test.go
+++ b/services/portfolio-service/handlers/grpc_server_test.go
@@ -6,10 +6,10 @@ import (
 	"time"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	pb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/portfolio"
 	pb_sec "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/securities"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 )
 
@@ -112,6 +112,7 @@ func TestUpdateHolding_Sell_WithTax(t *testing.T) {
 		Quantity:  2,
 		Price:     150.0,
 		Direction: "SELL",
+		AssetType: "STOCK",
 	})
 	require.NoError(t, err)
 	assert.NoError(t, mock.ExpectationsWereMet())
@@ -138,6 +139,34 @@ func TestUpdateHolding_Sell_Loss_NoTax(t *testing.T) {
 		Quantity:  5,
 		Price:     150.0,
 		Direction: "SELL",
+		AssetType: "STOCK",
+	})
+	require.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestUpdateHolding_Sell_Forex_NoTax(t *testing.T) {
+	// profitable sell but FOREX_PAIR — no tax record should be inserted
+	srv, mock := newServer(t)
+
+	mock.ExpectQuery(`SELECT buy_price FROM portfolio_entry`).
+		WithArgs(int64(1), "CLIENT", int64(10)).
+		WillReturnRows(sqlmock.NewRows([]string{"buy_price"}).AddRow(100.0))
+	mock.ExpectExec(`UPDATE portfolio_entry`).
+		WithArgs(int32(2), int64(1), "CLIENT", int64(10)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(`DELETE FROM portfolio_entry`).
+		WithArgs(int64(1), "CLIENT", int64(10)).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	_, err := srv.UpdateHolding(context.Background(), &pb.UpdateHoldingRequest{
+		UserId:    1,
+		UserType:  "CLIENT",
+		ListingId: 10,
+		Quantity:  2,
+		Price:     150.0,
+		Direction: "SELL",
+		AssetType: "FOREX_PAIR",
 	})
 	require.NoError(t, err)
 	assert.NoError(t, mock.ExpectationsWereMet())

--- a/services/portfolio-service/handlers/grpc_server_test.go
+++ b/services/portfolio-service/handlers/grpc_server_test.go
@@ -70,7 +70,6 @@ func TestUpdateHolding_Buy_NewEntry(t *testing.T) {
 func TestUpdateHolding_Buy_ExistingEntry_WeightedAvg(t *testing.T) {
 	srv, mock := newServer(t)
 
-	// ON CONFLICT DO UPDATE — same INSERT statement handles both cases
 	// sharedUserID returns 0 for EMPLOYEE so all actuaries share one portfolio.
 	mock.ExpectExec(`INSERT INTO portfolio_entry`).
 		WithArgs(int64(0), "EMPLOYEE", int64(20), int32(3), float64(200.0), int64(99)).
@@ -89,15 +88,22 @@ func TestUpdateHolding_Buy_ExistingEntry_WeightedAvg(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestUpdateHolding_Sell_Partial(t *testing.T) {
+func TestUpdateHolding_Sell_WithTax(t *testing.T) {
+	// buy at 100, sell at 150 → profit=50*2=100, tax=15
 	srv, mock := newServer(t)
 
+	mock.ExpectQuery(`SELECT buy_price FROM portfolio_entry`).
+		WithArgs(int64(1), "CLIENT", int64(10)).
+		WillReturnRows(sqlmock.NewRows([]string{"buy_price"}).AddRow(100.0))
 	mock.ExpectExec(`UPDATE portfolio_entry`).
 		WithArgs(int32(2), int64(1), "CLIENT", int64(10)).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec(`DELETE FROM portfolio_entry`).
 		WithArgs(int64(1), "CLIENT", int64(10)).
 		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(`INSERT INTO tax_record`).
+		WithArgs(int64(1), "CLIENT", sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_, err := srv.UpdateHolding(context.Background(), &pb.UpdateHoldingRequest{
 		UserId:    1,
@@ -111,9 +117,13 @@ func TestUpdateHolding_Sell_Partial(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestUpdateHolding_Sell_Full(t *testing.T) {
+func TestUpdateHolding_Sell_Loss_NoTax(t *testing.T) {
+	// buy at 200, sell at 150 → loss, no tax record
 	srv, mock := newServer(t)
 
+	mock.ExpectQuery(`SELECT buy_price FROM portfolio_entry`).
+		WithArgs(int64(1), "CLIENT", int64(10)).
+		WillReturnRows(sqlmock.NewRows([]string{"buy_price"}).AddRow(200.0))
 	mock.ExpectExec(`UPDATE portfolio_entry`).
 		WithArgs(int32(5), int64(1), "CLIENT", int64(10)).
 		WillReturnResult(sqlmock.NewResult(0, 1))
@@ -186,9 +196,6 @@ func TestGetPortfolio_WithPriceEnrichment(t *testing.T) {
 // ── GetProfit ─────────────────────────────────────────────────────────────────
 
 func TestGetProfit_HappyPath(t *testing.T) {
-	// Two holdings: AAPL bought at 150 (5 shares, current 200) = +250
-	//               MSFT bought at 300 (2 shares, current 280) = -40
-	// total profit = 210
 	sec := &mockSecClient{price: 200.0, ticker: "AAPL", assetType: "STOCK"}
 	srv, mock := newServerWithSec(t, sec)
 
@@ -202,7 +209,6 @@ func TestGetProfit_HappyPath(t *testing.T) {
 
 	mock.ExpectQuery(`SELECT`).WithArgs(int64(1), "").WillReturnRows(rows)
 
-	// Override mock to return different prices per call
 	callCount := 0
 	srv.SecuritiesClient = &callCountMockSecClient{
 		prices: []float64{200.0, 280.0},
@@ -247,6 +253,40 @@ func TestGetProfit_NegativeProfit(t *testing.T) {
 	require.NoError(t, err)
 	// (80 - 100) * 10 = -200
 	assert.InDelta(t, -200.0, resp.TotalProfit, 0.001)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// ── GetMyTax ──────────────────────────────────────────────────────────────────
+
+func TestGetMyTax_HappyPath(t *testing.T) {
+	srv, mock := newServer(t)
+
+	mock.ExpectQuery(`SELECT`).
+		WithArgs(int64(1), "CLIENT", sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"paid", "unpaid"}).AddRow(4500.0, 2250.0))
+
+	resp, err := srv.GetMyTax(context.Background(), &pb.GetMyTaxRequest{UserId: 1, UserType: "CLIENT"})
+	require.NoError(t, err)
+	assert.InDelta(t, 4500.0, resp.PaidThisYear, 0.001)
+	assert.InDelta(t, 2250.0, resp.UnpaidThisMonth, 0.001)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// ── GetTaxList ────────────────────────────────────────────────────────────────
+
+func TestGetTaxList_ReturnsDebts(t *testing.T) {
+	srv, mock := newServer(t)
+
+	mock.ExpectQuery(`SELECT user_id, user_type, SUM`).
+		WillReturnRows(sqlmock.NewRows([]string{"user_id", "user_type", "sum"}).
+			AddRow(int64(1), "CLIENT", 1500.0).
+			AddRow(int64(2), "EMPLOYEE", 750.0))
+
+	resp, err := srv.GetTaxList(context.Background(), &pb.GetTaxListRequest{})
+	require.NoError(t, err)
+	require.Len(t, resp.Entries, 2)
+	assert.Equal(t, int64(1), resp.Entries[0].UserId)
+	assert.InDelta(t, 1500.0, resp.Entries[0].DebtRsd, 0.001)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/services/portfolio-service/main.go
+++ b/services/portfolio-service/main.go
@@ -1,12 +1,17 @@
 package main
 
 import (
+	"context"
+	"database/sql"
 	"log"
 	"net"
 	"os"
+	"time"
 
 	portfoliodb "github.com/RAF-SI-2025/EXBanka-4-Backend/services/portfolio-service/db"
 	"github.com/RAF-SI-2025/EXBanka-4-Backend/services/portfolio-service/handlers"
+	taxcollector "github.com/RAF-SI-2025/EXBanka-4-Backend/services/portfolio-service/tax"
+	pb_ex "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/exchange"
 	pb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/portfolio"
 	pb_sec "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/securities"
 	"google.golang.org/grpc"
@@ -22,13 +27,28 @@ func main() {
 	}
 	defer func() { _ = db.Close() }()
 
+	accountDB, err := portfoliodb.Connect(os.Getenv("ACCOUNT_DB_URL"))
+	if err != nil {
+		log.Fatalf("failed to connect to account_db: %v", err)
+	}
+	defer func() { _ = accountDB.Close() }()
+
 	secConn, err := grpc.NewClient(os.Getenv("SECURITIES_SERVICE_ADDR"), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		log.Fatalf("failed to connect to securities-service: %v", err)
 	}
 	defer func() { _ = secConn.Close() }()
 
+	exConn, err := grpc.NewClient(os.Getenv("EXCHANGE_SERVICE_ADDR"), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		log.Fatalf("failed to connect to exchange-service: %v", err)
+	}
+	defer func() { _ = exConn.Close() }()
+
 	securitiesClient := pb_sec.NewSecuritiesServiceClient(secConn)
+	exchangeClient := pb_ex.NewExchangeServiceClient(exConn)
+
+	go runMonthlyTaxJob(db, accountDB, exchangeClient)
 
 	lis, err := net.Listen("tcp", grpcPort)
 	if err != nil {
@@ -38,11 +58,37 @@ func main() {
 	srv := grpc.NewServer()
 	pb.RegisterPortfolioServiceServer(srv, &handlers.PortfolioServer{
 		DB:               db,
+		AccountDB:        accountDB,
 		SecuritiesClient: securitiesClient,
+		ExchangeClient:   exchangeClient,
 	})
 
 	log.Printf("portfolio-service gRPC server listening on %s", grpcPort)
 	if err := srv.Serve(lis); err != nil {
 		log.Fatalf("gRPC serve error: %v", err)
+	}
+}
+
+// runMonthlyTaxJob sleeps until the last day of each month at 23:59 and collects all unpaid tax.
+func runMonthlyTaxJob(portfolioDB, accountDB *sql.DB, exchangeClient pb_ex.ExchangeServiceClient) {
+	for {
+		now := time.Now()
+		// Last day of current month at 23:59
+		firstOfNext := time.Date(now.Year(), now.Month()+1, 1, 0, 0, 0, 0, now.Location())
+		lastDay := time.Date(firstOfNext.Year(), firstOfNext.Month(), firstOfNext.Day()-1, 23, 59, 0, 0, now.Location())
+		if !now.Before(lastDay) {
+			// Already past this month's window; schedule for next month
+			firstOfNextNext := time.Date(now.Year(), now.Month()+2, 1, 0, 0, 0, 0, now.Location())
+			lastDay = time.Date(firstOfNextNext.Year(), firstOfNextNext.Month(), firstOfNextNext.Day()-1, 23, 59, 0, 0, now.Location())
+		}
+		time.Sleep(time.Until(lastDay))
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		if err := taxcollector.CollectUnpaid(ctx, portfolioDB, accountDB, exchangeClient, 0, ""); err != nil {
+			log.Printf("monthly tax job error: %v", err)
+		} else {
+			log.Printf("monthly tax collection completed")
+		}
+		cancel()
 	}
 }

--- a/services/portfolio-service/repository/portfolio_repo.go
+++ b/services/portfolio-service/repository/portfolio_repo.go
@@ -18,10 +18,11 @@ func sharedUserID(userID int64, userType string) int64 {
 // UpsertHolding updates portfolio holdings on each order fill.
 // BUY: creates or updates entry with weighted average buy price.
 // SELL: decrements amount; deletes entry if amount reaches zero.
-func UpsertHolding(ctx context.Context, db *sql.DB, userID int64, userType string, listingID, accountID int64, qty int32, price float64, direction string) error {
+// Returns the buy_price at the time of the operation (non-zero only on SELL, used by the caller to calculate tax).
+func UpsertHolding(ctx context.Context, db *sql.DB, userID int64, userType string, listingID, accountID int64, qty int32, price float64, direction string) (buyPrice float64, err error) {
 	uid := sharedUserID(userID, userType)
 	if direction == "BUY" {
-		_, err := db.ExecContext(ctx, `
+		_, err = db.ExecContext(ctx, `
 			INSERT INTO portfolio_entry (user_id, user_type, listing_id, amount, buy_price, account_id, last_modified)
 			VALUES ($1, $2, $3, $4, $5, $6, NOW())
 			ON CONFLICT (user_id, user_type, listing_id) DO UPDATE SET
@@ -30,18 +31,26 @@ func UpsertHolding(ctx context.Context, db *sql.DB, userID int64, userType strin
 				last_modified = NOW()`,
 			uid, userType, listingID, qty, price, accountID,
 		)
-		return err
+		return 0, err
 	}
 
-	// SELL: decrement amount
-	_, err := db.ExecContext(ctx, `
+	// SELL: read current buy_price before decrementing
+	row := db.QueryRowContext(ctx,
+		`SELECT buy_price FROM portfolio_entry WHERE user_id = $1 AND user_type = $2 AND listing_id = $3`,
+		uid, userType, listingID,
+	)
+	if scanErr := row.Scan(&buyPrice); scanErr != nil {
+		buyPrice = 0
+	}
+
+	_, err = db.ExecContext(ctx, `
 		UPDATE portfolio_entry
 		SET amount = amount - $1, last_modified = NOW()
 		WHERE user_id = $2 AND user_type = $3 AND listing_id = $4`,
 		qty, uid, userType, listingID,
 	)
 	if err != nil {
-		return err
+		return buyPrice, err
 	}
 
 	// Remove entry if fully sold
@@ -50,7 +59,7 @@ func UpsertHolding(ctx context.Context, db *sql.DB, userID int64, userType strin
 		WHERE user_id = $1 AND user_type = $2 AND listing_id = $3 AND amount <= 0`,
 		uid, userType, listingID,
 	)
-	return err
+	return buyPrice, err
 }
 
 // GetHoldings returns all portfolio entries for a user filtered by user type.

--- a/services/portfolio-service/repository/tax_repo.go
+++ b/services/portfolio-service/repository/tax_repo.go
@@ -18,9 +18,9 @@ type TaxRecord struct {
 }
 
 type TaxDebt struct {
-	UserID    int64
-	UserType  string
-	DebtRSD   float64
+	UserID   int64
+	UserType string
+	DebtRSD  float64
 }
 
 func InsertTaxRecord(ctx context.Context, db *sql.DB, userID int64, userType string, amountRSD float64, month, year int) error {

--- a/services/portfolio-service/repository/tax_repo.go
+++ b/services/portfolio-service/repository/tax_repo.go
@@ -1,0 +1,110 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"time"
+)
+
+type TaxRecord struct {
+	ID        int64
+	UserID    int64
+	UserType  string
+	AmountRSD float64
+	Month     int
+	Year      int
+	IsPaid    bool
+	PaidAt    *time.Time
+}
+
+type TaxDebt struct {
+	UserID    int64
+	UserType  string
+	DebtRSD   float64
+}
+
+func InsertTaxRecord(ctx context.Context, db *sql.DB, userID int64, userType string, amountRSD float64, month, year int) error {
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO tax_record (user_id, user_type, amount_rsd, month, year)
+		VALUES ($1, $2, $3, $4, $5)`,
+		userID, userType, amountRSD, month, year,
+	)
+	return err
+}
+
+func GetUnpaidRecords(ctx context.Context, db *sql.DB) ([]TaxRecord, error) {
+	return queryTaxRecords(ctx, db, `
+		SELECT id, user_id, user_type, amount_rsd, month, year, is_paid, paid_at
+		FROM tax_record WHERE is_paid = FALSE`)
+}
+
+func GetUnpaidRecordsForUser(ctx context.Context, db *sql.DB, userID int64, userType string) ([]TaxRecord, error) {
+	return queryTaxRecords(ctx, db, `
+		SELECT id, user_id, user_type, amount_rsd, month, year, is_paid, paid_at
+		FROM tax_record WHERE is_paid = FALSE AND user_id = $1 AND user_type = $2`,
+		userID, userType,
+	)
+}
+
+func MarkTaxPaid(ctx context.Context, db *sql.DB, id int64) error {
+	_, err := db.ExecContext(ctx,
+		`UPDATE tax_record SET is_paid = TRUE, paid_at = NOW() WHERE id = $1`, id,
+	)
+	return err
+}
+
+// GetMyTax returns amounts paid in the given year and unpaid in the current month.
+func GetMyTax(ctx context.Context, db *sql.DB, userID int64, userType string, year, month int) (paidThisYear, unpaidThisMonth float64, err error) {
+	row := db.QueryRowContext(ctx, `
+		SELECT
+			COALESCE(SUM(amount_rsd) FILTER (WHERE is_paid = TRUE AND year = $3), 0),
+			COALESCE(SUM(amount_rsd) FILTER (WHERE is_paid = FALSE AND year = $3 AND month = $4), 0)
+		FROM tax_record
+		WHERE user_id = $1 AND user_type = $2`,
+		userID, userType, year, month,
+	)
+	err = row.Scan(&paidThisYear, &unpaidThisMonth)
+	return
+}
+
+// GetTaxDebtList returns all users with unpaid tax, summed in RSD.
+func GetTaxDebtList(ctx context.Context, db *sql.DB) ([]TaxDebt, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT user_id, user_type, SUM(amount_rsd)
+		FROM tax_record
+		WHERE is_paid = FALSE
+		GROUP BY user_id, user_type
+		ORDER BY user_id`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var debts []TaxDebt
+	for rows.Next() {
+		var d TaxDebt
+		if err := rows.Scan(&d.UserID, &d.UserType, &d.DebtRSD); err != nil {
+			return nil, err
+		}
+		debts = append(debts, d)
+	}
+	return debts, rows.Err()
+}
+
+func queryTaxRecords(ctx context.Context, db *sql.DB, query string, args ...interface{}) ([]TaxRecord, error) {
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var records []TaxRecord
+	for rows.Next() {
+		var r TaxRecord
+		if err := rows.Scan(&r.ID, &r.UserID, &r.UserType, &r.AmountRSD, &r.Month, &r.Year, &r.IsPaid, &r.PaidAt); err != nil {
+			return nil, err
+		}
+		records = append(records, r)
+	}
+	return records, rows.Err()
+}

--- a/services/portfolio-service/repository/tax_repo_test.go
+++ b/services/portfolio-service/repository/tax_repo_test.go
@@ -1,0 +1,110 @@
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInsertTaxRecord(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	mock.ExpectExec(`INSERT INTO tax_record`).
+		WithArgs(int64(1), "CLIENT", 22.5, 4, 2026).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err = InsertTaxRecord(context.Background(), db, 1, "CLIENT", 22.5, 4, 2026)
+	require.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetUnpaidRecords(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	now := time.Now()
+	mock.ExpectQuery(`SELECT id, user_id, user_type, amount_rsd, month, year, is_paid, paid_at`).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "user_type", "amount_rsd", "month", "year", "is_paid", "paid_at"}).
+			AddRow(int64(1), int64(10), "CLIENT", 22.5, 4, 2026, false, (*time.Time)(nil)).
+			AddRow(int64(2), int64(20), "EMPLOYEE", 45.0, 4, 2026, false, &now))
+
+	records, err := GetUnpaidRecords(context.Background(), db)
+	require.NoError(t, err)
+	require.Len(t, records, 2)
+	assert.Equal(t, int64(1), records[0].ID)
+	assert.InDelta(t, 22.5, records[0].AmountRSD, 0.001)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetUnpaidRecordsForUser(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	mock.ExpectQuery(`SELECT id, user_id, user_type, amount_rsd, month, year, is_paid, paid_at`).
+		WithArgs(int64(5), "CLIENT").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "user_type", "amount_rsd", "month", "year", "is_paid", "paid_at"}).
+			AddRow(int64(3), int64(5), "CLIENT", 15.0, 3, 2026, false, (*time.Time)(nil)))
+
+	records, err := GetUnpaidRecordsForUser(context.Background(), db, 5, "CLIENT")
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	assert.Equal(t, int64(5), records[0].UserID)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestMarkTaxPaid(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	mock.ExpectExec(`UPDATE tax_record SET is_paid`).
+		WithArgs(int64(7)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	err = MarkTaxPaid(context.Background(), db, 7)
+	require.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetMyTax(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	mock.ExpectQuery(`SELECT`).
+		WithArgs(int64(1), "CLIENT", 2026, 4).
+		WillReturnRows(sqlmock.NewRows([]string{"paid", "unpaid"}).AddRow(4500.0, 2250.0))
+
+	paid, unpaid, err := GetMyTax(context.Background(), db, 1, "CLIENT", 2026, 4)
+	require.NoError(t, err)
+	assert.InDelta(t, 4500.0, paid, 0.001)
+	assert.InDelta(t, 2250.0, unpaid, 0.001)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetTaxDebtList(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	mock.ExpectQuery(`SELECT user_id, user_type, SUM`).
+		WillReturnRows(sqlmock.NewRows([]string{"user_id", "user_type", "sum"}).
+			AddRow(int64(1), "CLIENT", 1500.0).
+			AddRow(int64(2), "EMPLOYEE", 750.0))
+
+	debts, err := GetTaxDebtList(context.Background(), db)
+	require.NoError(t, err)
+	require.Len(t, debts, 2)
+	assert.Equal(t, int64(1), debts[0].UserID)
+	assert.InDelta(t, 1500.0, debts[0].DebtRSD, 0.001)
+	assert.Equal(t, "EMPLOYEE", debts[1].UserType)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}

--- a/services/portfolio-service/tax/collector.go
+++ b/services/portfolio-service/tax/collector.go
@@ -1,0 +1,105 @@
+package tax
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/RAF-SI-2025/EXBanka-4-Backend/services/portfolio-service/repository"
+	pb_ex "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/exchange"
+)
+
+// CollectUnpaid deducts all unpaid tax records from the relevant accounts.
+// Pass userID=0 and userType="" to process all users (supervisor/scheduled job).
+func CollectUnpaid(ctx context.Context, portfolioDB, accountDB *sql.DB, exchangeClient pb_ex.ExchangeServiceClient, userID int64, userType string) error {
+	var (
+		records []repository.TaxRecord
+		err     error
+	)
+	if userID == 0 {
+		records, err = repository.GetUnpaidRecords(ctx, portfolioDB)
+	} else {
+		records, err = repository.GetUnpaidRecordsForUser(ctx, portfolioDB, userID, userType)
+	}
+	if err != nil {
+		return fmt.Errorf("load unpaid records: %w", err)
+	}
+
+	// Cache exchange rates for the duration of this collection run.
+	var rates map[string]float64
+
+	for _, rec := range records {
+		accountID, err := getAccountForUser(ctx, portfolioDB, rec.UserID, rec.UserType)
+		if err != nil {
+			continue
+		}
+
+		currency, err := getAccountCurrency(ctx, accountDB, accountID)
+		if err != nil {
+			continue
+		}
+
+		deductAmount := rec.AmountRSD
+		if currency != "RSD" {
+			if rates == nil {
+				rates, err = fetchMiddleRates(ctx, exchangeClient)
+				if err != nil {
+					return fmt.Errorf("fetch exchange rates: %w", err)
+				}
+			}
+			middleRate, ok := rates[currency]
+			if !ok || middleRate == 0 {
+				continue
+			}
+			deductAmount = rec.AmountRSD / middleRate
+		}
+
+		if err := deductFromAccount(ctx, accountDB, accountID, deductAmount); err != nil {
+			continue
+		}
+
+		_ = repository.MarkTaxPaid(ctx, portfolioDB, rec.ID)
+	}
+	return nil
+}
+
+func getAccountForUser(ctx context.Context, db *sql.DB, userID int64, userType string) (int64, error) {
+	var accountID int64
+	err := db.QueryRowContext(ctx, `
+		SELECT account_id FROM portfolio_entry
+		WHERE user_id = $1 AND user_type = $2
+		LIMIT 1`,
+		userID, userType,
+	).Scan(&accountID)
+	return accountID, err
+}
+
+func getAccountCurrency(ctx context.Context, accountDB *sql.DB, accountID int64) (string, error) {
+	var currency string
+	err := accountDB.QueryRowContext(ctx,
+		`SELECT currency_code FROM accounts WHERE id = $1`, accountID,
+	).Scan(&currency)
+	return currency, err
+}
+
+func deductFromAccount(ctx context.Context, accountDB *sql.DB, accountID int64, amount float64) error {
+	_, err := accountDB.ExecContext(ctx, `
+		UPDATE accounts
+		SET balance = balance - $1, available_balance = available_balance - $1
+		WHERE id = $2`,
+		amount, accountID,
+	)
+	return err
+}
+
+func fetchMiddleRates(ctx context.Context, client pb_ex.ExchangeServiceClient) (map[string]float64, error) {
+	resp, err := client.GetExchangeRates(ctx, &pb_ex.GetExchangeRatesRequest{})
+	if err != nil {
+		return nil, err
+	}
+	m := make(map[string]float64, len(resp.Rates))
+	for _, r := range resp.Rates {
+		m[r.CurrencyCode] = r.MiddleRate
+	}
+	return m, nil
+}

--- a/services/portfolio-service/tax/collector_test.go
+++ b/services/portfolio-service/tax/collector_test.go
@@ -1,0 +1,132 @@
+package tax
+
+import (
+	"context"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	pb_ex "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/exchange"
+	"google.golang.org/grpc"
+)
+
+// mockExchangeClient satisfies pb_ex.ExchangeServiceClient.
+type mockExchangeClient struct {
+	rates []*pb_ex.ExchangeRate
+}
+
+func (m *mockExchangeClient) GetExchangeRates(_ context.Context, _ *pb_ex.GetExchangeRatesRequest, _ ...grpc.CallOption) (*pb_ex.GetExchangeRatesResponse, error) {
+	return &pb_ex.GetExchangeRatesResponse{Rates: m.rates}, nil
+}
+
+func (m *mockExchangeClient) ConvertAmount(_ context.Context, _ *pb_ex.ConvertAmountRequest, _ ...grpc.CallOption) (*pb_ex.ConvertAmountResponse, error) {
+	return &pb_ex.ConvertAmountResponse{}, nil
+}
+
+func (m *mockExchangeClient) GetExchangeHistory(_ context.Context, _ *pb_ex.GetExchangeHistoryRequest, _ ...grpc.CallOption) (*pb_ex.GetExchangeHistoryResponse, error) {
+	return &pb_ex.GetExchangeHistoryResponse{}, nil
+}
+
+func (m *mockExchangeClient) PreviewConversion(_ context.Context, _ *pb_ex.PreviewConversionRequest, _ ...grpc.CallOption) (*pb_ex.PreviewConversionResponse, error) {
+	return &pb_ex.PreviewConversionResponse{}, nil
+}
+
+func TestCollectUnpaid_RSD_SingleRecord(t *testing.T) {
+	portfolioDB, pMock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer portfolioDB.Close()
+
+	accountDB, aMock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer accountDB.Close()
+
+	// unpaid records query
+	pMock.ExpectQuery(`SELECT id, user_id, user_type, amount_rsd, month, year, is_paid, paid_at`).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "user_type", "amount_rsd", "month", "year", "is_paid", "paid_at"}).
+			AddRow(int64(1), int64(10), "CLIENT", 100.0, 4, 2026, false, nil))
+
+	// account_id lookup in portfolioDB
+	pMock.ExpectQuery(`SELECT account_id FROM portfolio_entry`).
+		WithArgs(int64(10), "CLIENT").
+		WillReturnRows(sqlmock.NewRows([]string{"account_id"}).AddRow(int64(42)))
+
+	// currency lookup in accountDB
+	aMock.ExpectQuery(`SELECT currency_code FROM accounts`).
+		WithArgs(int64(42)).
+		WillReturnRows(sqlmock.NewRows([]string{"currency_code"}).AddRow("RSD"))
+
+	// deduct from account
+	aMock.ExpectExec(`UPDATE accounts`).
+		WithArgs(100.0, int64(42)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	// mark paid
+	pMock.ExpectExec(`UPDATE tax_record SET is_paid`).
+		WithArgs(int64(1)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	err = CollectUnpaid(context.Background(), portfolioDB, accountDB, &mockExchangeClient{}, 0, "")
+	require.NoError(t, err)
+	assert.NoError(t, pMock.ExpectationsWereMet())
+	assert.NoError(t, aMock.ExpectationsWereMet())
+}
+
+func TestCollectUnpaid_ForeignCurrency_ConvertsToRSD(t *testing.T) {
+	portfolioDB, pMock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer portfolioDB.Close()
+
+	accountDB, aMock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer accountDB.Close()
+
+	exchangeClient := &mockExchangeClient{
+		rates: []*pb_ex.ExchangeRate{
+			{CurrencyCode: "USD", MiddleRate: 110.0},
+		},
+	}
+
+	pMock.ExpectQuery(`SELECT id, user_id, user_type, amount_rsd, month, year, is_paid, paid_at`).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "user_type", "amount_rsd", "month", "year", "is_paid", "paid_at"}).
+			AddRow(int64(2), int64(11), "CLIENT", 220.0, 4, 2026, false, nil))
+
+	pMock.ExpectQuery(`SELECT account_id FROM portfolio_entry`).
+		WithArgs(int64(11), "CLIENT").
+		WillReturnRows(sqlmock.NewRows([]string{"account_id"}).AddRow(int64(55)))
+
+	aMock.ExpectQuery(`SELECT currency_code FROM accounts`).
+		WithArgs(int64(55)).
+		WillReturnRows(sqlmock.NewRows([]string{"currency_code"}).AddRow("USD"))
+
+	// 220 RSD / 110 middle rate = 2 USD
+	aMock.ExpectExec(`UPDATE accounts`).
+		WithArgs(2.0, int64(55)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	pMock.ExpectExec(`UPDATE tax_record SET is_paid`).
+		WithArgs(int64(2)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	err = CollectUnpaid(context.Background(), portfolioDB, accountDB, exchangeClient, 0, "")
+	require.NoError(t, err)
+	assert.NoError(t, pMock.ExpectationsWereMet())
+	assert.NoError(t, aMock.ExpectationsWereMet())
+}
+
+func TestCollectUnpaid_NoRecords(t *testing.T) {
+	portfolioDB, pMock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer portfolioDB.Close()
+
+	accountDB, _, err := sqlmock.New()
+	require.NoError(t, err)
+	defer accountDB.Close()
+
+	pMock.ExpectQuery(`SELECT id, user_id, user_type, amount_rsd, month, year, is_paid, paid_at`).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "user_type", "amount_rsd", "month", "year", "is_paid", "paid_at"}))
+
+	err = CollectUnpaid(context.Background(), portfolioDB, accountDB, &mockExchangeClient{}, 0, "")
+	require.NoError(t, err)
+	assert.NoError(t, pMock.ExpectationsWereMet())
+}

--- a/services/portfolio-service/tax/collector_test.go
+++ b/services/portfolio-service/tax/collector_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	pb_ex "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/exchange"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	pb_ex "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/exchange"
 	"google.golang.org/grpc"
 )
 

--- a/shared/pb/portfolio/portfolio.pb.go
+++ b/shared/pb/portfolio/portfolio.pb.go
@@ -31,6 +31,7 @@ type UpdateHoldingRequest struct {
 	Price         float64                `protobuf:"fixed64,5,opt,name=price,proto3" json:"price,omitempty"`       // price per unit at fill time
 	Direction     string                 `protobuf:"bytes,6,opt,name=direction,proto3" json:"direction,omitempty"` // BUY or SELL
 	AccountId     int64                  `protobuf:"varint,7,opt,name=account_id,json=accountId,proto3" json:"account_id,omitempty"`
+	AssetType     string                 `protobuf:"bytes,8,opt,name=asset_type,json=assetType,proto3" json:"asset_type,omitempty"` // e.g. STOCK, FOREX_PAIR, FUTURES_CONTRACT, OPTION
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -112,6 +113,13 @@ func (x *UpdateHoldingRequest) GetAccountId() int64 {
 		return x.AccountId
 	}
 	return 0
+}
+
+func (x *UpdateHoldingRequest) GetAssetType() string {
+	if x != nil {
+		return x.AssetType
+	}
+	return ""
 }
 
 type UpdateHoldingResponse struct {
@@ -998,7 +1006,7 @@ var File_portfolio_proto protoreflect.FileDescriptor
 
 const file_portfolio_proto_rawDesc = "" +
 	"\n" +
-	"\x0fportfolio.proto\x12\tportfolio\"\xda\x01\n" +
+	"\x0fportfolio.proto\x12\tportfolio\"\xf9\x01\n" +
 	"\x14UpdateHoldingRequest\x12\x17\n" +
 	"\auser_id\x18\x01 \x01(\x03R\x06userId\x12\x1b\n" +
 	"\tuser_type\x18\x02 \x01(\tR\buserType\x12\x1d\n" +
@@ -1008,7 +1016,9 @@ const file_portfolio_proto_rawDesc = "" +
 	"\x05price\x18\x05 \x01(\x01R\x05price\x12\x1c\n" +
 	"\tdirection\x18\x06 \x01(\tR\tdirection\x12\x1d\n" +
 	"\n" +
-	"account_id\x18\a \x01(\x03R\taccountId\"\x17\n" +
+	"account_id\x18\a \x01(\x03R\taccountId\x12\x1d\n" +
+	"\n" +
+	"asset_type\x18\b \x01(\tR\tassetType\"\x17\n" +
 	"\x15UpdateHoldingResponse\"K\n" +
 	"\x13GetPortfolioRequest\x12\x17\n" +
 	"\auser_id\x18\x01 \x01(\x03R\x06userId\x12\x1b\n" +

--- a/shared/pb/portfolio/portfolio.pb.go
+++ b/shared/pb/portfolio/portfolio.pb.go
@@ -573,6 +573,427 @@ func (*SetPublicAmountResponse) Descriptor() ([]byte, []int) {
 	return file_portfolio_proto_rawDescGZIP(), []int{8}
 }
 
+// Tax RPCs (#157)
+type GetMyTaxRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	UserId        int64                  `protobuf:"varint,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
+	UserType      string                 `protobuf:"bytes,2,opt,name=user_type,json=userType,proto3" json:"user_type,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetMyTaxRequest) Reset() {
+	*x = GetMyTaxRequest{}
+	mi := &file_portfolio_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetMyTaxRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetMyTaxRequest) ProtoMessage() {}
+
+func (x *GetMyTaxRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_portfolio_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetMyTaxRequest.ProtoReflect.Descriptor instead.
+func (*GetMyTaxRequest) Descriptor() ([]byte, []int) {
+	return file_portfolio_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *GetMyTaxRequest) GetUserId() int64 {
+	if x != nil {
+		return x.UserId
+	}
+	return 0
+}
+
+func (x *GetMyTaxRequest) GetUserType() string {
+	if x != nil {
+		return x.UserType
+	}
+	return ""
+}
+
+type GetMyTaxResponse struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	PaidThisYear    float64                `protobuf:"fixed64,1,opt,name=paid_this_year,json=paidThisYear,proto3" json:"paid_this_year,omitempty"`
+	UnpaidThisMonth float64                `protobuf:"fixed64,2,opt,name=unpaid_this_month,json=unpaidThisMonth,proto3" json:"unpaid_this_month,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *GetMyTaxResponse) Reset() {
+	*x = GetMyTaxResponse{}
+	mi := &file_portfolio_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetMyTaxResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetMyTaxResponse) ProtoMessage() {}
+
+func (x *GetMyTaxResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_portfolio_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetMyTaxResponse.ProtoReflect.Descriptor instead.
+func (*GetMyTaxResponse) Descriptor() ([]byte, []int) {
+	return file_portfolio_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *GetMyTaxResponse) GetPaidThisYear() float64 {
+	if x != nil {
+		return x.PaidThisYear
+	}
+	return 0
+}
+
+func (x *GetMyTaxResponse) GetUnpaidThisMonth() float64 {
+	if x != nil {
+		return x.UnpaidThisMonth
+	}
+	return 0
+}
+
+type GetTaxListRequest struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	UserTypeFilter string                 `protobuf:"bytes,1,opt,name=user_type_filter,json=userTypeFilter,proto3" json:"user_type_filter,omitempty"`
+	NameFilter     string                 `protobuf:"bytes,2,opt,name=name_filter,json=nameFilter,proto3" json:"name_filter,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *GetTaxListRequest) Reset() {
+	*x = GetTaxListRequest{}
+	mi := &file_portfolio_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetTaxListRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetTaxListRequest) ProtoMessage() {}
+
+func (x *GetTaxListRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_portfolio_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetTaxListRequest.ProtoReflect.Descriptor instead.
+func (*GetTaxListRequest) Descriptor() ([]byte, []int) {
+	return file_portfolio_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *GetTaxListRequest) GetUserTypeFilter() string {
+	if x != nil {
+		return x.UserTypeFilter
+	}
+	return ""
+}
+
+func (x *GetTaxListRequest) GetNameFilter() string {
+	if x != nil {
+		return x.NameFilter
+	}
+	return ""
+}
+
+type TaxDebtEntry struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	UserId        int64                  `protobuf:"varint,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
+	Type          string                 `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty"`
+	DebtRsd       float64                `protobuf:"fixed64,3,opt,name=debt_rsd,json=debtRsd,proto3" json:"debt_rsd,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TaxDebtEntry) Reset() {
+	*x = TaxDebtEntry{}
+	mi := &file_portfolio_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TaxDebtEntry) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TaxDebtEntry) ProtoMessage() {}
+
+func (x *TaxDebtEntry) ProtoReflect() protoreflect.Message {
+	mi := &file_portfolio_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TaxDebtEntry.ProtoReflect.Descriptor instead.
+func (*TaxDebtEntry) Descriptor() ([]byte, []int) {
+	return file_portfolio_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *TaxDebtEntry) GetUserId() int64 {
+	if x != nil {
+		return x.UserId
+	}
+	return 0
+}
+
+func (x *TaxDebtEntry) GetType() string {
+	if x != nil {
+		return x.Type
+	}
+	return ""
+}
+
+func (x *TaxDebtEntry) GetDebtRsd() float64 {
+	if x != nil {
+		return x.DebtRsd
+	}
+	return 0
+}
+
+type GetTaxListResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Entries       []*TaxDebtEntry        `protobuf:"bytes,1,rep,name=entries,proto3" json:"entries,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetTaxListResponse) Reset() {
+	*x = GetTaxListResponse{}
+	mi := &file_portfolio_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetTaxListResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetTaxListResponse) ProtoMessage() {}
+
+func (x *GetTaxListResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_portfolio_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetTaxListResponse.ProtoReflect.Descriptor instead.
+func (*GetTaxListResponse) Descriptor() ([]byte, []int) {
+	return file_portfolio_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *GetTaxListResponse) GetEntries() []*TaxDebtEntry {
+	if x != nil {
+		return x.Entries
+	}
+	return nil
+}
+
+type CollectTaxRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CollectTaxRequest) Reset() {
+	*x = CollectTaxRequest{}
+	mi := &file_portfolio_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CollectTaxRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CollectTaxRequest) ProtoMessage() {}
+
+func (x *CollectTaxRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_portfolio_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CollectTaxRequest.ProtoReflect.Descriptor instead.
+func (*CollectTaxRequest) Descriptor() ([]byte, []int) {
+	return file_portfolio_proto_rawDescGZIP(), []int{14}
+}
+
+type CollectTaxResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CollectTaxResponse) Reset() {
+	*x = CollectTaxResponse{}
+	mi := &file_portfolio_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CollectTaxResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CollectTaxResponse) ProtoMessage() {}
+
+func (x *CollectTaxResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_portfolio_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CollectTaxResponse.ProtoReflect.Descriptor instead.
+func (*CollectTaxResponse) Descriptor() ([]byte, []int) {
+	return file_portfolio_proto_rawDescGZIP(), []int{15}
+}
+
+type CollectTaxForUserRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	UserId        int64                  `protobuf:"varint,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
+	UserType      string                 `protobuf:"bytes,2,opt,name=user_type,json=userType,proto3" json:"user_type,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CollectTaxForUserRequest) Reset() {
+	*x = CollectTaxForUserRequest{}
+	mi := &file_portfolio_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CollectTaxForUserRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CollectTaxForUserRequest) ProtoMessage() {}
+
+func (x *CollectTaxForUserRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_portfolio_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CollectTaxForUserRequest.ProtoReflect.Descriptor instead.
+func (*CollectTaxForUserRequest) Descriptor() ([]byte, []int) {
+	return file_portfolio_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *CollectTaxForUserRequest) GetUserId() int64 {
+	if x != nil {
+		return x.UserId
+	}
+	return 0
+}
+
+func (x *CollectTaxForUserRequest) GetUserType() string {
+	if x != nil {
+		return x.UserType
+	}
+	return ""
+}
+
+type CollectTaxForUserResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CollectTaxForUserResponse) Reset() {
+	*x = CollectTaxForUserResponse{}
+	mi := &file_portfolio_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CollectTaxForUserResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CollectTaxForUserResponse) ProtoMessage() {}
+
+func (x *CollectTaxForUserResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_portfolio_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CollectTaxForUserResponse.ProtoReflect.Descriptor instead.
+func (*CollectTaxForUserResponse) Descriptor() ([]byte, []int) {
+	return file_portfolio_proto_rawDescGZIP(), []int{17}
+}
+
 var File_portfolio_proto protoreflect.FileDescriptor
 
 const file_portfolio_proto_rawDesc = "" +
@@ -621,12 +1042,40 @@ const file_portfolio_proto_rawDesc = "" +
 	"\n" +
 	"listing_id\x18\x02 \x01(\x03R\tlistingId\x12\x16\n" +
 	"\x06amount\x18\x03 \x01(\x05R\x06amount\"\x19\n" +
-	"\x17SetPublicAmountResponse2\xd9\x02\n" +
+	"\x17SetPublicAmountResponse\"G\n" +
+	"\x0fGetMyTaxRequest\x12\x17\n" +
+	"\auser_id\x18\x01 \x01(\x03R\x06userId\x12\x1b\n" +
+	"\tuser_type\x18\x02 \x01(\tR\buserType\"d\n" +
+	"\x10GetMyTaxResponse\x12$\n" +
+	"\x0epaid_this_year\x18\x01 \x01(\x01R\fpaidThisYear\x12*\n" +
+	"\x11unpaid_this_month\x18\x02 \x01(\x01R\x0funpaidThisMonth\"^\n" +
+	"\x11GetTaxListRequest\x12(\n" +
+	"\x10user_type_filter\x18\x01 \x01(\tR\x0euserTypeFilter\x12\x1f\n" +
+	"\vname_filter\x18\x02 \x01(\tR\n" +
+	"nameFilter\"V\n" +
+	"\fTaxDebtEntry\x12\x17\n" +
+	"\auser_id\x18\x01 \x01(\x03R\x06userId\x12\x12\n" +
+	"\x04type\x18\x02 \x01(\tR\x04type\x12\x19\n" +
+	"\bdebt_rsd\x18\x03 \x01(\x01R\adebtRsd\"G\n" +
+	"\x12GetTaxListResponse\x121\n" +
+	"\aentries\x18\x01 \x03(\v2\x17.portfolio.TaxDebtEntryR\aentries\"\x13\n" +
+	"\x11CollectTaxRequest\"\x14\n" +
+	"\x12CollectTaxResponse\"P\n" +
+	"\x18CollectTaxForUserRequest\x12\x17\n" +
+	"\auser_id\x18\x01 \x01(\x03R\x06userId\x12\x1b\n" +
+	"\tuser_type\x18\x02 \x01(\tR\buserType\"\x1b\n" +
+	"\x19CollectTaxForUserResponse2\x94\x05\n" +
 	"\x10PortfolioService\x12R\n" +
 	"\rUpdateHolding\x12\x1f.portfolio.UpdateHoldingRequest\x1a .portfolio.UpdateHoldingResponse\x12O\n" +
 	"\fGetPortfolio\x12\x1e.portfolio.GetPortfolioRequest\x1a\x1f.portfolio.GetPortfolioResponse\x12F\n" +
 	"\tGetProfit\x12\x1b.portfolio.GetProfitRequest\x1a\x1c.portfolio.GetProfitResponse\x12X\n" +
-	"\x0fSetPublicAmount\x12!.portfolio.SetPublicAmountRequest\x1a\".portfolio.SetPublicAmountResponseB>Z<github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/portfoliob\x06proto3"
+	"\x0fSetPublicAmount\x12!.portfolio.SetPublicAmountRequest\x1a\".portfolio.SetPublicAmountResponse\x12C\n" +
+	"\bGetMyTax\x12\x1a.portfolio.GetMyTaxRequest\x1a\x1b.portfolio.GetMyTaxResponse\x12I\n" +
+	"\n" +
+	"GetTaxList\x12\x1c.portfolio.GetTaxListRequest\x1a\x1d.portfolio.GetTaxListResponse\x12I\n" +
+	"\n" +
+	"CollectTax\x12\x1c.portfolio.CollectTaxRequest\x1a\x1d.portfolio.CollectTaxResponse\x12^\n" +
+	"\x11CollectTaxForUser\x12#.portfolio.CollectTaxForUserRequest\x1a$.portfolio.CollectTaxForUserResponseB>Z<github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/portfoliob\x06proto3"
 
 var (
 	file_portfolio_proto_rawDescOnce sync.Once
@@ -640,33 +1089,51 @@ func file_portfolio_proto_rawDescGZIP() []byte {
 	return file_portfolio_proto_rawDescData
 }
 
-var file_portfolio_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
+var file_portfolio_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
 var file_portfolio_proto_goTypes = []any{
-	(*UpdateHoldingRequest)(nil),    // 0: portfolio.UpdateHoldingRequest
-	(*UpdateHoldingResponse)(nil),   // 1: portfolio.UpdateHoldingResponse
-	(*GetPortfolioRequest)(nil),     // 2: portfolio.GetPortfolioRequest
-	(*PortfolioEntry)(nil),          // 3: portfolio.PortfolioEntry
-	(*GetPortfolioResponse)(nil),    // 4: portfolio.GetPortfolioResponse
-	(*GetProfitRequest)(nil),        // 5: portfolio.GetProfitRequest
-	(*GetProfitResponse)(nil),       // 6: portfolio.GetProfitResponse
-	(*SetPublicAmountRequest)(nil),  // 7: portfolio.SetPublicAmountRequest
-	(*SetPublicAmountResponse)(nil), // 8: portfolio.SetPublicAmountResponse
+	(*UpdateHoldingRequest)(nil),      // 0: portfolio.UpdateHoldingRequest
+	(*UpdateHoldingResponse)(nil),     // 1: portfolio.UpdateHoldingResponse
+	(*GetPortfolioRequest)(nil),       // 2: portfolio.GetPortfolioRequest
+	(*PortfolioEntry)(nil),            // 3: portfolio.PortfolioEntry
+	(*GetPortfolioResponse)(nil),      // 4: portfolio.GetPortfolioResponse
+	(*GetProfitRequest)(nil),          // 5: portfolio.GetProfitRequest
+	(*GetProfitResponse)(nil),         // 6: portfolio.GetProfitResponse
+	(*SetPublicAmountRequest)(nil),    // 7: portfolio.SetPublicAmountRequest
+	(*SetPublicAmountResponse)(nil),   // 8: portfolio.SetPublicAmountResponse
+	(*GetMyTaxRequest)(nil),           // 9: portfolio.GetMyTaxRequest
+	(*GetMyTaxResponse)(nil),          // 10: portfolio.GetMyTaxResponse
+	(*GetTaxListRequest)(nil),         // 11: portfolio.GetTaxListRequest
+	(*TaxDebtEntry)(nil),              // 12: portfolio.TaxDebtEntry
+	(*GetTaxListResponse)(nil),        // 13: portfolio.GetTaxListResponse
+	(*CollectTaxRequest)(nil),         // 14: portfolio.CollectTaxRequest
+	(*CollectTaxResponse)(nil),        // 15: portfolio.CollectTaxResponse
+	(*CollectTaxForUserRequest)(nil),  // 16: portfolio.CollectTaxForUserRequest
+	(*CollectTaxForUserResponse)(nil), // 17: portfolio.CollectTaxForUserResponse
 }
 var file_portfolio_proto_depIdxs = []int32{
-	3, // 0: portfolio.GetPortfolioResponse.entries:type_name -> portfolio.PortfolioEntry
-	0, // 1: portfolio.PortfolioService.UpdateHolding:input_type -> portfolio.UpdateHoldingRequest
-	2, // 2: portfolio.PortfolioService.GetPortfolio:input_type -> portfolio.GetPortfolioRequest
-	5, // 3: portfolio.PortfolioService.GetProfit:input_type -> portfolio.GetProfitRequest
-	7, // 4: portfolio.PortfolioService.SetPublicAmount:input_type -> portfolio.SetPublicAmountRequest
-	1, // 5: portfolio.PortfolioService.UpdateHolding:output_type -> portfolio.UpdateHoldingResponse
-	4, // 6: portfolio.PortfolioService.GetPortfolio:output_type -> portfolio.GetPortfolioResponse
-	6, // 7: portfolio.PortfolioService.GetProfit:output_type -> portfolio.GetProfitResponse
-	8, // 8: portfolio.PortfolioService.SetPublicAmount:output_type -> portfolio.SetPublicAmountResponse
-	5, // [5:9] is the sub-list for method output_type
-	1, // [1:5] is the sub-list for method input_type
-	1, // [1:1] is the sub-list for extension type_name
-	1, // [1:1] is the sub-list for extension extendee
-	0, // [0:1] is the sub-list for field type_name
+	3,  // 0: portfolio.GetPortfolioResponse.entries:type_name -> portfolio.PortfolioEntry
+	12, // 1: portfolio.GetTaxListResponse.entries:type_name -> portfolio.TaxDebtEntry
+	0,  // 2: portfolio.PortfolioService.UpdateHolding:input_type -> portfolio.UpdateHoldingRequest
+	2,  // 3: portfolio.PortfolioService.GetPortfolio:input_type -> portfolio.GetPortfolioRequest
+	5,  // 4: portfolio.PortfolioService.GetProfit:input_type -> portfolio.GetProfitRequest
+	7,  // 5: portfolio.PortfolioService.SetPublicAmount:input_type -> portfolio.SetPublicAmountRequest
+	9,  // 6: portfolio.PortfolioService.GetMyTax:input_type -> portfolio.GetMyTaxRequest
+	11, // 7: portfolio.PortfolioService.GetTaxList:input_type -> portfolio.GetTaxListRequest
+	14, // 8: portfolio.PortfolioService.CollectTax:input_type -> portfolio.CollectTaxRequest
+	16, // 9: portfolio.PortfolioService.CollectTaxForUser:input_type -> portfolio.CollectTaxForUserRequest
+	1,  // 10: portfolio.PortfolioService.UpdateHolding:output_type -> portfolio.UpdateHoldingResponse
+	4,  // 11: portfolio.PortfolioService.GetPortfolio:output_type -> portfolio.GetPortfolioResponse
+	6,  // 12: portfolio.PortfolioService.GetProfit:output_type -> portfolio.GetProfitResponse
+	8,  // 13: portfolio.PortfolioService.SetPublicAmount:output_type -> portfolio.SetPublicAmountResponse
+	10, // 14: portfolio.PortfolioService.GetMyTax:output_type -> portfolio.GetMyTaxResponse
+	13, // 15: portfolio.PortfolioService.GetTaxList:output_type -> portfolio.GetTaxListResponse
+	15, // 16: portfolio.PortfolioService.CollectTax:output_type -> portfolio.CollectTaxResponse
+	17, // 17: portfolio.PortfolioService.CollectTaxForUser:output_type -> portfolio.CollectTaxForUserResponse
+	10, // [10:18] is the sub-list for method output_type
+	2,  // [2:10] is the sub-list for method input_type
+	2,  // [2:2] is the sub-list for extension type_name
+	2,  // [2:2] is the sub-list for extension extendee
+	0,  // [0:2] is the sub-list for field type_name
 }
 
 func init() { file_portfolio_proto_init() }
@@ -680,7 +1147,7 @@ func file_portfolio_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_portfolio_proto_rawDesc), len(file_portfolio_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   9,
+			NumMessages:   18,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/shared/pb/portfolio/portfolio_grpc.pb.go
+++ b/shared/pb/portfolio/portfolio_grpc.pb.go
@@ -19,10 +19,14 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	PortfolioService_UpdateHolding_FullMethodName   = "/portfolio.PortfolioService/UpdateHolding"
-	PortfolioService_GetPortfolio_FullMethodName    = "/portfolio.PortfolioService/GetPortfolio"
-	PortfolioService_GetProfit_FullMethodName       = "/portfolio.PortfolioService/GetProfit"
-	PortfolioService_SetPublicAmount_FullMethodName = "/portfolio.PortfolioService/SetPublicAmount"
+	PortfolioService_UpdateHolding_FullMethodName     = "/portfolio.PortfolioService/UpdateHolding"
+	PortfolioService_GetPortfolio_FullMethodName      = "/portfolio.PortfolioService/GetPortfolio"
+	PortfolioService_GetProfit_FullMethodName         = "/portfolio.PortfolioService/GetProfit"
+	PortfolioService_SetPublicAmount_FullMethodName   = "/portfolio.PortfolioService/SetPublicAmount"
+	PortfolioService_GetMyTax_FullMethodName          = "/portfolio.PortfolioService/GetMyTax"
+	PortfolioService_GetTaxList_FullMethodName        = "/portfolio.PortfolioService/GetTaxList"
+	PortfolioService_CollectTax_FullMethodName        = "/portfolio.PortfolioService/CollectTax"
+	PortfolioService_CollectTaxForUser_FullMethodName = "/portfolio.PortfolioService/CollectTaxForUser"
 )
 
 // PortfolioServiceClient is the client API for PortfolioService service.
@@ -33,6 +37,10 @@ type PortfolioServiceClient interface {
 	GetPortfolio(ctx context.Context, in *GetPortfolioRequest, opts ...grpc.CallOption) (*GetPortfolioResponse, error)
 	GetProfit(ctx context.Context, in *GetProfitRequest, opts ...grpc.CallOption) (*GetProfitResponse, error)
 	SetPublicAmount(ctx context.Context, in *SetPublicAmountRequest, opts ...grpc.CallOption) (*SetPublicAmountResponse, error)
+	GetMyTax(ctx context.Context, in *GetMyTaxRequest, opts ...grpc.CallOption) (*GetMyTaxResponse, error)
+	GetTaxList(ctx context.Context, in *GetTaxListRequest, opts ...grpc.CallOption) (*GetTaxListResponse, error)
+	CollectTax(ctx context.Context, in *CollectTaxRequest, opts ...grpc.CallOption) (*CollectTaxResponse, error)
+	CollectTaxForUser(ctx context.Context, in *CollectTaxForUserRequest, opts ...grpc.CallOption) (*CollectTaxForUserResponse, error)
 }
 
 type portfolioServiceClient struct {
@@ -83,6 +91,46 @@ func (c *portfolioServiceClient) SetPublicAmount(ctx context.Context, in *SetPub
 	return out, nil
 }
 
+func (c *portfolioServiceClient) GetMyTax(ctx context.Context, in *GetMyTaxRequest, opts ...grpc.CallOption) (*GetMyTaxResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetMyTaxResponse)
+	err := c.cc.Invoke(ctx, PortfolioService_GetMyTax_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *portfolioServiceClient) GetTaxList(ctx context.Context, in *GetTaxListRequest, opts ...grpc.CallOption) (*GetTaxListResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetTaxListResponse)
+	err := c.cc.Invoke(ctx, PortfolioService_GetTaxList_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *portfolioServiceClient) CollectTax(ctx context.Context, in *CollectTaxRequest, opts ...grpc.CallOption) (*CollectTaxResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(CollectTaxResponse)
+	err := c.cc.Invoke(ctx, PortfolioService_CollectTax_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *portfolioServiceClient) CollectTaxForUser(ctx context.Context, in *CollectTaxForUserRequest, opts ...grpc.CallOption) (*CollectTaxForUserResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(CollectTaxForUserResponse)
+	err := c.cc.Invoke(ctx, PortfolioService_CollectTaxForUser_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // PortfolioServiceServer is the server API for PortfolioService service.
 // All implementations must embed UnimplementedPortfolioServiceServer
 // for forward compatibility.
@@ -91,6 +139,10 @@ type PortfolioServiceServer interface {
 	GetPortfolio(context.Context, *GetPortfolioRequest) (*GetPortfolioResponse, error)
 	GetProfit(context.Context, *GetProfitRequest) (*GetProfitResponse, error)
 	SetPublicAmount(context.Context, *SetPublicAmountRequest) (*SetPublicAmountResponse, error)
+	GetMyTax(context.Context, *GetMyTaxRequest) (*GetMyTaxResponse, error)
+	GetTaxList(context.Context, *GetTaxListRequest) (*GetTaxListResponse, error)
+	CollectTax(context.Context, *CollectTaxRequest) (*CollectTaxResponse, error)
+	CollectTaxForUser(context.Context, *CollectTaxForUserRequest) (*CollectTaxForUserResponse, error)
 	mustEmbedUnimplementedPortfolioServiceServer()
 }
 
@@ -112,6 +164,18 @@ func (UnimplementedPortfolioServiceServer) GetProfit(context.Context, *GetProfit
 }
 func (UnimplementedPortfolioServiceServer) SetPublicAmount(context.Context, *SetPublicAmountRequest) (*SetPublicAmountResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method SetPublicAmount not implemented")
+}
+func (UnimplementedPortfolioServiceServer) GetMyTax(context.Context, *GetMyTaxRequest) (*GetMyTaxResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetMyTax not implemented")
+}
+func (UnimplementedPortfolioServiceServer) GetTaxList(context.Context, *GetTaxListRequest) (*GetTaxListResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetTaxList not implemented")
+}
+func (UnimplementedPortfolioServiceServer) CollectTax(context.Context, *CollectTaxRequest) (*CollectTaxResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method CollectTax not implemented")
+}
+func (UnimplementedPortfolioServiceServer) CollectTaxForUser(context.Context, *CollectTaxForUserRequest) (*CollectTaxForUserResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method CollectTaxForUser not implemented")
 }
 func (UnimplementedPortfolioServiceServer) mustEmbedUnimplementedPortfolioServiceServer() {}
 func (UnimplementedPortfolioServiceServer) testEmbeddedByValue()                          {}
@@ -206,6 +270,78 @@ func _PortfolioService_SetPublicAmount_Handler(srv interface{}, ctx context.Cont
 	return interceptor(ctx, in, info, handler)
 }
 
+func _PortfolioService_GetMyTax_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetMyTaxRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(PortfolioServiceServer).GetMyTax(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: PortfolioService_GetMyTax_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(PortfolioServiceServer).GetMyTax(ctx, req.(*GetMyTaxRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _PortfolioService_GetTaxList_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetTaxListRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(PortfolioServiceServer).GetTaxList(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: PortfolioService_GetTaxList_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(PortfolioServiceServer).GetTaxList(ctx, req.(*GetTaxListRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _PortfolioService_CollectTax_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CollectTaxRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(PortfolioServiceServer).CollectTax(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: PortfolioService_CollectTax_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(PortfolioServiceServer).CollectTax(ctx, req.(*CollectTaxRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _PortfolioService_CollectTaxForUser_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CollectTaxForUserRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(PortfolioServiceServer).CollectTaxForUser(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: PortfolioService_CollectTaxForUser_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(PortfolioServiceServer).CollectTaxForUser(ctx, req.(*CollectTaxForUserRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // PortfolioService_ServiceDesc is the grpc.ServiceDesc for PortfolioService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -228,6 +364,22 @@ var PortfolioService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "SetPublicAmount",
 			Handler:    _PortfolioService_SetPublicAmount_Handler,
+		},
+		{
+			MethodName: "GetMyTax",
+			Handler:    _PortfolioService_GetMyTax_Handler,
+		},
+		{
+			MethodName: "GetTaxList",
+			Handler:    _PortfolioService_GetTaxList_Handler,
+		},
+		{
+			MethodName: "CollectTax",
+			Handler:    _PortfolioService_CollectTax_Handler,
+		},
+		{
+			MethodName: "CollectTaxForUser",
+			Handler:    _PortfolioService_CollectTaxForUser_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/shared/proto/portfolio.proto
+++ b/shared/proto/portfolio.proto
@@ -9,6 +9,10 @@ service PortfolioService {
   rpc GetPortfolio(GetPortfolioRequest)   returns (GetPortfolioResponse);
   rpc GetProfit(GetProfitRequest)         returns (GetProfitResponse);
   rpc SetPublicAmount(SetPublicAmountRequest) returns (SetPublicAmountResponse);
+  rpc GetMyTax(GetMyTaxRequest)                       returns (GetMyTaxResponse);
+  rpc GetTaxList(GetTaxListRequest)                   returns (GetTaxListResponse);
+  rpc CollectTax(CollectTaxRequest)                   returns (CollectTaxResponse);
+  rpc CollectTaxForUser(CollectTaxForUserRequest)     returns (CollectTaxForUserResponse);
 }
 
 // UpdateHolding — called by order-service on each partial fill
@@ -62,3 +66,35 @@ message SetPublicAmountRequest {
   int32 amount     = 3;
 }
 message SetPublicAmountResponse {}
+
+// Tax RPCs (#157)
+message GetMyTaxRequest {
+  int64  user_id   = 1;
+  string user_type = 2;
+}
+message GetMyTaxResponse {
+  double paid_this_year    = 1;
+  double unpaid_this_month = 2;
+}
+
+message GetTaxListRequest {
+  string user_type_filter = 1;
+  string name_filter      = 2;
+}
+message TaxDebtEntry {
+  int64  user_id  = 1;
+  string type     = 2;
+  double debt_rsd = 3;
+}
+message GetTaxListResponse {
+  repeated TaxDebtEntry entries = 1;
+}
+
+message CollectTaxRequest {}
+message CollectTaxResponse {}
+
+message CollectTaxForUserRequest {
+  int64  user_id   = 1;
+  string user_type = 2;
+}
+message CollectTaxForUserResponse {}

--- a/shared/proto/portfolio.proto
+++ b/shared/proto/portfolio.proto
@@ -24,6 +24,7 @@ message UpdateHoldingRequest {
   double price      = 5; // price per unit at fill time
   string direction  = 6; // BUY or SELL
   int64  account_id = 7;
+  string asset_type  = 8; // e.g. STOCK, FOREX_PAIR, FUTURES_CONTRACT, OPTION
 }
 message UpdateHoldingResponse {}
 


### PR DESCRIPTION
## Summary

- **#157** — Capital gains tax calculation + monthly scheduled job in `portfolio-service`:
  - `tax_record` DB table (schema migration included)
  - 15% tax recorded on every profitable SELL via `UpdateHolding`
  - `CollectUnpaid` logic deducts from user accounts (FX-aware: converts RSD → foreign currency via exchange-service middle rate)
  - Monthly scheduled goroutine runs at end-of-month 23:59
  - gRPC methods: `GetMyTax`, `GetTaxList`, `CollectTax`, `CollectTaxForUser`

- **#158** — Tax tracking REST API endpoints via `api-gateway`:
  - `GET /tax` — supervisor: list all users with unpaid tax debt (enriched with full names from employee/client service)
  - `GET /tax/my` / `GET /client/tax/my` — actuary or client: own paid/unpaid tax
  - `POST /tax/collect` — supervisor: trigger collection for all users
  - `POST /tax/collect/:userId` — supervisor: trigger for specific user

## Test plan

- [ ] `cd services/portfolio-service && go test ./...` — all pass
- [ ] `cd services/api-gateway && go test ./handlers/...` — all pass
- [ ] Start stack with `./scripts/dev.sh`
- [ ] Place a SELL order at profit → confirm `tax_record` row created with `is_paid=false`
- [ ] `POST /tax/collect` as supervisor → confirm `is_paid=true` and account balance reduced
- [ ] `GET /tax/my` as actuary → confirm paid/unpaid amounts returned
- [ ] `GET /tax` as supervisor → confirm list with full names

🤖 Generated with [Claude Code](https://claude.com/claude-code)