### PR TITLE
feat: add InvestFund and WithdrawFund endpoints (#217)

### DIFF
--- a/services/api-gateway/handlers/fund.go
+++ b/services/api-gateway/handlers/fund.go
@@ -41,6 +41,8 @@ func mapFundError(c *gin.Context, err error) {
 		c.JSON(http.StatusConflict, gin.H{"error": status.Convert(err).Message()})
 	case codes.InvalidArgument:
 		c.JSON(http.StatusBadRequest, gin.H{"error": status.Convert(err).Message()})
+	case codes.FailedPrecondition:
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": status.Convert(err).Message()})
 	default:
 		c.JSON(http.StatusInternalServerError, gin.H{"error": status.Convert(err).Message()})
 	}
@@ -237,5 +239,99 @@ func DeleteFund(client pb.FundServiceClient) gin.HandlerFunc {
 			return
 		}
 		c.JSON(http.StatusOK, gin.H{"message": "fund deleted"})
+	}
+}
+
+func InvestFund(client pb.FundServiceClient) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		userID, err := middleware.GetUserIDFromToken(c)
+		if err != nil {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "could not extract identity from token"})
+			return
+		}
+
+		callerRole := middleware.GetCallerRoleFromToken(c)
+		clientType := "CLIENT"
+		if callerRole == "EMPLOYEE" {
+			clientType = "BANK"
+		}
+
+		fundID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid fund id"})
+			return
+		}
+
+		var req struct {
+			SourceAccountId int64   `json:"sourceAccountId" binding:"required"`
+			Amount          float64 `json:"amount"          binding:"required"`
+		}
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 15*time.Second)
+		defer cancel()
+
+		resp, err := client.InvestFund(ctx, &pb.InvestFundRequest{
+			FundId:          fundID,
+			ClientId:        userID,
+			ClientType:      clientType,
+			SourceAccountId: req.SourceAccountId,
+			Amount:          req.Amount,
+		})
+		if err != nil {
+			mapFundError(c, err)
+			return
+		}
+		c.JSON(http.StatusOK, fundToJSON(resp))
+	}
+}
+
+func WithdrawFund(client pb.FundServiceClient) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		userID, err := middleware.GetUserIDFromToken(c)
+		if err != nil {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "could not extract identity from token"})
+			return
+		}
+
+		callerRole := middleware.GetCallerRoleFromToken(c)
+		clientType := "CLIENT"
+		if callerRole == "EMPLOYEE" {
+			clientType = "BANK"
+		}
+
+		fundID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid fund id"})
+			return
+		}
+
+		var req struct {
+			DestinationAccountId int64   `json:"destinationAccountId" binding:"required"`
+			Amount               float64 `json:"amount"`
+		}
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 15*time.Second)
+		defer cancel()
+
+		resp, err := client.WithdrawFund(ctx, &pb.WithdrawFundRequest{
+			FundId:               fundID,
+			ClientId:             userID,
+			ClientType:           clientType,
+			DestinationAccountId: req.DestinationAccountId,
+			Amount:               req.Amount,
+		})
+		if err != nil {
+			mapFundError(c, err)
+			return
+		}
+		c.JSON(http.StatusOK, fundToJSON(resp))
 	}
 }

--- a/services/api-gateway/handlers/fund_test.go
+++ b/services/api-gateway/handlers/fund_test.go
@@ -37,6 +37,8 @@ type stubFundClient struct {
 	getFundFn      func(context.Context, *pb.GetFundRequest, ...grpc.CallOption) (*pb.FundResponse, error)
 	updateFundFn   func(context.Context, *pb.UpdateFundRequest, ...grpc.CallOption) (*pb.FundResponse, error)
 	deleteFundFn   func(context.Context, *pb.DeleteFundRequest, ...grpc.CallOption) (*pb.DeleteFundResponse, error)
+	investFundFn   func(context.Context, *pb.InvestFundRequest, ...grpc.CallOption) (*pb.FundResponse, error)
+	withdrawFundFn func(context.Context, *pb.WithdrawFundRequest, ...grpc.CallOption) (*pb.FundResponse, error)
 }
 
 func (s *stubFundClient) Ping(ctx context.Context, in *pb.PingRequest, opts ...grpc.CallOption) (*pb.PingResponse, error) {
@@ -72,6 +74,18 @@ func (s *stubFundClient) UpdateFund(ctx context.Context, in *pb.UpdateFundReques
 func (s *stubFundClient) DeleteFund(ctx context.Context, in *pb.DeleteFundRequest, opts ...grpc.CallOption) (*pb.DeleteFundResponse, error) {
 	if s.deleteFundFn != nil {
 		return s.deleteFundFn(ctx, in, opts...)
+	}
+	return nil, fmt.Errorf("not implemented")
+}
+func (s *stubFundClient) InvestFund(ctx context.Context, in *pb.InvestFundRequest, opts ...grpc.CallOption) (*pb.FundResponse, error) {
+	if s.investFundFn != nil {
+		return s.investFundFn(ctx, in, opts...)
+	}
+	return nil, fmt.Errorf("not implemented")
+}
+func (s *stubFundClient) WithdrawFund(ctx context.Context, in *pb.WithdrawFundRequest, opts ...grpc.CallOption) (*pb.FundResponse, error) {
+	if s.withdrawFundFn != nil {
+		return s.withdrawFundFn(ctx, in, opts...)
 	}
 	return nil, fmt.Errorf("not implemented")
 }

--- a/services/api-gateway/handlers/otc_test.go
+++ b/services/api-gateway/handlers/otc_test.go
@@ -31,13 +31,13 @@ func makeEmployeeToken() string {
 // ---- stub OTC client ----
 
 type stubOtcClient struct {
-	pingFn                func(context.Context, *pb.PingRequest, ...grpc.CallOption) (*pb.PingResponse, error)
-	createNegotiationFn   func(context.Context, *pb.CreateNegotiationRequest, ...grpc.CallOption) (*pb.NegotiationResponse, error)
-	listNegotiationsFn    func(context.Context, *pb.ListNegotiationsRequest, ...grpc.CallOption) (*pb.ListNegotiationsResponse, error)
-	getNegotiationFn      func(context.Context, *pb.GetNegotiationRequest, ...grpc.CallOption) (*pb.NegotiationResponse, error)
-	counterOfferFn        func(context.Context, *pb.CounterOfferRequest, ...grpc.CallOption) (*pb.NegotiationResponse, error)
-	acceptNegotiationFn   func(context.Context, *pb.AcceptNegotiationRequest, ...grpc.CallOption) (*pb.NegotiationResponse, error)
-	rejectNegotiationFn   func(context.Context, *pb.RejectNegotiationRequest, ...grpc.CallOption) (*pb.NegotiationResponse, error)
+	pingFn              func(context.Context, *pb.PingRequest, ...grpc.CallOption) (*pb.PingResponse, error)
+	createNegotiationFn func(context.Context, *pb.CreateNegotiationRequest, ...grpc.CallOption) (*pb.NegotiationResponse, error)
+	listNegotiationsFn  func(context.Context, *pb.ListNegotiationsRequest, ...grpc.CallOption) (*pb.ListNegotiationsResponse, error)
+	getNegotiationFn    func(context.Context, *pb.GetNegotiationRequest, ...grpc.CallOption) (*pb.NegotiationResponse, error)
+	counterOfferFn      func(context.Context, *pb.CounterOfferRequest, ...grpc.CallOption) (*pb.NegotiationResponse, error)
+	acceptNegotiationFn func(context.Context, *pb.AcceptNegotiationRequest, ...grpc.CallOption) (*pb.NegotiationResponse, error)
+	rejectNegotiationFn func(context.Context, *pb.RejectNegotiationRequest, ...grpc.CallOption) (*pb.NegotiationResponse, error)
 }
 
 func (s *stubOtcClient) Ping(ctx context.Context, in *pb.PingRequest, opts ...grpc.CallOption) (*pb.PingResponse, error) {

--- a/services/api-gateway/main.go
+++ b/services/api-gateway/main.go
@@ -243,6 +243,8 @@ func main() {
 	r.GET("/investment/funds/:id", middleware.RequireRole("CLIENT", "EMPLOYEE"), handlers.GetFund(fundClient))
 	r.PUT("/investment/funds/:id", middleware.RequireRole("SUPERVISOR"), handlers.UpdateFund(fundClient))
 	r.DELETE("/investment/funds/:id", middleware.RequireRole("SUPERVISOR"), handlers.DeleteFund(fundClient))
+	r.POST("/investment/funds/:id/invest", middleware.RequireRole("CLIENT", "EMPLOYEE"), handlers.InvestFund(fundClient))
+	r.POST("/investment/funds/:id/withdraw", middleware.RequireRole("CLIENT", "EMPLOYEE"), handlers.WithdrawFund(fundClient))
 
 	r.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 	if err := r.Run(":8083"); err != nil {

--- a/services/fund-service/handlers/grpc_server.go
+++ b/services/fund-service/handlers/grpc_server.go
@@ -216,6 +216,220 @@ func (s *FundServer) fetchFundByID(ctx context.Context, id int64, includeAccount
 	return &f, nil
 }
 
+func (s *FundServer) InvestFund(ctx context.Context, req *pb.InvestFundRequest) (*pb.FundResponse, error) {
+	if req.Amount <= 0 {
+		return nil, status.Error(codes.InvalidArgument, "amount must be greater than 0")
+	}
+
+	var minimumContribution float64
+	var active bool
+	err := s.DB.QueryRowContext(ctx,
+		`SELECT minimum_contribution, active FROM investment_funds WHERE id = $1`, req.FundId,
+	).Scan(&minimumContribution, &active)
+	if err == sql.ErrNoRows {
+		return nil, status.Error(codes.NotFound, "fund not found")
+	} else if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to fetch fund: %v", err)
+	}
+	if !active {
+		return nil, status.Error(codes.NotFound, "fund not found")
+	}
+	if req.Amount < minimumContribution {
+		return nil, status.Errorf(codes.InvalidArgument, "amount %.2f is below minimum contribution %.2f", req.Amount, minimumContribution)
+	}
+
+	var availableBalance float64
+	err = s.AccountDB.QueryRowContext(ctx,
+		`SELECT available_balance FROM accounts WHERE id = $1`, req.SourceAccountId,
+	).Scan(&availableBalance)
+	if err == sql.ErrNoRows {
+		return nil, status.Error(codes.NotFound, "source account not found")
+	} else if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to fetch account: %v", err)
+	}
+	if availableBalance < req.Amount {
+		return nil, status.Error(codes.FailedPrecondition, "insufficient account balance")
+	}
+
+	_, err = s.AccountDB.ExecContext(ctx,
+		`UPDATE accounts SET balance = balance - $1, available_balance = available_balance - $1 WHERE id = $2`,
+		req.Amount, req.SourceAccountId,
+	)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to debit account: %v", err)
+	}
+
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		// compensate
+		_, _ = s.AccountDB.ExecContext(ctx,
+			`UPDATE accounts SET balance = balance + $1, available_balance = available_balance + $1 WHERE id = $2`,
+			req.Amount, req.SourceAccountId,
+		)
+		return nil, status.Errorf(codes.Internal, "failed to begin transaction: %v", err)
+	}
+
+	_, err = tx.ExecContext(ctx,
+		`UPDATE investment_funds SET liquid_assets = liquid_assets + $1 WHERE id = $2`,
+		req.Amount, req.FundId,
+	)
+	if err != nil {
+		_ = tx.Rollback()
+		_, _ = s.AccountDB.ExecContext(ctx,
+			`UPDATE accounts SET balance = balance + $1, available_balance = available_balance + $1 WHERE id = $2`,
+			req.Amount, req.SourceAccountId,
+		)
+		return nil, status.Errorf(codes.Internal, "failed to update fund liquid assets: %v", err)
+	}
+
+	_, err = tx.ExecContext(ctx, `
+		INSERT INTO client_fund_positions (client_id, client_type, fund_id, total_invested_amount)
+		VALUES ($1, $2, $3, $4)
+		ON CONFLICT (client_id, client_type, fund_id) DO UPDATE
+		SET total_invested_amount = client_fund_positions.total_invested_amount + EXCLUDED.total_invested_amount,
+		    last_modified_at = NOW()`,
+		req.ClientId, req.ClientType, req.FundId, req.Amount,
+	)
+	if err != nil {
+		_ = tx.Rollback()
+		_, _ = s.AccountDB.ExecContext(ctx,
+			`UPDATE accounts SET balance = balance + $1, available_balance = available_balance + $1 WHERE id = $2`,
+			req.Amount, req.SourceAccountId,
+		)
+		return nil, status.Errorf(codes.Internal, "failed to upsert position: %v", err)
+	}
+
+	_, err = tx.ExecContext(ctx,
+		`INSERT INTO client_fund_transactions (client_id, client_type, fund_id, amount, is_inflow, status) VALUES ($1, $2, $3, $4, true, 'COMPLETED')`,
+		req.ClientId, req.ClientType, req.FundId, req.Amount,
+	)
+	if err != nil {
+		_ = tx.Rollback()
+		_, _ = s.AccountDB.ExecContext(ctx,
+			`UPDATE accounts SET balance = balance + $1, available_balance = available_balance + $1 WHERE id = $2`,
+			req.Amount, req.SourceAccountId,
+		)
+		return nil, status.Errorf(codes.Internal, "failed to insert transaction: %v", err)
+	}
+
+	if err = tx.Commit(); err != nil {
+		_, _ = s.AccountDB.ExecContext(ctx,
+			`UPDATE accounts SET balance = balance + $1, available_balance = available_balance + $1 WHERE id = $2`,
+			req.Amount, req.SourceAccountId,
+		)
+		return nil, status.Errorf(codes.Internal, "failed to commit: %v", err)
+	}
+
+	return s.fetchFundByID(ctx, req.FundId, true)
+}
+
+func (s *FundServer) WithdrawFund(ctx context.Context, req *pb.WithdrawFundRequest) (*pb.FundResponse, error) {
+	var liquidAssets float64
+	var active bool
+	err := s.DB.QueryRowContext(ctx,
+		`SELECT liquid_assets, active FROM investment_funds WHERE id = $1`, req.FundId,
+	).Scan(&liquidAssets, &active)
+	if err == sql.ErrNoRows {
+		return nil, status.Error(codes.NotFound, "fund not found")
+	} else if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to fetch fund: %v", err)
+	}
+	if !active {
+		return nil, status.Error(codes.NotFound, "fund not found")
+	}
+
+	var positionAmount float64
+	err = s.DB.QueryRowContext(ctx,
+		`SELECT total_invested_amount FROM client_fund_positions WHERE fund_id = $1 AND client_id = $2 AND client_type = $3`,
+		req.FundId, req.ClientId, req.ClientType,
+	).Scan(&positionAmount)
+	if err == sql.ErrNoRows {
+		return nil, status.Error(codes.NotFound, "no position in this fund")
+	} else if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to fetch position: %v", err)
+	}
+
+	amount := req.Amount
+	if amount == 0 {
+		amount = positionAmount
+	}
+	if amount <= 0 {
+		return nil, status.Error(codes.InvalidArgument, "nothing to withdraw")
+	}
+	if amount > positionAmount {
+		return nil, status.Errorf(codes.InvalidArgument, "withdrawal amount %.2f exceeds position %.2f", amount, positionAmount)
+	}
+	if amount > liquidAssets {
+		return nil, status.Error(codes.FailedPrecondition, "insufficient fund liquidity")
+	}
+
+	_, err = s.AccountDB.ExecContext(ctx,
+		`UPDATE accounts SET balance = balance + $1, available_balance = available_balance + $1 WHERE id = $2`,
+		amount, req.DestinationAccountId,
+	)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to credit account: %v", err)
+	}
+
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		_, _ = s.AccountDB.ExecContext(ctx,
+			`UPDATE accounts SET balance = balance - $1, available_balance = available_balance - $1 WHERE id = $2`,
+			amount, req.DestinationAccountId,
+		)
+		return nil, status.Errorf(codes.Internal, "failed to begin transaction: %v", err)
+	}
+
+	_, err = tx.ExecContext(ctx,
+		`UPDATE investment_funds SET liquid_assets = liquid_assets - $1 WHERE id = $2`,
+		amount, req.FundId,
+	)
+	if err != nil {
+		_ = tx.Rollback()
+		_, _ = s.AccountDB.ExecContext(ctx,
+			`UPDATE accounts SET balance = balance - $1, available_balance = available_balance - $1 WHERE id = $2`,
+			amount, req.DestinationAccountId,
+		)
+		return nil, status.Errorf(codes.Internal, "failed to update fund liquid assets: %v", err)
+	}
+
+	_, err = tx.ExecContext(ctx,
+		`UPDATE client_fund_positions SET total_invested_amount = total_invested_amount - $1, last_modified_at = NOW() WHERE fund_id = $2 AND client_id = $3 AND client_type = $4`,
+		amount, req.FundId, req.ClientId, req.ClientType,
+	)
+	if err != nil {
+		_ = tx.Rollback()
+		_, _ = s.AccountDB.ExecContext(ctx,
+			`UPDATE accounts SET balance = balance - $1, available_balance = available_balance - $1 WHERE id = $2`,
+			amount, req.DestinationAccountId,
+		)
+		return nil, status.Errorf(codes.Internal, "failed to update position: %v", err)
+	}
+
+	_, err = tx.ExecContext(ctx,
+		`INSERT INTO client_fund_transactions (client_id, client_type, fund_id, amount, is_inflow, status) VALUES ($1, $2, $3, $4, false, 'COMPLETED')`,
+		req.ClientId, req.ClientType, req.FundId, amount,
+	)
+	if err != nil {
+		_ = tx.Rollback()
+		_, _ = s.AccountDB.ExecContext(ctx,
+			`UPDATE accounts SET balance = balance - $1, available_balance = available_balance - $1 WHERE id = $2`,
+			amount, req.DestinationAccountId,
+		)
+		return nil, status.Errorf(codes.Internal, "failed to insert transaction: %v", err)
+	}
+
+	if err = tx.Commit(); err != nil {
+		_, _ = s.AccountDB.ExecContext(ctx,
+			`UPDATE accounts SET balance = balance - $1, available_balance = available_balance - $1 WHERE id = $2`,
+			amount, req.DestinationAccountId,
+		)
+		return nil, status.Errorf(codes.Internal, "failed to commit: %v", err)
+	}
+
+	return s.fetchFundByID(ctx, req.FundId, true)
+}
+
 // isUniqueViolation checks if the error is a PostgreSQL unique constraint violation (error code 23505).
 func isUniqueViolation(err error) bool {
 	return strings.Contains(err.Error(), "23505") || strings.Contains(err.Error(), "unique constraint")

--- a/shared/pb/fund/fund.pb.go
+++ b/shared/pb/fund/fund.pb.go
@@ -605,6 +605,158 @@ func (x *ListFundsResponse) GetFunds() []*FundResponse {
 	return nil
 }
 
+type InvestFundRequest struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	FundId          int64                  `protobuf:"varint,1,opt,name=fund_id,json=fundId,proto3" json:"fund_id,omitempty"`
+	ClientId        int64                  `protobuf:"varint,2,opt,name=client_id,json=clientId,proto3" json:"client_id,omitempty"`
+	ClientType      string                 `protobuf:"bytes,3,opt,name=client_type,json=clientType,proto3" json:"client_type,omitempty"` // "CLIENT" or "BANK"
+	SourceAccountId int64                  `protobuf:"varint,4,opt,name=source_account_id,json=sourceAccountId,proto3" json:"source_account_id,omitempty"`
+	Amount          float64                `protobuf:"fixed64,5,opt,name=amount,proto3" json:"amount,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *InvestFundRequest) Reset() {
+	*x = InvestFundRequest{}
+	mi := &file_fund_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InvestFundRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InvestFundRequest) ProtoMessage() {}
+
+func (x *InvestFundRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_fund_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InvestFundRequest.ProtoReflect.Descriptor instead.
+func (*InvestFundRequest) Descriptor() ([]byte, []int) {
+	return file_fund_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *InvestFundRequest) GetFundId() int64 {
+	if x != nil {
+		return x.FundId
+	}
+	return 0
+}
+
+func (x *InvestFundRequest) GetClientId() int64 {
+	if x != nil {
+		return x.ClientId
+	}
+	return 0
+}
+
+func (x *InvestFundRequest) GetClientType() string {
+	if x != nil {
+		return x.ClientType
+	}
+	return ""
+}
+
+func (x *InvestFundRequest) GetSourceAccountId() int64 {
+	if x != nil {
+		return x.SourceAccountId
+	}
+	return 0
+}
+
+func (x *InvestFundRequest) GetAmount() float64 {
+	if x != nil {
+		return x.Amount
+	}
+	return 0
+}
+
+type WithdrawFundRequest struct {
+	state                protoimpl.MessageState `protogen:"open.v1"`
+	FundId               int64                  `protobuf:"varint,1,opt,name=fund_id,json=fundId,proto3" json:"fund_id,omitempty"`
+	ClientId             int64                  `protobuf:"varint,2,opt,name=client_id,json=clientId,proto3" json:"client_id,omitempty"`
+	ClientType           string                 `protobuf:"bytes,3,opt,name=client_type,json=clientType,proto3" json:"client_type,omitempty"`
+	DestinationAccountId int64                  `protobuf:"varint,4,opt,name=destination_account_id,json=destinationAccountId,proto3" json:"destination_account_id,omitempty"`
+	Amount               float64                `protobuf:"fixed64,5,opt,name=amount,proto3" json:"amount,omitempty"` // 0 = full position
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
+}
+
+func (x *WithdrawFundRequest) Reset() {
+	*x = WithdrawFundRequest{}
+	mi := &file_fund_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WithdrawFundRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WithdrawFundRequest) ProtoMessage() {}
+
+func (x *WithdrawFundRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_fund_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WithdrawFundRequest.ProtoReflect.Descriptor instead.
+func (*WithdrawFundRequest) Descriptor() ([]byte, []int) {
+	return file_fund_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *WithdrawFundRequest) GetFundId() int64 {
+	if x != nil {
+		return x.FundId
+	}
+	return 0
+}
+
+func (x *WithdrawFundRequest) GetClientId() int64 {
+	if x != nil {
+		return x.ClientId
+	}
+	return 0
+}
+
+func (x *WithdrawFundRequest) GetClientType() string {
+	if x != nil {
+		return x.ClientType
+	}
+	return ""
+}
+
+func (x *WithdrawFundRequest) GetDestinationAccountId() int64 {
+	if x != nil {
+		return x.DestinationAccountId
+	}
+	return 0
+}
+
+func (x *WithdrawFundRequest) GetAmount() float64 {
+	if x != nil {
+		return x.Amount
+	}
+	return 0
+}
+
 var File_fund_proto protoreflect.FileDescriptor
 
 const file_fund_proto_rawDesc = "" +
@@ -655,7 +807,21 @@ const file_fund_proto_rawDesc = "" +
 	"\n" +
 	"account_id\x18\r \x01(\x03R\taccountId\"=\n" +
 	"\x11ListFundsResponse\x12(\n" +
-	"\x05funds\x18\x01 \x03(\v2\x12.fund.FundResponseR\x05funds2\xe6\x02\n" +
+	"\x05funds\x18\x01 \x03(\v2\x12.fund.FundResponseR\x05funds\"\xae\x01\n" +
+	"\x11InvestFundRequest\x12\x17\n" +
+	"\afund_id\x18\x01 \x01(\x03R\x06fundId\x12\x1b\n" +
+	"\tclient_id\x18\x02 \x01(\x03R\bclientId\x12\x1f\n" +
+	"\vclient_type\x18\x03 \x01(\tR\n" +
+	"clientType\x12*\n" +
+	"\x11source_account_id\x18\x04 \x01(\x03R\x0fsourceAccountId\x12\x16\n" +
+	"\x06amount\x18\x05 \x01(\x01R\x06amount\"\xba\x01\n" +
+	"\x13WithdrawFundRequest\x12\x17\n" +
+	"\afund_id\x18\x01 \x01(\x03R\x06fundId\x12\x1b\n" +
+	"\tclient_id\x18\x02 \x01(\x03R\bclientId\x12\x1f\n" +
+	"\vclient_type\x18\x03 \x01(\tR\n" +
+	"clientType\x124\n" +
+	"\x16destination_account_id\x18\x04 \x01(\x03R\x14destinationAccountId\x12\x16\n" +
+	"\x06amount\x18\x05 \x01(\x01R\x06amount2\xe0\x03\n" +
 	"\vFundService\x12-\n" +
 	"\x04Ping\x12\x11.fund.PingRequest\x1a\x12.fund.PingResponse\x129\n" +
 	"\n" +
@@ -665,7 +831,10 @@ const file_fund_proto_rawDesc = "" +
 	"\n" +
 	"UpdateFund\x12\x17.fund.UpdateFundRequest\x1a\x12.fund.FundResponse\x12?\n" +
 	"\n" +
-	"DeleteFund\x12\x17.fund.DeleteFundRequest\x1a\x18.fund.DeleteFundResponseB9Z7github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/fundb\x06proto3"
+	"DeleteFund\x12\x17.fund.DeleteFundRequest\x1a\x18.fund.DeleteFundResponse\x129\n" +
+	"\n" +
+	"InvestFund\x12\x17.fund.InvestFundRequest\x1a\x12.fund.FundResponse\x12=\n" +
+	"\fWithdrawFund\x12\x19.fund.WithdrawFundRequest\x1a\x12.fund.FundResponseB9Z7github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/fundb\x06proto3"
 
 var (
 	file_fund_proto_rawDescOnce sync.Once
@@ -679,38 +848,44 @@ func file_fund_proto_rawDescGZIP() []byte {
 	return file_fund_proto_rawDescData
 }
 
-var file_fund_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
+var file_fund_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
 var file_fund_proto_goTypes = []any{
-	(*PingRequest)(nil),        // 0: fund.PingRequest
-	(*PingResponse)(nil),       // 1: fund.PingResponse
-	(*CreateFundRequest)(nil),  // 2: fund.CreateFundRequest
-	(*UpdateFundRequest)(nil),  // 3: fund.UpdateFundRequest
-	(*DeleteFundRequest)(nil),  // 4: fund.DeleteFundRequest
-	(*DeleteFundResponse)(nil), // 5: fund.DeleteFundResponse
-	(*ListFundsRequest)(nil),   // 6: fund.ListFundsRequest
-	(*GetFundRequest)(nil),     // 7: fund.GetFundRequest
-	(*FundResponse)(nil),       // 8: fund.FundResponse
-	(*ListFundsResponse)(nil),  // 9: fund.ListFundsResponse
+	(*PingRequest)(nil),         // 0: fund.PingRequest
+	(*PingResponse)(nil),        // 1: fund.PingResponse
+	(*CreateFundRequest)(nil),   // 2: fund.CreateFundRequest
+	(*UpdateFundRequest)(nil),   // 3: fund.UpdateFundRequest
+	(*DeleteFundRequest)(nil),   // 4: fund.DeleteFundRequest
+	(*DeleteFundResponse)(nil),  // 5: fund.DeleteFundResponse
+	(*ListFundsRequest)(nil),    // 6: fund.ListFundsRequest
+	(*GetFundRequest)(nil),      // 7: fund.GetFundRequest
+	(*FundResponse)(nil),        // 8: fund.FundResponse
+	(*ListFundsResponse)(nil),   // 9: fund.ListFundsResponse
+	(*InvestFundRequest)(nil),   // 10: fund.InvestFundRequest
+	(*WithdrawFundRequest)(nil), // 11: fund.WithdrawFundRequest
 }
 var file_fund_proto_depIdxs = []int32{
-	8, // 0: fund.ListFundsResponse.funds:type_name -> fund.FundResponse
-	0, // 1: fund.FundService.Ping:input_type -> fund.PingRequest
-	2, // 2: fund.FundService.CreateFund:input_type -> fund.CreateFundRequest
-	6, // 3: fund.FundService.ListFunds:input_type -> fund.ListFundsRequest
-	7, // 4: fund.FundService.GetFund:input_type -> fund.GetFundRequest
-	3, // 5: fund.FundService.UpdateFund:input_type -> fund.UpdateFundRequest
-	4, // 6: fund.FundService.DeleteFund:input_type -> fund.DeleteFundRequest
-	1, // 7: fund.FundService.Ping:output_type -> fund.PingResponse
-	8, // 8: fund.FundService.CreateFund:output_type -> fund.FundResponse
-	9, // 9: fund.FundService.ListFunds:output_type -> fund.ListFundsResponse
-	8, // 10: fund.FundService.GetFund:output_type -> fund.FundResponse
-	8, // 11: fund.FundService.UpdateFund:output_type -> fund.FundResponse
-	5, // 12: fund.FundService.DeleteFund:output_type -> fund.DeleteFundResponse
-	7, // [7:13] is the sub-list for method output_type
-	1, // [1:7] is the sub-list for method input_type
-	1, // [1:1] is the sub-list for extension type_name
-	1, // [1:1] is the sub-list for extension extendee
-	0, // [0:1] is the sub-list for field type_name
+	8,  // 0: fund.ListFundsResponse.funds:type_name -> fund.FundResponse
+	0,  // 1: fund.FundService.Ping:input_type -> fund.PingRequest
+	2,  // 2: fund.FundService.CreateFund:input_type -> fund.CreateFundRequest
+	6,  // 3: fund.FundService.ListFunds:input_type -> fund.ListFundsRequest
+	7,  // 4: fund.FundService.GetFund:input_type -> fund.GetFundRequest
+	3,  // 5: fund.FundService.UpdateFund:input_type -> fund.UpdateFundRequest
+	4,  // 6: fund.FundService.DeleteFund:input_type -> fund.DeleteFundRequest
+	10, // 7: fund.FundService.InvestFund:input_type -> fund.InvestFundRequest
+	11, // 8: fund.FundService.WithdrawFund:input_type -> fund.WithdrawFundRequest
+	1,  // 9: fund.FundService.Ping:output_type -> fund.PingResponse
+	8,  // 10: fund.FundService.CreateFund:output_type -> fund.FundResponse
+	9,  // 11: fund.FundService.ListFunds:output_type -> fund.ListFundsResponse
+	8,  // 12: fund.FundService.GetFund:output_type -> fund.FundResponse
+	8,  // 13: fund.FundService.UpdateFund:output_type -> fund.FundResponse
+	5,  // 14: fund.FundService.DeleteFund:output_type -> fund.DeleteFundResponse
+	8,  // 15: fund.FundService.InvestFund:output_type -> fund.FundResponse
+	8,  // 16: fund.FundService.WithdrawFund:output_type -> fund.FundResponse
+	9,  // [9:17] is the sub-list for method output_type
+	1,  // [1:9] is the sub-list for method input_type
+	1,  // [1:1] is the sub-list for extension type_name
+	1,  // [1:1] is the sub-list for extension extendee
+	0,  // [0:1] is the sub-list for field type_name
 }
 
 func init() { file_fund_proto_init() }
@@ -724,7 +899,7 @@ func file_fund_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_fund_proto_rawDesc), len(file_fund_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   10,
+			NumMessages:   12,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/shared/pb/fund/fund_grpc.pb.go
+++ b/shared/pb/fund/fund_grpc.pb.go
@@ -19,12 +19,14 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	FundService_Ping_FullMethodName       = "/fund.FundService/Ping"
-	FundService_CreateFund_FullMethodName = "/fund.FundService/CreateFund"
-	FundService_ListFunds_FullMethodName  = "/fund.FundService/ListFunds"
-	FundService_GetFund_FullMethodName    = "/fund.FundService/GetFund"
-	FundService_UpdateFund_FullMethodName = "/fund.FundService/UpdateFund"
-	FundService_DeleteFund_FullMethodName = "/fund.FundService/DeleteFund"
+	FundService_Ping_FullMethodName         = "/fund.FundService/Ping"
+	FundService_CreateFund_FullMethodName   = "/fund.FundService/CreateFund"
+	FundService_ListFunds_FullMethodName    = "/fund.FundService/ListFunds"
+	FundService_GetFund_FullMethodName      = "/fund.FundService/GetFund"
+	FundService_UpdateFund_FullMethodName   = "/fund.FundService/UpdateFund"
+	FundService_DeleteFund_FullMethodName   = "/fund.FundService/DeleteFund"
+	FundService_InvestFund_FullMethodName   = "/fund.FundService/InvestFund"
+	FundService_WithdrawFund_FullMethodName = "/fund.FundService/WithdrawFund"
 )
 
 // FundServiceClient is the client API for FundService service.
@@ -37,6 +39,8 @@ type FundServiceClient interface {
 	GetFund(ctx context.Context, in *GetFundRequest, opts ...grpc.CallOption) (*FundResponse, error)
 	UpdateFund(ctx context.Context, in *UpdateFundRequest, opts ...grpc.CallOption) (*FundResponse, error)
 	DeleteFund(ctx context.Context, in *DeleteFundRequest, opts ...grpc.CallOption) (*DeleteFundResponse, error)
+	InvestFund(ctx context.Context, in *InvestFundRequest, opts ...grpc.CallOption) (*FundResponse, error)
+	WithdrawFund(ctx context.Context, in *WithdrawFundRequest, opts ...grpc.CallOption) (*FundResponse, error)
 }
 
 type fundServiceClient struct {
@@ -107,6 +111,26 @@ func (c *fundServiceClient) DeleteFund(ctx context.Context, in *DeleteFundReques
 	return out, nil
 }
 
+func (c *fundServiceClient) InvestFund(ctx context.Context, in *InvestFundRequest, opts ...grpc.CallOption) (*FundResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(FundResponse)
+	err := c.cc.Invoke(ctx, FundService_InvestFund_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *fundServiceClient) WithdrawFund(ctx context.Context, in *WithdrawFundRequest, opts ...grpc.CallOption) (*FundResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(FundResponse)
+	err := c.cc.Invoke(ctx, FundService_WithdrawFund_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // FundServiceServer is the server API for FundService service.
 // All implementations must embed UnimplementedFundServiceServer
 // for forward compatibility.
@@ -117,6 +141,8 @@ type FundServiceServer interface {
 	GetFund(context.Context, *GetFundRequest) (*FundResponse, error)
 	UpdateFund(context.Context, *UpdateFundRequest) (*FundResponse, error)
 	DeleteFund(context.Context, *DeleteFundRequest) (*DeleteFundResponse, error)
+	InvestFund(context.Context, *InvestFundRequest) (*FundResponse, error)
+	WithdrawFund(context.Context, *WithdrawFundRequest) (*FundResponse, error)
 	mustEmbedUnimplementedFundServiceServer()
 }
 
@@ -144,6 +170,12 @@ func (UnimplementedFundServiceServer) UpdateFund(context.Context, *UpdateFundReq
 }
 func (UnimplementedFundServiceServer) DeleteFund(context.Context, *DeleteFundRequest) (*DeleteFundResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method DeleteFund not implemented")
+}
+func (UnimplementedFundServiceServer) InvestFund(context.Context, *InvestFundRequest) (*FundResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method InvestFund not implemented")
+}
+func (UnimplementedFundServiceServer) WithdrawFund(context.Context, *WithdrawFundRequest) (*FundResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method WithdrawFund not implemented")
 }
 func (UnimplementedFundServiceServer) mustEmbedUnimplementedFundServiceServer() {}
 func (UnimplementedFundServiceServer) testEmbeddedByValue()                     {}
@@ -274,6 +306,42 @@ func _FundService_DeleteFund_Handler(srv interface{}, ctx context.Context, dec f
 	return interceptor(ctx, in, info, handler)
 }
 
+func _FundService_InvestFund_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(InvestFundRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(FundServiceServer).InvestFund(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: FundService_InvestFund_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(FundServiceServer).InvestFund(ctx, req.(*InvestFundRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _FundService_WithdrawFund_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(WithdrawFundRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(FundServiceServer).WithdrawFund(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: FundService_WithdrawFund_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(FundServiceServer).WithdrawFund(ctx, req.(*WithdrawFundRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // FundService_ServiceDesc is the grpc.ServiceDesc for FundService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -304,6 +372,14 @@ var FundService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "DeleteFund",
 			Handler:    _FundService_DeleteFund_Handler,
+		},
+		{
+			MethodName: "InvestFund",
+			Handler:    _FundService_InvestFund_Handler,
+		},
+		{
+			MethodName: "WithdrawFund",
+			Handler:    _FundService_WithdrawFund_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/shared/proto/fund.proto
+++ b/shared/proto/fund.proto
@@ -9,6 +9,8 @@ service FundService {
   rpc GetFund(GetFundRequest) returns (FundResponse);
   rpc UpdateFund(UpdateFundRequest) returns (FundResponse);
   rpc DeleteFund(DeleteFundRequest) returns (DeleteFundResponse);
+  rpc InvestFund(InvestFundRequest) returns (FundResponse);
+  rpc WithdrawFund(WithdrawFundRequest) returns (FundResponse);
 }
 
 message PingRequest {}
@@ -62,4 +64,20 @@ message FundResponse {
 
 message ListFundsResponse {
   repeated FundResponse funds = 1;
+}
+
+message InvestFundRequest {
+  int64  fund_id           = 1;
+  int64  client_id         = 2;
+  string client_type       = 3; // "CLIENT" or "BANK"
+  int64  source_account_id = 4;
+  double amount            = 5;
+}
+
+message WithdrawFundRequest {
+  int64  fund_id                = 1;
+  int64  client_id              = 2;
+  string client_type            = 3;
+  int64  destination_account_id = 4;
+  double amount                 = 5; // 0 = full position
 }


### PR DESCRIPTION
## Summary
- Add `InvestFund` and `WithdrawFund` RPCs to `fund.proto`; regenerate pb bindings
- `InvestFund`: validates minimum contribution and account balance, debits source account, upserts `client_fund_positions`, inserts transaction record — compensates on failure
- `WithdrawFund`: validates position exists and fund has sufficient liquidity, credits destination account, updates position and `liquid_assets` — compensates on failure
- Add `POST /investment/funds/:id/invest` and `POST /investment/funds/:id/withdraw` to api-gateway (CLIENT + EMPLOYEE roles)
- Map `FailedPrecondition` gRPC code to 422 in `mapFundError`

Closes #217

## Test plan
- [ ] POST `/investment/funds/:id/invest` as client → position created, `liquid_assets` increased
- [ ] POST `/investment/funds/:id/invest` with `amount < minimum_contribution` → 400
- [ ] POST `/investment/funds/:id/invest` with insufficient balance → 422
- [ ] POST `/investment/funds/:id/withdraw` with `amount: 0` → full position withdrawn
- [ ] POST `/investment/funds/:id/withdraw` with amount exceeding position → 400
- [ ] POST `/investment/funds/:id/withdraw` when `liquid_assets` insufficient → 422

🤖 Generated with [Claude Code](https://claude.com/claude-code)