### PR TITLE
fix: tax collection silently skipping all records

### DIFF
--- a/services/portfolio-service/repository/portfolio_repo.go
+++ b/services/portfolio-service/repository/portfolio_repo.go
@@ -49,16 +49,6 @@ func UpsertHolding(ctx context.Context, db *sql.DB, userID int64, userType strin
 		WHERE user_id = $2 AND user_type = $3 AND listing_id = $4`,
 		qty, uid, userType, listingID,
 	)
-	if err != nil {
-		return buyPrice, err
-	}
-
-	// Remove entry if fully sold
-	_, err = db.ExecContext(ctx, `
-		DELETE FROM portfolio_entry
-		WHERE user_id = $1 AND user_type = $2 AND listing_id = $3 AND amount <= 0`,
-		uid, userType, listingID,
-	)
 	return buyPrice, err
 }
 

--- a/services/portfolio-service/tax/collector.go
+++ b/services/portfolio-service/tax/collector.go
@@ -69,12 +69,16 @@ func CollectUnpaid(ctx context.Context, portfolioDB, accountDB, exchangeDB *sql.
 }
 
 func getAccountForUser(ctx context.Context, db *sql.DB, userID int64, userType string) (int64, error) {
+	uid := userID
+	if userType == "EMPLOYEE" {
+		uid = 0
+	}
 	var accountID int64
 	err := db.QueryRowContext(ctx, `
 		SELECT account_id FROM portfolio_entry
 		WHERE user_id = $1 AND user_type = $2
 		LIMIT 1`,
-		userID, userType,
+		uid, userType,
 	).Scan(&accountID)
 	return accountID, err
 }


### PR DESCRIPTION
Two bugs prevented tax collection from ever deducting anything:
1. UpsertHolding deleted portfolio_entry rows on full sell, leaving getAccountForUser with no row to look up the account_id from. Keep rows at amount=0 instead (GetHoldings already filters amount>0).
2. EMPLOYEE-type portfolio entries are stored under user_id=0 via sharedUserID, but getAccountForUser queried with the real user_id, never finding a match. Apply the same sharedUserID logic in the collector.