### PR TITLE
fix: fund account subtype tagging and CreateFund 500 fix

### DIFF
--- a/services/account-service/handlers/grpc_server.go
+++ b/services/account-service/handlers/grpc_server.go
@@ -254,17 +254,21 @@ func accountTypeCode(accountType string) string {
 }
 
 func (s *AccountServer) CreateAccount(ctx context.Context, req *pb.CreateAccountRequest) (*pb.CreateAccountResponse, error) {
-	// 1. Validate client exists and fetch contact info for email
+	// 1. Validate client exists and fetch contact info for email.
+	// Skip for ClientId == 0 (BANK/fund accounts that have no client owner).
 	var clientID int64
 	var clientEmail, clientFirstName string
-	err := s.ClientDB.QueryRowContext(ctx,
-		`SELECT id, email, first_name FROM clients WHERE id = $1`, req.ClientId).
-		Scan(&clientID, &clientEmail, &clientFirstName)
-	if err == sql.ErrNoRows {
-		return nil, status.Errorf(codes.NotFound, "client with id %d not found", req.ClientId)
-	}
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to verify client: %v", err)
+	var err error
+	if req.ClientId != 0 {
+		err = s.ClientDB.QueryRowContext(ctx,
+			`SELECT id, email, first_name FROM clients WHERE id = $1`, req.ClientId).
+			Scan(&clientID, &clientEmail, &clientFirstName)
+		if err == sql.ErrNoRows {
+			return nil, status.Errorf(codes.NotFound, "client with id %d not found", req.ClientId)
+		}
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to verify client: %v", err)
+		}
 	}
 
 	// 2. Validate currency exists and get its id
@@ -401,7 +405,7 @@ func (s *AccountServer) GetBankAccounts(ctx context.Context, _ *pb.GetBankAccoun
 	rows, err := s.DB.QueryContext(ctx, `
 		SELECT id, account_number, account_name, balance, available_balance, currency_id
 		FROM accounts
-		WHERE owner_id = 0 AND account_type = 'BANK'
+		WHERE owner_id = 0 AND account_type = 'BANK' AND COALESCE(account_subtype, '') != 'FUND'
 		ORDER BY currency_id`)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to query bank accounts: %v", err)

--- a/services/fund-service/handlers/grpc_server.go
+++ b/services/fund-service/handlers/grpc_server.go
@@ -36,6 +36,7 @@ func (s *FundServer) CreateFund(ctx context.Context, req *pb.CreateFundRequest) 
 	accountResp, err := s.AccountClient.CreateAccount(ctx, &pb_account.CreateAccountRequest{
 		ClientId:       0,
 		AccountType:    "BANK",
+		AccountSubtype: "FUND",
 		CurrencyCode:   "RSD",
 		InitialBalance: 0,
 		AccountName:    "Fund: " + req.Name,


### PR DESCRIPTION
## Summary
- Fixed HTTP 500 on Create Fund: `CreateAccount` was failing when `ClientId == 0` (bank/fund accounts have no client owner) — now skips the client lookup for `ClientId == 0`
- Fund bank accounts are now tagged with `account_subtype = 'FUND'` at creation time
- `GET /api/bank-accounts` now excludes `account_subtype = 'FUND'` accounts so fund accounts don't appear as options in deposit/withdraw dropdowns (would be circular)

## Test plan
- [ ] Create a fund → succeeds, redirects to fund list
- [ ] Supervisor → Deposit modal → fund's own account not in dropdown
- [ ] Supervisor → Withdraw modal → fund's own account not in dropdown
- [ ] Deposit and withdraw complete successfully with a valid bank account

🤖 Generated with [Claude Code](https://claude.com/claude-code)