### PR TITLE
BE-S2-04 InvestmentFund — GET /client/funds/positions

### DIFF
--- a/services/api-gateway/handlers/fund.go
+++ b/services/api-gateway/handlers/fund.go
@@ -462,3 +462,41 @@ func BankRedeemFund(client pb.FundServiceClient) gin.HandlerFunc {
 		c.JSON(http.StatusOK, fundToJSON(resp))
 	}
 }
+
+func GetMyPositions(client pb.FundServiceClient) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		userID, err := middleware.GetUserIDFromToken(c)
+		if err != nil {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "could not extract identity from token"})
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 10*time.Second)
+		defer cancel()
+
+		resp, err := client.GetMyPositions(ctx, &pb.GetMyPositionsRequest{
+			ClientId:   userID,
+			ClientType: "CLIENT",
+		})
+		if err != nil {
+			mapFundError(c, err)
+			return
+		}
+
+		result := make([]gin.H, 0, len(resp.Positions))
+		for _, p := range resp.Positions {
+			result = append(result, gin.H{
+				"fundId":               p.FundId,
+				"fundName":             p.FundName,
+				"description":          p.Description,
+				"fundValue":            p.FundValue,
+				"fundPercentage":       p.FundPercentage,
+				"currentPositionValue": p.CurrentPositionValue,
+				"totalInvestedAmount":  p.TotalInvestedAmount,
+				"profit":               p.Profit,
+				"minimumContribution":  p.MinimumContribution,
+			})
+		}
+		c.JSON(http.StatusOK, result)
+	}
+}

--- a/services/api-gateway/handlers/fund_test.go
+++ b/services/api-gateway/handlers/fund_test.go
@@ -31,17 +31,18 @@ func makeSupervisorToken() string {
 // ---- stub fund client ----
 
 type stubFundClient struct {
-	pingFn         func(context.Context, *pb.PingRequest, ...grpc.CallOption) (*pb.PingResponse, error)
-	createFundFn   func(context.Context, *pb.CreateFundRequest, ...grpc.CallOption) (*pb.FundResponse, error)
-	listFundsFn    func(context.Context, *pb.ListFundsRequest, ...grpc.CallOption) (*pb.ListFundsResponse, error)
-	getFundFn      func(context.Context, *pb.GetFundRequest, ...grpc.CallOption) (*pb.FundResponse, error)
-	updateFundFn   func(context.Context, *pb.UpdateFundRequest, ...grpc.CallOption) (*pb.FundResponse, error)
-	deleteFundFn   func(context.Context, *pb.DeleteFundRequest, ...grpc.CallOption) (*pb.DeleteFundResponse, error)
-	investFundFn           func(context.Context, *pb.InvestFundRequest, ...grpc.CallOption) (*pb.FundResponse, error)
-	withdrawFundFn         func(context.Context, *pb.WithdrawFundRequest, ...grpc.CallOption) (*pb.FundResponse, error)
-	getBankPositionsFn     func(context.Context, *pb.GetBankPositionsRequest, ...grpc.CallOption) (*pb.GetBankPositionsResponse, error)
-	validateFundAccountFn  func(context.Context, *pb.ValidateFundAccountRequest, ...grpc.CallOption) (*pb.ValidateFundAccountResponse, error)
-	updateFundHoldingFn    func(context.Context, *pb.UpdateFundHoldingRequest, ...grpc.CallOption) (*pb.UpdateFundHoldingResponse, error)
+	pingFn                func(context.Context, *pb.PingRequest, ...grpc.CallOption) (*pb.PingResponse, error)
+	createFundFn          func(context.Context, *pb.CreateFundRequest, ...grpc.CallOption) (*pb.FundResponse, error)
+	listFundsFn           func(context.Context, *pb.ListFundsRequest, ...grpc.CallOption) (*pb.ListFundsResponse, error)
+	getFundFn             func(context.Context, *pb.GetFundRequest, ...grpc.CallOption) (*pb.FundResponse, error)
+	updateFundFn          func(context.Context, *pb.UpdateFundRequest, ...grpc.CallOption) (*pb.FundResponse, error)
+	deleteFundFn          func(context.Context, *pb.DeleteFundRequest, ...grpc.CallOption) (*pb.DeleteFundResponse, error)
+	investFundFn          func(context.Context, *pb.InvestFundRequest, ...grpc.CallOption) (*pb.FundResponse, error)
+	withdrawFundFn        func(context.Context, *pb.WithdrawFundRequest, ...grpc.CallOption) (*pb.FundResponse, error)
+	getBankPositionsFn    func(context.Context, *pb.GetBankPositionsRequest, ...grpc.CallOption) (*pb.GetBankPositionsResponse, error)
+	validateFundAccountFn func(context.Context, *pb.ValidateFundAccountRequest, ...grpc.CallOption) (*pb.ValidateFundAccountResponse, error)
+	updateFundHoldingFn   func(context.Context, *pb.UpdateFundHoldingRequest, ...grpc.CallOption) (*pb.UpdateFundHoldingResponse, error)
+	getMyPositionsFn      func(context.Context, *pb.GetMyPositionsRequest, ...grpc.CallOption) (*pb.GetMyPositionsResponse, error)
 }
 
 func (s *stubFundClient) Ping(ctx context.Context, in *pb.PingRequest, opts ...grpc.CallOption) (*pb.PingResponse, error) {
@@ -107,6 +108,12 @@ func (s *stubFundClient) ValidateFundAccount(ctx context.Context, in *pb.Validat
 func (s *stubFundClient) UpdateFundHolding(ctx context.Context, in *pb.UpdateFundHoldingRequest, opts ...grpc.CallOption) (*pb.UpdateFundHoldingResponse, error) {
 	if s.updateFundHoldingFn != nil {
 		return s.updateFundHoldingFn(ctx, in, opts...)
+	}
+	return nil, fmt.Errorf("not implemented")
+}
+func (s *stubFundClient) GetMyPositions(ctx context.Context, in *pb.GetMyPositionsRequest, opts ...grpc.CallOption) (*pb.GetMyPositionsResponse, error) {
+	if s.getMyPositionsFn != nil {
+		return s.getMyPositionsFn(ctx, in, opts...)
 	}
 	return nil, fmt.Errorf("not implemented")
 }
@@ -398,5 +405,70 @@ func TestDeleteFund_Happy(t *testing.T) {
 	}
 	if resp["message"] != "fund deleted" {
 		t.Fatalf("expected message 'fund deleted' got %v", resp["message"])
+	}
+}
+
+func TestGetMyPositions_NoToken(t *testing.T) {
+	w := serveHandlerFull(GetMyPositions(&stubFundClient{}), "GET", "/client/funds/positions", "/client/funds/positions", "", "")
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 got %d", w.Code)
+	}
+}
+
+func TestGetMyPositions_Empty(t *testing.T) {
+	svc := &stubFundClient{
+		getMyPositionsFn: func(_ context.Context, _ *pb.GetMyPositionsRequest, _ ...grpc.CallOption) (*pb.GetMyPositionsResponse, error) {
+			return &pb.GetMyPositionsResponse{Positions: []*pb.ClientFundPosition{}}, nil
+		},
+	}
+	w := serveHandlerFull(GetMyPositions(svc), "GET", "/client/funds/positions", "/client/funds/positions", "", makeClientToken())
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d", w.Code)
+	}
+	var resp []interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if len(resp) != 0 {
+		t.Fatalf("expected empty array, got %d items", len(resp))
+	}
+}
+
+func TestGetMyPositions_Happy(t *testing.T) {
+	svc := &stubFundClient{
+		getMyPositionsFn: func(_ context.Context, req *pb.GetMyPositionsRequest, _ ...grpc.CallOption) (*pb.GetMyPositionsResponse, error) {
+			return &pb.GetMyPositionsResponse{
+				Positions: []*pb.ClientFundPosition{
+					{
+						FundId:               7,
+						FundName:             "RAF Growth Fund",
+						Description:          "A growth fund",
+						FundValue:            50000,
+						FundPercentage:       100,
+						CurrentPositionValue: 50000,
+						TotalInvestedAmount:  10000,
+						Profit:               40000,
+						MinimumContribution:  1000,
+					},
+				},
+			}, nil
+		},
+	}
+	w := serveHandlerFull(GetMyPositions(svc), "GET", "/client/funds/positions", "/client/funds/positions", "", makeClientToken())
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d", w.Code)
+	}
+	var resp []map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if len(resp) != 1 {
+		t.Fatalf("expected 1 position, got %d", len(resp))
+	}
+	if resp[0]["fundName"] != "RAF Growth Fund" {
+		t.Fatalf("unexpected fundName: %v", resp[0]["fundName"])
+	}
+	if resp[0]["profit"] != float64(40000) {
+		t.Fatalf("unexpected profit: %v", resp[0]["profit"])
 	}
 }

--- a/services/api-gateway/handlers/orders_test.go
+++ b/services/api-gateway/handlers/orders_test.go
@@ -19,12 +19,12 @@ import (
 // ---- stub client ----
 
 type stubOrderClient struct {
-	createOrderFn    func(context.Context, *pb.CreateOrderRequest, ...grpc.CallOption) (*pb.CreateOrderResponse, error)
-	listOrdersFn     func(context.Context, *pb.ListOrdersRequest, ...grpc.CallOption) (*pb.ListOrdersResponse, error)
-	getOrderByIdFn   func(context.Context, *pb.GetOrderByIdRequest, ...grpc.CallOption) (*pb.GetOrderByIdResponse, error)
-	approveOrderFn   func(context.Context, *pb.ApproveOrderRequest, ...grpc.CallOption) (*pb.ApproveOrderResponse, error)
-	declineOrderFn   func(context.Context, *pb.DeclineOrderRequest, ...grpc.CallOption) (*pb.DeclineOrderResponse, error)
-	cancelOrderFn    func(context.Context, *pb.CancelOrderRequest, ...grpc.CallOption) (*pb.CancelOrderResponse, error)
+	createOrderFn       func(context.Context, *pb.CreateOrderRequest, ...grpc.CallOption) (*pb.CreateOrderResponse, error)
+	listOrdersFn        func(context.Context, *pb.ListOrdersRequest, ...grpc.CallOption) (*pb.ListOrdersResponse, error)
+	getOrderByIdFn      func(context.Context, *pb.GetOrderByIdRequest, ...grpc.CallOption) (*pb.GetOrderByIdResponse, error)
+	approveOrderFn      func(context.Context, *pb.ApproveOrderRequest, ...grpc.CallOption) (*pb.ApproveOrderResponse, error)
+	declineOrderFn      func(context.Context, *pb.DeclineOrderRequest, ...grpc.CallOption) (*pb.DeclineOrderResponse, error)
+	cancelOrderFn       func(context.Context, *pb.CancelOrderRequest, ...grpc.CallOption) (*pb.CancelOrderResponse, error)
 	cancelPortionsFn    func(context.Context, *pb.CancelOrderPortionsRequest, ...grpc.CallOption) (*pb.CancelOrderPortionsResponse, error)
 	getActuaryProfitsFn func(context.Context, *pb.GetActuaryProfitsRequest, ...grpc.CallOption) (*pb.GetActuaryProfitsResponse, error)
 }
@@ -385,7 +385,7 @@ func TestCreateOrder_FundPurchase_Happy(t *testing.T) {
 	w := serveHandlerFull(CreateOrder(ordSvc, fundSvc), "POST", "/orders", "/orders", body, makeSupervisorToken())
 	assert.Equal(t, http.StatusCreated, w.Code)
 	require.NotNil(t, capturedReq)
-	assert.Equal(t, int64(99), capturedReq.AccountId)  // fund's account used
+	assert.Equal(t, int64(99), capturedReq.AccountId) // fund's account used
 	assert.Equal(t, int64(3), capturedReq.FundId)
 }
 

--- a/services/api-gateway/main.go
+++ b/services/api-gateway/main.go
@@ -254,6 +254,7 @@ func main() {
 	r.DELETE("/investment/funds/:id", middleware.RequireRole("SUPERVISOR"), handlers.DeleteFund(fundClient))
 	r.POST("/investment/funds/:id/invest", middleware.RequireRole("CLIENT", "AGENT", "SUPERVISOR"), handlers.InvestFund(fundClient))
 	r.POST("/investment/funds/:id/withdraw", middleware.RequireRole("CLIENT", "AGENT", "SUPERVISOR"), handlers.WithdrawFund(fundClient))
+	r.GET("/client/funds/positions", middleware.RequireRole("CLIENT"), handlers.GetMyPositions(fundClient))
 
 	r.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 	if err := r.Run(":8083"); err != nil {

--- a/services/fund-service/handlers/grpc_server.go
+++ b/services/fund-service/handlers/grpc_server.go
@@ -453,8 +453,8 @@ func (s *FundServer) ValidateFundAccount(ctx context.Context, req *pb.ValidateFu
 		return nil, status.Error(codes.PermissionDenied, "not the fund manager")
 	}
 	return &pb.ValidateFundAccountResponse{
-		AccountId:   accountID,
-		IsLiquid:    liquidAssets >= req.RequiredAmount,
+		AccountId:    accountID,
+		IsLiquid:     liquidAssets >= req.RequiredAmount,
 		LiquidAssets: liquidAssets,
 	}, nil
 }
@@ -499,6 +499,71 @@ func (s *FundServer) UpdateFundHolding(ctx context.Context, req *pb.UpdateFundHo
 		return nil, status.Errorf(codes.Internal, "commit: %v", err)
 	}
 	return &pb.UpdateFundHoldingResponse{}, nil
+}
+
+func (s *FundServer) GetMyPositions(ctx context.Context, req *pb.GetMyPositionsRequest) (*pb.GetMyPositionsResponse, error) {
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT cfp.fund_id,
+		       cfp.total_invested_amount,
+		       f.name,
+		       COALESCE(f.description, ''),
+		       f.liquid_assets            AS fund_value,
+		       f.minimum_contribution,
+		       COALESCE((SELECT SUM(total_invested_amount)
+		                 FROM client_fund_positions
+		                 WHERE fund_id = cfp.fund_id), 0) AS total_all_invested
+		FROM client_fund_positions cfp
+		JOIN investment_funds f ON f.id = cfp.fund_id
+		WHERE cfp.client_id   = $1
+		  AND cfp.client_type = $2
+		  AND f.active        = TRUE`,
+		req.ClientId, req.ClientType)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "get my positions: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var positions []*pb.ClientFundPosition
+	for rows.Next() {
+		var (
+			fundID           int64
+			totalInvested    float64
+			fundName         string
+			description      string
+			fundValue        float64
+			minContribution  float64
+			totalAllInvested float64
+		)
+		if err := rows.Scan(&fundID, &totalInvested, &fundName, &description,
+			&fundValue, &minContribution, &totalAllInvested); err != nil {
+			return nil, status.Errorf(codes.Internal, "scan position: %v", err)
+		}
+
+		var currentPositionValue float64
+		if totalAllInvested > 0 {
+			currentPositionValue = (totalInvested / totalAllInvested) * fundValue
+		}
+		var fundPercentage float64
+		if fundValue > 0 {
+			fundPercentage = (currentPositionValue / fundValue) * 100
+		}
+
+		positions = append(positions, &pb.ClientFundPosition{
+			FundId:               fundID,
+			FundName:             fundName,
+			Description:          description,
+			FundValue:            fundValue,
+			FundPercentage:       fundPercentage,
+			CurrentPositionValue: currentPositionValue,
+			TotalInvestedAmount:  totalInvested,
+			Profit:               currentPositionValue - totalInvested,
+			MinimumContribution:  minContribution,
+		})
+	}
+	if positions == nil {
+		positions = []*pb.ClientFundPosition{}
+	}
+	return &pb.GetMyPositionsResponse{Positions: positions}, nil
 }
 
 // GetBankPositions returns all investment fund positions held by the bank (client_type='BANK', client_id=0).

--- a/services/fund-service/handlers/grpc_server_test.go
+++ b/services/fund-service/handlers/grpc_server_test.go
@@ -678,3 +678,51 @@ func TestUpdateFundHolding_Sell(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, fundMock.ExpectationsWereMet())
 }
+
+func TestGetMyPositions_Empty(t *testing.T) {
+	s, fundMock, _, _ := newFundServer(t, &mockAccountClient{})
+
+	fundMock.ExpectQuery("SELECT cfp.fund_id").
+		WithArgs(int64(42), "CLIENT").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"fund_id", "total_invested_amount", "name", "description",
+			"fund_value", "minimum_contribution", "total_all_invested",
+		}))
+
+	resp, err := s.GetMyPositions(context.Background(), &pb.GetMyPositionsRequest{
+		ClientId: 42, ClientType: "CLIENT",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, resp.Positions)
+	require.NoError(t, fundMock.ExpectationsWereMet())
+}
+
+func TestGetMyPositions_Happy(t *testing.T) {
+	s, fundMock, _, _ := newFundServer(t, &mockAccountClient{})
+
+	// client invested 10000, total all invested is also 10000 (sole investor), fund value 50000
+	fundMock.ExpectQuery("SELECT cfp.fund_id").
+		WithArgs(int64(1), "CLIENT").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"fund_id", "total_invested_amount", "name", "description",
+			"fund_value", "minimum_contribution", "total_all_invested",
+		}).AddRow(int64(7), float64(10000), "RAF Growth Fund", "A growth fund", float64(50000), float64(1000), float64(10000)))
+
+	resp, err := s.GetMyPositions(context.Background(), &pb.GetMyPositionsRequest{
+		ClientId: 1, ClientType: "CLIENT",
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Positions, 1)
+
+	pos := resp.Positions[0]
+	assert.Equal(t, int64(7), pos.FundId)
+	assert.Equal(t, "RAF Growth Fund", pos.FundName)
+	assert.Equal(t, float64(10000), pos.TotalInvestedAmount)
+	// currentPositionValue = (10000/10000) * 50000 = 50000
+	assert.InDelta(t, 50000.0, pos.CurrentPositionValue, 0.01)
+	// fundPercentage = (50000/50000) * 100 = 100
+	assert.InDelta(t, 100.0, pos.FundPercentage, 0.01)
+	// profit = 50000 - 10000 = 40000
+	assert.InDelta(t, 40000.0, pos.Profit, 0.01)
+	require.NoError(t, fundMock.ExpectationsWereMet())
+}

--- a/services/order-service/execution/scheduler_test.go
+++ b/services/order-service/execution/scheduler_test.go
@@ -128,7 +128,7 @@ func (m *mockExchangeClient) PreviewConversion(ctx context.Context, in *pb_excha
 func TestListingCurrency_Success(t *testing.T) {
 	secDB, mock, err := sqlmock.New()
 	require.NoError(t, err)
-	defer secDB.Close()
+	defer func() { _ = secDB.Close() }()
 
 	mock.ExpectQuery(`SELECT e\.currency`).
 		WithArgs(int64(1)).
@@ -144,7 +144,7 @@ func TestListingCurrency_Success(t *testing.T) {
 func TestListingCurrency_NotFound(t *testing.T) {
 	secDB, mock, err := sqlmock.New()
 	require.NoError(t, err)
-	defer secDB.Close()
+	defer func() { _ = secDB.Close() }()
 
 	mock.ExpectQuery(`SELECT e\.currency`).
 		WithArgs(int64(99)).
@@ -160,7 +160,7 @@ func TestListingCurrency_NotFound(t *testing.T) {
 func TestValidateMargin_Employee_WithMarginPermission(t *testing.T) {
 	accDB, accMock, err := sqlmock.New()
 	require.NoError(t, err)
-	defer accDB.Close()
+	defer func() { _ = accDB.Close() }()
 
 	accMock.ExpectQuery(`SELECT available_balance`).
 		WithArgs(int64(42)).
@@ -178,7 +178,7 @@ func TestValidateMargin_Employee_WithMarginPermission(t *testing.T) {
 func TestValidateMargin_Employee_NoMarginPermission_Insufficient(t *testing.T) {
 	accDB, accMock, err := sqlmock.New()
 	require.NoError(t, err)
-	defer accDB.Close()
+	defer func() { _ = accDB.Close() }()
 
 	accMock.ExpectQuery(`SELECT available_balance`).
 		WithArgs(int64(42)).
@@ -195,7 +195,7 @@ func TestValidateMargin_Employee_NoMarginPermission_Insufficient(t *testing.T) {
 func TestValidateMargin_Client_SufficientLoan(t *testing.T) {
 	accDB, accMock, err := sqlmock.New()
 	require.NoError(t, err)
-	defer accDB.Close()
+	defer func() { _ = accDB.Close() }()
 
 	accMock.ExpectQuery(`SELECT available_balance`).
 		WithArgs(int64(10)).
@@ -213,7 +213,7 @@ func TestValidateMargin_Client_SufficientLoan(t *testing.T) {
 func TestValidateMargin_Client_InsufficientFunds(t *testing.T) {
 	accDB, accMock, err := sqlmock.New()
 	require.NoError(t, err)
-	defer accDB.Close()
+	defer func() { _ = accDB.Close() }()
 
 	accMock.ExpectQuery(`SELECT available_balance`).
 		WithArgs(int64(10)).
@@ -232,11 +232,11 @@ func TestValidateMargin_Client_InsufficientFunds(t *testing.T) {
 func TestSettle_Buy_SameCurrency(t *testing.T) {
 	accDB, accMock, err := sqlmock.New()
 	require.NoError(t, err)
-	defer accDB.Close()
+	defer func() { _ = accDB.Close() }()
 
 	exchDB, exchMock, err := sqlmock.New()
 	require.NoError(t, err)
-	defer exchDB.Close()
+	defer func() { _ = exchDB.Close() }()
 
 	// 1. look up account currency_id
 	accMock.ExpectQuery(`SELECT currency_id FROM accounts`).
@@ -278,11 +278,11 @@ func TestSettle_Buy_SameCurrency(t *testing.T) {
 func TestSettle_Sell_SameCurrency(t *testing.T) {
 	accDB, accMock, err := sqlmock.New()
 	require.NoError(t, err)
-	defer accDB.Close()
+	defer func() { _ = accDB.Close() }()
 
 	exchDB, exchMock, err := sqlmock.New()
 	require.NoError(t, err)
-	defer exchDB.Close()
+	defer func() { _ = exchDB.Close() }()
 
 	accMock.ExpectQuery(`SELECT currency_id FROM accounts`).
 		WithArgs(int64(1)).
@@ -319,11 +319,11 @@ func TestSettle_Sell_SameCurrency(t *testing.T) {
 func TestSettle_Buy_InsufficientFunds(t *testing.T) {
 	accDB, accMock, err := sqlmock.New()
 	require.NoError(t, err)
-	defer accDB.Close()
+	defer func() { _ = accDB.Close() }()
 
 	exchDB, exchMock, err := sqlmock.New()
 	require.NoError(t, err)
-	defer exchDB.Close()
+	defer func() { _ = exchDB.Close() }()
 
 	accMock.ExpectQuery(`SELECT currency_id FROM accounts`).
 		WithArgs(int64(1)).
@@ -348,7 +348,7 @@ func TestSettle_Buy_InsufficientFunds(t *testing.T) {
 func TestDeclineExpiredOrders_NoPendingOrders(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	mock.ExpectQuery(`SELECT id, user_id`).
 		WillReturnRows(sqlmock.NewRows([]string{
@@ -359,7 +359,7 @@ func TestDeclineExpiredOrders_NoPendingOrders(t *testing.T) {
 
 	secDB, secMock, err := sqlmock.New()
 	require.NoError(t, err)
-	defer secDB.Close()
+	defer func() { _ = secDB.Close() }()
 
 	s := &Scheduler{DB: db, SecuritiesDB: secDB}
 	s.declineExpiredOrders()
@@ -370,7 +370,7 @@ func TestDeclineExpiredOrders_NoPendingOrders(t *testing.T) {
 func TestDeclineExpiredOrders_ExpiredFutures(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	pastDate := time.Now().UTC().AddDate(0, 0, -2).Format("2006-01-02")
 
@@ -387,7 +387,7 @@ func TestDeclineExpiredOrders_ExpiredFutures(t *testing.T) {
 
 	secDB, secMock, err := sqlmock.New()
 	require.NoError(t, err)
-	defer secDB.Close()
+	defer func() { _ = secDB.Close() }()
 
 	secMock.ExpectQuery(`SELECT settlement_date`).
 		WithArgs(int64(10)).

--- a/shared/pb/fund/fund.pb.go
+++ b/shared/pb/fund/fund.pb.go
@@ -921,6 +921,210 @@ func (x *GetBankPositionsResponse) GetPositions() []*BankFundPosition {
 	return nil
 }
 
+type ClientFundPosition struct {
+	state                protoimpl.MessageState `protogen:"open.v1"`
+	FundId               int64                  `protobuf:"varint,1,opt,name=fund_id,json=fundId,proto3" json:"fund_id,omitempty"`
+	FundName             string                 `protobuf:"bytes,2,opt,name=fund_name,json=fundName,proto3" json:"fund_name,omitempty"`
+	Description          string                 `protobuf:"bytes,3,opt,name=description,proto3" json:"description,omitempty"`
+	FundValue            float64                `protobuf:"fixed64,4,opt,name=fund_value,json=fundValue,proto3" json:"fund_value,omitempty"`
+	FundPercentage       float64                `protobuf:"fixed64,5,opt,name=fund_percentage,json=fundPercentage,proto3" json:"fund_percentage,omitempty"`
+	CurrentPositionValue float64                `protobuf:"fixed64,6,opt,name=current_position_value,json=currentPositionValue,proto3" json:"current_position_value,omitempty"`
+	TotalInvestedAmount  float64                `protobuf:"fixed64,7,opt,name=total_invested_amount,json=totalInvestedAmount,proto3" json:"total_invested_amount,omitempty"`
+	Profit               float64                `protobuf:"fixed64,8,opt,name=profit,proto3" json:"profit,omitempty"`
+	MinimumContribution  float64                `protobuf:"fixed64,9,opt,name=minimum_contribution,json=minimumContribution,proto3" json:"minimum_contribution,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
+}
+
+func (x *ClientFundPosition) Reset() {
+	*x = ClientFundPosition{}
+	mi := &file_fund_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ClientFundPosition) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ClientFundPosition) ProtoMessage() {}
+
+func (x *ClientFundPosition) ProtoReflect() protoreflect.Message {
+	mi := &file_fund_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ClientFundPosition.ProtoReflect.Descriptor instead.
+func (*ClientFundPosition) Descriptor() ([]byte, []int) {
+	return file_fund_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *ClientFundPosition) GetFundId() int64 {
+	if x != nil {
+		return x.FundId
+	}
+	return 0
+}
+
+func (x *ClientFundPosition) GetFundName() string {
+	if x != nil {
+		return x.FundName
+	}
+	return ""
+}
+
+func (x *ClientFundPosition) GetDescription() string {
+	if x != nil {
+		return x.Description
+	}
+	return ""
+}
+
+func (x *ClientFundPosition) GetFundValue() float64 {
+	if x != nil {
+		return x.FundValue
+	}
+	return 0
+}
+
+func (x *ClientFundPosition) GetFundPercentage() float64 {
+	if x != nil {
+		return x.FundPercentage
+	}
+	return 0
+}
+
+func (x *ClientFundPosition) GetCurrentPositionValue() float64 {
+	if x != nil {
+		return x.CurrentPositionValue
+	}
+	return 0
+}
+
+func (x *ClientFundPosition) GetTotalInvestedAmount() float64 {
+	if x != nil {
+		return x.TotalInvestedAmount
+	}
+	return 0
+}
+
+func (x *ClientFundPosition) GetProfit() float64 {
+	if x != nil {
+		return x.Profit
+	}
+	return 0
+}
+
+func (x *ClientFundPosition) GetMinimumContribution() float64 {
+	if x != nil {
+		return x.MinimumContribution
+	}
+	return 0
+}
+
+type GetMyPositionsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ClientId      int64                  `protobuf:"varint,1,opt,name=client_id,json=clientId,proto3" json:"client_id,omitempty"`
+	ClientType    string                 `protobuf:"bytes,2,opt,name=client_type,json=clientType,proto3" json:"client_type,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetMyPositionsRequest) Reset() {
+	*x = GetMyPositionsRequest{}
+	mi := &file_fund_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetMyPositionsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetMyPositionsRequest) ProtoMessage() {}
+
+func (x *GetMyPositionsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_fund_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetMyPositionsRequest.ProtoReflect.Descriptor instead.
+func (*GetMyPositionsRequest) Descriptor() ([]byte, []int) {
+	return file_fund_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *GetMyPositionsRequest) GetClientId() int64 {
+	if x != nil {
+		return x.ClientId
+	}
+	return 0
+}
+
+func (x *GetMyPositionsRequest) GetClientType() string {
+	if x != nil {
+		return x.ClientType
+	}
+	return ""
+}
+
+type GetMyPositionsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Positions     []*ClientFundPosition  `protobuf:"bytes,1,rep,name=positions,proto3" json:"positions,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetMyPositionsResponse) Reset() {
+	*x = GetMyPositionsResponse{}
+	mi := &file_fund_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetMyPositionsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetMyPositionsResponse) ProtoMessage() {}
+
+func (x *GetMyPositionsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_fund_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetMyPositionsResponse.ProtoReflect.Descriptor instead.
+func (*GetMyPositionsResponse) Descriptor() ([]byte, []int) {
+	return file_fund_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *GetMyPositionsResponse) GetPositions() []*ClientFundPosition {
+	if x != nil {
+		return x.Positions
+	}
+	return nil
+}
+
 type ValidateFundAccountRequest struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
 	FundId         int64                  `protobuf:"varint,1,opt,name=fund_id,json=fundId,proto3" json:"fund_id,omitempty"`
@@ -932,7 +1136,7 @@ type ValidateFundAccountRequest struct {
 
 func (x *ValidateFundAccountRequest) Reset() {
 	*x = ValidateFundAccountRequest{}
-	mi := &file_fund_proto_msgTypes[15]
+	mi := &file_fund_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -944,7 +1148,7 @@ func (x *ValidateFundAccountRequest) String() string {
 func (*ValidateFundAccountRequest) ProtoMessage() {}
 
 func (x *ValidateFundAccountRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fund_proto_msgTypes[15]
+	mi := &file_fund_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -957,7 +1161,7 @@ func (x *ValidateFundAccountRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ValidateFundAccountRequest.ProtoReflect.Descriptor instead.
 func (*ValidateFundAccountRequest) Descriptor() ([]byte, []int) {
-	return file_fund_proto_rawDescGZIP(), []int{15}
+	return file_fund_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *ValidateFundAccountRequest) GetFundId() int64 {
@@ -992,7 +1196,7 @@ type ValidateFundAccountResponse struct {
 
 func (x *ValidateFundAccountResponse) Reset() {
 	*x = ValidateFundAccountResponse{}
-	mi := &file_fund_proto_msgTypes[16]
+	mi := &file_fund_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1004,7 +1208,7 @@ func (x *ValidateFundAccountResponse) String() string {
 func (*ValidateFundAccountResponse) ProtoMessage() {}
 
 func (x *ValidateFundAccountResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fund_proto_msgTypes[16]
+	mi := &file_fund_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1017,7 +1221,7 @@ func (x *ValidateFundAccountResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ValidateFundAccountResponse.ProtoReflect.Descriptor instead.
 func (*ValidateFundAccountResponse) Descriptor() ([]byte, []int) {
-	return file_fund_proto_rawDescGZIP(), []int{16}
+	return file_fund_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *ValidateFundAccountResponse) GetAccountId() int64 {
@@ -1054,7 +1258,7 @@ type UpdateFundHoldingRequest struct {
 
 func (x *UpdateFundHoldingRequest) Reset() {
 	*x = UpdateFundHoldingRequest{}
-	mi := &file_fund_proto_msgTypes[17]
+	mi := &file_fund_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1066,7 +1270,7 @@ func (x *UpdateFundHoldingRequest) String() string {
 func (*UpdateFundHoldingRequest) ProtoMessage() {}
 
 func (x *UpdateFundHoldingRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fund_proto_msgTypes[17]
+	mi := &file_fund_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1079,7 +1283,7 @@ func (x *UpdateFundHoldingRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateFundHoldingRequest.ProtoReflect.Descriptor instead.
 func (*UpdateFundHoldingRequest) Descriptor() ([]byte, []int) {
-	return file_fund_proto_rawDescGZIP(), []int{17}
+	return file_fund_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *UpdateFundHoldingRequest) GetFundId() int64 {
@@ -1125,7 +1329,7 @@ type UpdateFundHoldingResponse struct {
 
 func (x *UpdateFundHoldingResponse) Reset() {
 	*x = UpdateFundHoldingResponse{}
-	mi := &file_fund_proto_msgTypes[18]
+	mi := &file_fund_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1137,7 +1341,7 @@ func (x *UpdateFundHoldingResponse) String() string {
 func (*UpdateFundHoldingResponse) ProtoMessage() {}
 
 func (x *UpdateFundHoldingResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fund_proto_msgTypes[18]
+	mi := &file_fund_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1150,7 +1354,7 @@ func (x *UpdateFundHoldingResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateFundHoldingResponse.ProtoReflect.Descriptor instead.
 func (*UpdateFundHoldingResponse) Descriptor() ([]byte, []int) {
-	return file_fund_proto_rawDescGZIP(), []int{18}
+	return file_fund_proto_rawDescGZIP(), []int{21}
 }
 
 var File_fund_proto protoreflect.FileDescriptor
@@ -1228,7 +1432,24 @@ const file_fund_proto_rawDesc = "" +
 	"profit_rsd\x18\x06 \x01(\x01R\tprofitRsd\"\x19\n" +
 	"\x17GetBankPositionsRequest\"P\n" +
 	"\x18GetBankPositionsResponse\x124\n" +
-	"\tpositions\x18\x01 \x03(\v2\x16.fund.BankFundPositionR\tpositions\"}\n" +
+	"\tpositions\x18\x01 \x03(\v2\x16.fund.BankFundPositionR\tpositions\"\xe9\x02\n" +
+	"\x12ClientFundPosition\x12\x17\n" +
+	"\afund_id\x18\x01 \x01(\x03R\x06fundId\x12\x1b\n" +
+	"\tfund_name\x18\x02 \x01(\tR\bfundName\x12 \n" +
+	"\vdescription\x18\x03 \x01(\tR\vdescription\x12\x1d\n" +
+	"\n" +
+	"fund_value\x18\x04 \x01(\x01R\tfundValue\x12'\n" +
+	"\x0ffund_percentage\x18\x05 \x01(\x01R\x0efundPercentage\x124\n" +
+	"\x16current_position_value\x18\x06 \x01(\x01R\x14currentPositionValue\x122\n" +
+	"\x15total_invested_amount\x18\a \x01(\x01R\x13totalInvestedAmount\x12\x16\n" +
+	"\x06profit\x18\b \x01(\x01R\x06profit\x121\n" +
+	"\x14minimum_contribution\x18\t \x01(\x01R\x13minimumContribution\"U\n" +
+	"\x15GetMyPositionsRequest\x12\x1b\n" +
+	"\tclient_id\x18\x01 \x01(\x03R\bclientId\x12\x1f\n" +
+	"\vclient_type\x18\x02 \x01(\tR\n" +
+	"clientType\"P\n" +
+	"\x16GetMyPositionsResponse\x126\n" +
+	"\tpositions\x18\x01 \x03(\v2\x18.fund.ClientFundPositionR\tpositions\"}\n" +
 	"\x1aValidateFundAccountRequest\x12\x17\n" +
 	"\afund_id\x18\x01 \x01(\x03R\x06fundId\x12\x1d\n" +
 	"\n" +
@@ -1246,7 +1467,7 @@ const file_fund_proto_rawDesc = "" +
 	"\bquantity\x18\x03 \x01(\x03R\bquantity\x12\x14\n" +
 	"\x05price\x18\x04 \x01(\x01R\x05price\x12\x1c\n" +
 	"\tdirection\x18\x05 \x01(\tR\tdirection\"\x1b\n" +
-	"\x19UpdateFundHoldingResponse2\xe5\x05\n" +
+	"\x19UpdateFundHoldingResponse2\xb2\x06\n" +
 	"\vFundService\x12-\n" +
 	"\x04Ping\x12\x11.fund.PingRequest\x1a\x12.fund.PingResponse\x129\n" +
 	"\n" +
@@ -1260,7 +1481,8 @@ const file_fund_proto_rawDesc = "" +
 	"\n" +
 	"InvestFund\x12\x17.fund.InvestFundRequest\x1a\x12.fund.FundResponse\x12=\n" +
 	"\fWithdrawFund\x12\x19.fund.WithdrawFundRequest\x1a\x12.fund.FundResponse\x12Q\n" +
-	"\x10GetBankPositions\x12\x1d.fund.GetBankPositionsRequest\x1a\x1e.fund.GetBankPositionsResponse\x12Z\n" +
+	"\x10GetBankPositions\x12\x1d.fund.GetBankPositionsRequest\x1a\x1e.fund.GetBankPositionsResponse\x12K\n" +
+	"\x0eGetMyPositions\x12\x1b.fund.GetMyPositionsRequest\x1a\x1c.fund.GetMyPositionsResponse\x12Z\n" +
 	"\x13ValidateFundAccount\x12 .fund.ValidateFundAccountRequest\x1a!.fund.ValidateFundAccountResponse\x12T\n" +
 	"\x11UpdateFundHolding\x12\x1e.fund.UpdateFundHoldingRequest\x1a\x1f.fund.UpdateFundHoldingResponseB9Z7github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/fundb\x06proto3"
 
@@ -1276,7 +1498,7 @@ func file_fund_proto_rawDescGZIP() []byte {
 	return file_fund_proto_rawDescData
 }
 
-var file_fund_proto_msgTypes = make([]protoimpl.MessageInfo, 19)
+var file_fund_proto_msgTypes = make([]protoimpl.MessageInfo, 22)
 var file_fund_proto_goTypes = []any{
 	(*PingRequest)(nil),                 // 0: fund.PingRequest
 	(*PingResponse)(nil),                // 1: fund.PingResponse
@@ -1293,41 +1515,47 @@ var file_fund_proto_goTypes = []any{
 	(*BankFundPosition)(nil),            // 12: fund.BankFundPosition
 	(*GetBankPositionsRequest)(nil),     // 13: fund.GetBankPositionsRequest
 	(*GetBankPositionsResponse)(nil),    // 14: fund.GetBankPositionsResponse
-	(*ValidateFundAccountRequest)(nil),  // 15: fund.ValidateFundAccountRequest
-	(*ValidateFundAccountResponse)(nil), // 16: fund.ValidateFundAccountResponse
-	(*UpdateFundHoldingRequest)(nil),    // 17: fund.UpdateFundHoldingRequest
-	(*UpdateFundHoldingResponse)(nil),   // 18: fund.UpdateFundHoldingResponse
+	(*ClientFundPosition)(nil),          // 15: fund.ClientFundPosition
+	(*GetMyPositionsRequest)(nil),       // 16: fund.GetMyPositionsRequest
+	(*GetMyPositionsResponse)(nil),      // 17: fund.GetMyPositionsResponse
+	(*ValidateFundAccountRequest)(nil),  // 18: fund.ValidateFundAccountRequest
+	(*ValidateFundAccountResponse)(nil), // 19: fund.ValidateFundAccountResponse
+	(*UpdateFundHoldingRequest)(nil),    // 20: fund.UpdateFundHoldingRequest
+	(*UpdateFundHoldingResponse)(nil),   // 21: fund.UpdateFundHoldingResponse
 }
 var file_fund_proto_depIdxs = []int32{
 	8,  // 0: fund.ListFundsResponse.funds:type_name -> fund.FundResponse
 	12, // 1: fund.GetBankPositionsResponse.positions:type_name -> fund.BankFundPosition
-	0,  // 2: fund.FundService.Ping:input_type -> fund.PingRequest
-	2,  // 3: fund.FundService.CreateFund:input_type -> fund.CreateFundRequest
-	6,  // 4: fund.FundService.ListFunds:input_type -> fund.ListFundsRequest
-	7,  // 5: fund.FundService.GetFund:input_type -> fund.GetFundRequest
-	3,  // 6: fund.FundService.UpdateFund:input_type -> fund.UpdateFundRequest
-	4,  // 7: fund.FundService.DeleteFund:input_type -> fund.DeleteFundRequest
-	10, // 8: fund.FundService.InvestFund:input_type -> fund.InvestFundRequest
-	11, // 9: fund.FundService.WithdrawFund:input_type -> fund.WithdrawFundRequest
-	13, // 10: fund.FundService.GetBankPositions:input_type -> fund.GetBankPositionsRequest
-	15, // 11: fund.FundService.ValidateFundAccount:input_type -> fund.ValidateFundAccountRequest
-	17, // 12: fund.FundService.UpdateFundHolding:input_type -> fund.UpdateFundHoldingRequest
-	1,  // 13: fund.FundService.Ping:output_type -> fund.PingResponse
-	8,  // 14: fund.FundService.CreateFund:output_type -> fund.FundResponse
-	9,  // 15: fund.FundService.ListFunds:output_type -> fund.ListFundsResponse
-	8,  // 16: fund.FundService.GetFund:output_type -> fund.FundResponse
-	8,  // 17: fund.FundService.UpdateFund:output_type -> fund.FundResponse
-	5,  // 18: fund.FundService.DeleteFund:output_type -> fund.DeleteFundResponse
-	8,  // 19: fund.FundService.InvestFund:output_type -> fund.FundResponse
-	8,  // 20: fund.FundService.WithdrawFund:output_type -> fund.FundResponse
-	14, // 21: fund.FundService.GetBankPositions:output_type -> fund.GetBankPositionsResponse
-	16, // 22: fund.FundService.ValidateFundAccount:output_type -> fund.ValidateFundAccountResponse
-	18, // 23: fund.FundService.UpdateFundHolding:output_type -> fund.UpdateFundHoldingResponse
-	13, // [13:24] is the sub-list for method output_type
-	2,  // [2:13] is the sub-list for method input_type
-	2,  // [2:2] is the sub-list for extension type_name
-	2,  // [2:2] is the sub-list for extension extendee
-	0,  // [0:2] is the sub-list for field type_name
+	15, // 2: fund.GetMyPositionsResponse.positions:type_name -> fund.ClientFundPosition
+	0,  // 3: fund.FundService.Ping:input_type -> fund.PingRequest
+	2,  // 4: fund.FundService.CreateFund:input_type -> fund.CreateFundRequest
+	6,  // 5: fund.FundService.ListFunds:input_type -> fund.ListFundsRequest
+	7,  // 6: fund.FundService.GetFund:input_type -> fund.GetFundRequest
+	3,  // 7: fund.FundService.UpdateFund:input_type -> fund.UpdateFundRequest
+	4,  // 8: fund.FundService.DeleteFund:input_type -> fund.DeleteFundRequest
+	10, // 9: fund.FundService.InvestFund:input_type -> fund.InvestFundRequest
+	11, // 10: fund.FundService.WithdrawFund:input_type -> fund.WithdrawFundRequest
+	13, // 11: fund.FundService.GetBankPositions:input_type -> fund.GetBankPositionsRequest
+	16, // 12: fund.FundService.GetMyPositions:input_type -> fund.GetMyPositionsRequest
+	18, // 13: fund.FundService.ValidateFundAccount:input_type -> fund.ValidateFundAccountRequest
+	20, // 14: fund.FundService.UpdateFundHolding:input_type -> fund.UpdateFundHoldingRequest
+	1,  // 15: fund.FundService.Ping:output_type -> fund.PingResponse
+	8,  // 16: fund.FundService.CreateFund:output_type -> fund.FundResponse
+	9,  // 17: fund.FundService.ListFunds:output_type -> fund.ListFundsResponse
+	8,  // 18: fund.FundService.GetFund:output_type -> fund.FundResponse
+	8,  // 19: fund.FundService.UpdateFund:output_type -> fund.FundResponse
+	5,  // 20: fund.FundService.DeleteFund:output_type -> fund.DeleteFundResponse
+	8,  // 21: fund.FundService.InvestFund:output_type -> fund.FundResponse
+	8,  // 22: fund.FundService.WithdrawFund:output_type -> fund.FundResponse
+	14, // 23: fund.FundService.GetBankPositions:output_type -> fund.GetBankPositionsResponse
+	17, // 24: fund.FundService.GetMyPositions:output_type -> fund.GetMyPositionsResponse
+	19, // 25: fund.FundService.ValidateFundAccount:output_type -> fund.ValidateFundAccountResponse
+	21, // 26: fund.FundService.UpdateFundHolding:output_type -> fund.UpdateFundHoldingResponse
+	15, // [15:27] is the sub-list for method output_type
+	3,  // [3:15] is the sub-list for method input_type
+	3,  // [3:3] is the sub-list for extension type_name
+	3,  // [3:3] is the sub-list for extension extendee
+	0,  // [0:3] is the sub-list for field type_name
 }
 
 func init() { file_fund_proto_init() }
@@ -1341,7 +1569,7 @@ func file_fund_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_fund_proto_rawDesc), len(file_fund_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   19,
+			NumMessages:   22,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/shared/pb/fund/fund_grpc.pb.go
+++ b/shared/pb/fund/fund_grpc.pb.go
@@ -28,6 +28,7 @@ const (
 	FundService_InvestFund_FullMethodName          = "/fund.FundService/InvestFund"
 	FundService_WithdrawFund_FullMethodName        = "/fund.FundService/WithdrawFund"
 	FundService_GetBankPositions_FullMethodName    = "/fund.FundService/GetBankPositions"
+	FundService_GetMyPositions_FullMethodName      = "/fund.FundService/GetMyPositions"
 	FundService_ValidateFundAccount_FullMethodName = "/fund.FundService/ValidateFundAccount"
 	FundService_UpdateFundHolding_FullMethodName   = "/fund.FundService/UpdateFundHolding"
 )
@@ -45,6 +46,7 @@ type FundServiceClient interface {
 	InvestFund(ctx context.Context, in *InvestFundRequest, opts ...grpc.CallOption) (*FundResponse, error)
 	WithdrawFund(ctx context.Context, in *WithdrawFundRequest, opts ...grpc.CallOption) (*FundResponse, error)
 	GetBankPositions(ctx context.Context, in *GetBankPositionsRequest, opts ...grpc.CallOption) (*GetBankPositionsResponse, error)
+	GetMyPositions(ctx context.Context, in *GetMyPositionsRequest, opts ...grpc.CallOption) (*GetMyPositionsResponse, error)
 	ValidateFundAccount(ctx context.Context, in *ValidateFundAccountRequest, opts ...grpc.CallOption) (*ValidateFundAccountResponse, error)
 	UpdateFundHolding(ctx context.Context, in *UpdateFundHoldingRequest, opts ...grpc.CallOption) (*UpdateFundHoldingResponse, error)
 }
@@ -147,6 +149,16 @@ func (c *fundServiceClient) GetBankPositions(ctx context.Context, in *GetBankPos
 	return out, nil
 }
 
+func (c *fundServiceClient) GetMyPositions(ctx context.Context, in *GetMyPositionsRequest, opts ...grpc.CallOption) (*GetMyPositionsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetMyPositionsResponse)
+	err := c.cc.Invoke(ctx, FundService_GetMyPositions_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *fundServiceClient) ValidateFundAccount(ctx context.Context, in *ValidateFundAccountRequest, opts ...grpc.CallOption) (*ValidateFundAccountResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(ValidateFundAccountResponse)
@@ -180,6 +192,7 @@ type FundServiceServer interface {
 	InvestFund(context.Context, *InvestFundRequest) (*FundResponse, error)
 	WithdrawFund(context.Context, *WithdrawFundRequest) (*FundResponse, error)
 	GetBankPositions(context.Context, *GetBankPositionsRequest) (*GetBankPositionsResponse, error)
+	GetMyPositions(context.Context, *GetMyPositionsRequest) (*GetMyPositionsResponse, error)
 	ValidateFundAccount(context.Context, *ValidateFundAccountRequest) (*ValidateFundAccountResponse, error)
 	UpdateFundHolding(context.Context, *UpdateFundHoldingRequest) (*UpdateFundHoldingResponse, error)
 	mustEmbedUnimplementedFundServiceServer()
@@ -218,6 +231,9 @@ func (UnimplementedFundServiceServer) WithdrawFund(context.Context, *WithdrawFun
 }
 func (UnimplementedFundServiceServer) GetBankPositions(context.Context, *GetBankPositionsRequest) (*GetBankPositionsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetBankPositions not implemented")
+}
+func (UnimplementedFundServiceServer) GetMyPositions(context.Context, *GetMyPositionsRequest) (*GetMyPositionsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetMyPositions not implemented")
 }
 func (UnimplementedFundServiceServer) ValidateFundAccount(context.Context, *ValidateFundAccountRequest) (*ValidateFundAccountResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ValidateFundAccount not implemented")
@@ -408,6 +424,24 @@ func _FundService_GetBankPositions_Handler(srv interface{}, ctx context.Context,
 	return interceptor(ctx, in, info, handler)
 }
 
+func _FundService_GetMyPositions_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetMyPositionsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(FundServiceServer).GetMyPositions(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: FundService_GetMyPositions_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(FundServiceServer).GetMyPositions(ctx, req.(*GetMyPositionsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _FundService_ValidateFundAccount_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(ValidateFundAccountRequest)
 	if err := dec(in); err != nil {
@@ -486,6 +520,10 @@ var FundService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetBankPositions",
 			Handler:    _FundService_GetBankPositions_Handler,
+		},
+		{
+			MethodName: "GetMyPositions",
+			Handler:    _FundService_GetMyPositions_Handler,
 		},
 		{
 			MethodName: "ValidateFundAccount",

--- a/shared/proto/fund.proto
+++ b/shared/proto/fund.proto
@@ -12,6 +12,7 @@ service FundService {
   rpc InvestFund(InvestFundRequest) returns (FundResponse);
   rpc WithdrawFund(WithdrawFundRequest) returns (FundResponse);
   rpc GetBankPositions(GetBankPositionsRequest) returns (GetBankPositionsResponse);
+  rpc GetMyPositions(GetMyPositionsRequest) returns (GetMyPositionsResponse);
   rpc ValidateFundAccount(ValidateFundAccountRequest) returns (ValidateFundAccountResponse);
   rpc UpdateFundHolding(UpdateFundHoldingRequest) returns (UpdateFundHoldingResponse);
 }
@@ -98,6 +99,27 @@ message BankFundPosition {
 message GetBankPositionsRequest {}
 message GetBankPositionsResponse {
   repeated BankFundPosition positions = 1;
+}
+
+// ── GetMyPositions ────────────────────────────────────────────────────────────
+
+message ClientFundPosition {
+  int64  fund_id                = 1;
+  string fund_name              = 2;
+  string description            = 3;
+  double fund_value             = 4;
+  double fund_percentage        = 5;
+  double current_position_value = 6;
+  double total_invested_amount  = 7;
+  double profit                 = 8;
+  double minimum_contribution   = 9;
+}
+message GetMyPositionsRequest {
+  int64  client_id   = 1;
+  string client_type = 2;
+}
+message GetMyPositionsResponse {
+  repeated ClientFundPosition positions = 1;
 }
 
 // ── ValidateFundAccount ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds `GetMyPositions` RPC to `shared/proto/fund.proto` with `ClientFundPosition`, `GetMyPositionsRequest`, and `GetMyPositionsResponse` messages; regenerates bindings
- Implements the handler in `fund-service` — queries `client_fund_positions` joined with `investment_funds` and computes `currentPositionValue`, `fundPercentage`, and `profit`
- Adds `GetMyPositions` HTTP handler in the API Gateway and registers `GET /client/funds/positions` with `RequireRole("CLIENT")`

## Test plan

- [ ] `TestGetMyPositions_Empty` (gRPC) — client with no positions returns empty slice
- [ ] `TestGetMyPositions_Happy` (gRPC) — derived fields (`currentPositionValue`, `fundPercentage`, `profit`) are correct
- [ ] `TestGetMyPositions_NoToken` (gateway) — missing token returns 401
- [ ] `TestGetMyPositions_Empty` (gateway) — empty array returned with 200
- [ ] `TestGetMyPositions_Happy` (gateway) — correct JSON shape and field values

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)