### PR TITLE
BE-S2-08 InvestmentFund — fund ownership transfer on isSupervisor removal

### DIFF
--- a/services/api-gateway/handlers/employees.go
+++ b/services/api-gateway/handlers/employees.go
@@ -8,11 +8,14 @@ import (
 	"net/mail"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
+	"github.com/RAF-SI-2025/EXBanka-4-Backend/services/api-gateway/middleware"
 	authpb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/auth"
 	emailpb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/email"
 	pb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/employee"
+	pb_fund "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/fund"
 	"github.com/gin-gonic/gin"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -147,7 +150,7 @@ func GetEmployeeById(client pb.EmployeeServiceClient) gin.HandlerFunc {
 // @Failure      500   {object}  map[string]string
 // @Security     BearerAuth
 // @Router       /employees/{id} [put]
-func UpdateEmployee(client pb.EmployeeServiceClient) gin.HandlerFunc {
+func UpdateEmployee(empClient pb.EmployeeServiceClient, fundClient pb_fund.FundServiceClient) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 		if err != nil {
@@ -181,9 +184,33 @@ func UpdateEmployee(client pb.EmployeeServiceClient) gin.HandlerFunc {
 			return
 		}
 
+		// If SUPERVISOR is not in the new permissions, transfer any funds managed
+		// by this employee to the admin performing the action. Fund transfer happens
+		// first so a failure leaves permissions untouched.
+		newHasSupervisor := false
+		for _, p := range req.Permissions {
+			if strings.ToUpper(p) == "SUPERVISOR" {
+				newHasSupervisor = true
+				break
+			}
+		}
+		if !newHasSupervisor {
+			if adminId, tokenErr := middleware.GetUserIDFromToken(c); tokenErr == nil {
+				tCtx, tCancel := context.WithTimeout(c.Request.Context(), 10*time.Second)
+				defer tCancel()
+				if _, err := fundClient.TransferFundsByManager(tCtx, &pb_fund.TransferFundsByManagerRequest{
+					OldManagerId: id,
+					NewManagerId: adminId,
+				}); err != nil {
+					c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to transfer fund ownership"})
+					return
+				}
+			}
+		}
+
 		ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
 		defer cancel()
-		resp, err := client.UpdateEmployee(ctx, &pb.UpdateEmployeeRequest{
+		resp, err := empClient.UpdateEmployee(ctx, &pb.UpdateEmployeeRequest{
 			Id:          id,
 			FirstName:   req.FirstName,
 			LastName:    req.LastName,

--- a/services/api-gateway/handlers/employees_test.go
+++ b/services/api-gateway/handlers/employees_test.go
@@ -8,11 +8,14 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	authpb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/auth"
 	emailpb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/email"
 	pb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/employee"
+	pb_fund "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/fund"
 	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -415,27 +418,27 @@ var validUpdateBody = `{
 
 func TestUpdateEmployee_InvalidId(t *testing.T) {
 	client := &stubEmpClient{}
-	w := serveHandler(UpdateEmployee(client), "PUT", "/employees/:id", "/employees/abc", validUpdateBody)
+	w := serveHandler(UpdateEmployee(client, &stubFundClient{}), "PUT", "/employees/:id", "/employees/abc", validUpdateBody)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
 func TestUpdateEmployee_BadJSON(t *testing.T) {
 	client := &stubEmpClient{}
-	w := serveHandler(UpdateEmployee(client), "PUT", "/employees/:id", "/employees/1", `{invalid}`)
+	w := serveHandler(UpdateEmployee(client, &stubFundClient{}), "PUT", "/employees/:id", "/employees/1", `{invalid}`)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
 func TestUpdateEmployee_MissingRequiredField(t *testing.T) {
 	client := &stubEmpClient{}
 	// missing last_name
-	w := serveHandler(UpdateEmployee(client), "PUT", "/employees/:id", "/employees/1", `{"first_name":"Marko","email":"m@e.rs","username":"u"}`)
+	w := serveHandler(UpdateEmployee(client, &stubFundClient{}), "PUT", "/employees/:id", "/employees/1", `{"first_name":"Marko","email":"m@e.rs","username":"u"}`)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
 func TestUpdateEmployee_InvalidEmail(t *testing.T) {
 	client := &stubEmpClient{}
 	body := `{"first_name":"Marko","last_name":"M","email":"not-an-email","username":"u"}`
-	w := serveHandler(UpdateEmployee(client), "PUT", "/employees/:id", "/employees/1", body)
+	w := serveHandler(UpdateEmployee(client, &stubFundClient{}), "PUT", "/employees/:id", "/employees/1", body)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
@@ -445,7 +448,7 @@ func TestUpdateEmployee_NotFound(t *testing.T) {
 			return nil, status.Error(codes.NotFound, "not found")
 		},
 	}
-	w := serveHandler(UpdateEmployee(client), "PUT", "/employees/:id", "/employees/1", validUpdateBody)
+	w := serveHandler(UpdateEmployee(client, &stubFundClient{}), "PUT", "/employees/:id", "/employees/1", validUpdateBody)
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
@@ -455,7 +458,7 @@ func TestUpdateEmployee_Conflict(t *testing.T) {
 			return nil, status.Error(codes.AlreadyExists, "email already in use")
 		},
 	}
-	w := serveHandler(UpdateEmployee(client), "PUT", "/employees/:id", "/employees/1", validUpdateBody)
+	w := serveHandler(UpdateEmployee(client, &stubFundClient{}), "PUT", "/employees/:id", "/employees/1", validUpdateBody)
 	assert.Equal(t, http.StatusConflict, w.Code)
 }
 
@@ -465,7 +468,7 @@ func TestUpdateEmployee_FailedPrecondition(t *testing.T) {
 			return nil, status.Error(codes.FailedPrecondition, "invalid state")
 		},
 	}
-	w := serveHandler(UpdateEmployee(client), "PUT", "/employees/:id", "/employees/1", validUpdateBody)
+	w := serveHandler(UpdateEmployee(client, &stubFundClient{}), "PUT", "/employees/:id", "/employees/1", validUpdateBody)
 	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
 }
 
@@ -475,7 +478,7 @@ func TestUpdateEmployee_InternalError(t *testing.T) {
 			return nil, fmt.Errorf("db error")
 		},
 	}
-	w := serveHandler(UpdateEmployee(client), "PUT", "/employees/:id", "/employees/1", validUpdateBody)
+	w := serveHandler(UpdateEmployee(client, &stubFundClient{}), "PUT", "/employees/:id", "/employees/1", validUpdateBody)
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
@@ -486,7 +489,7 @@ func TestUpdateEmployee_Happy(t *testing.T) {
 			return &pb.UpdateEmployeeResponse{Employee: emp}, nil
 		},
 	}
-	w := serveHandler(UpdateEmployee(client), "PUT", "/employees/:id", "/employees/1", validUpdateBody)
+	w := serveHandler(UpdateEmployee(client, &stubFundClient{}), "PUT", "/employees/:id", "/employees/1", validUpdateBody)
 	require.Equal(t, http.StatusOK, w.Code)
 	var resp employeeResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
@@ -596,4 +599,80 @@ func TestToEmployeeResponse_NilPermissions(t *testing.T) {
 	r := toEmployeeResponse(emp)
 	assert.NotNil(t, r.Permissions)
 	assert.Len(t, r.Permissions, 0)
+}
+
+// ---- UpdateEmployee — supervisor removal / fund transfer ----
+
+func makeAdminToken() string {
+	claims := jwt.MapClaims{
+		"user_id": float64(99),
+		"role":    "EMPLOYEE",
+		"dozvole": []interface{}{"ADMIN", "SUPERVISOR"},
+		"exp":     time.Now().Add(time.Hour).Unix(),
+	}
+	tok, _ := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(""))
+	return "Bearer " + tok
+}
+
+var supervisorRemovalBody = `{
+	"first_name":"Ana","last_name":"Anić",
+	"email":"ana@exbanka.rs","username":"aanc",
+	"permissions":["READ"]
+}`
+
+func TestUpdateEmployee_SupervisorRemovedTransfersFunds(t *testing.T) {
+	transferCalled := false
+	fundStub := &stubFundClient{
+		transferFundsByManagerFn: func(_ context.Context, req *pb_fund.TransferFundsByManagerRequest, _ ...grpc.CallOption) (*pb_fund.TransferFundsByManagerResponse, error) {
+			transferCalled = true
+			assert.Equal(t, int64(1), req.OldManagerId)
+			assert.Equal(t, int64(99), req.NewManagerId) // admin user_id from token
+			return &pb_fund.TransferFundsByManagerResponse{FundsTransferred: 2}, nil
+		},
+	}
+	empStub := &stubEmpClient{
+		updateFn: func(_ context.Context, _ *pb.UpdateEmployeeRequest, _ ...grpc.CallOption) (*pb.UpdateEmployeeResponse, error) {
+			return &pb.UpdateEmployeeResponse{Employee: sampleEmployee()}, nil
+		},
+	}
+	w := serveHandlerFull(UpdateEmployee(empStub, fundStub), "PUT", "/employees/:id", "/employees/1", supervisorRemovalBody, makeAdminToken())
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.True(t, transferCalled, "fund transfer should have been called")
+}
+
+func TestUpdateEmployee_SupervisorRemovedFundTransferFails(t *testing.T) {
+	empUpdateCalled := false
+	fundStub := &stubFundClient{
+		transferFundsByManagerFn: func(_ context.Context, _ *pb_fund.TransferFundsByManagerRequest, _ ...grpc.CallOption) (*pb_fund.TransferFundsByManagerResponse, error) {
+			return nil, fmt.Errorf("fund db error")
+		},
+	}
+	empStub := &stubEmpClient{
+		updateFn: func(_ context.Context, _ *pb.UpdateEmployeeRequest, _ ...grpc.CallOption) (*pb.UpdateEmployeeResponse, error) {
+			empUpdateCalled = true
+			return &pb.UpdateEmployeeResponse{Employee: sampleEmployee()}, nil
+		},
+	}
+	w := serveHandlerFull(UpdateEmployee(empStub, fundStub), "PUT", "/employees/:id", "/employees/1", supervisorRemovalBody, makeAdminToken())
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.False(t, empUpdateCalled, "employee update should not have been called after fund transfer failure")
+}
+
+func TestUpdateEmployee_SupervisorKeptNoTransfer(t *testing.T) {
+	transferCalled := false
+	fundStub := &stubFundClient{
+		transferFundsByManagerFn: func(_ context.Context, _ *pb_fund.TransferFundsByManagerRequest, _ ...grpc.CallOption) (*pb_fund.TransferFundsByManagerResponse, error) {
+			transferCalled = true
+			return &pb_fund.TransferFundsByManagerResponse{}, nil
+		},
+	}
+	empStub := &stubEmpClient{
+		updateFn: func(_ context.Context, _ *pb.UpdateEmployeeRequest, _ ...grpc.CallOption) (*pb.UpdateEmployeeResponse, error) {
+			return &pb.UpdateEmployeeResponse{Employee: sampleEmployee()}, nil
+		},
+	}
+	body := `{"first_name":"Ana","last_name":"Anić","email":"ana@exbanka.rs","username":"aanc","permissions":["SUPERVISOR"]}`
+	w := serveHandlerFull(UpdateEmployee(empStub, fundStub), "PUT", "/employees/:id", "/employees/1", body, makeAdminToken())
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.False(t, transferCalled, "fund transfer should NOT be called when SUPERVISOR is kept")
 }

--- a/services/api-gateway/handlers/fund_test.go
+++ b/services/api-gateway/handlers/fund_test.go
@@ -31,18 +31,19 @@ func makeSupervisorToken() string {
 // ---- stub fund client ----
 
 type stubFundClient struct {
-	pingFn                func(context.Context, *pb.PingRequest, ...grpc.CallOption) (*pb.PingResponse, error)
-	createFundFn          func(context.Context, *pb.CreateFundRequest, ...grpc.CallOption) (*pb.FundResponse, error)
-	listFundsFn           func(context.Context, *pb.ListFundsRequest, ...grpc.CallOption) (*pb.ListFundsResponse, error)
-	getFundFn             func(context.Context, *pb.GetFundRequest, ...grpc.CallOption) (*pb.FundResponse, error)
-	updateFundFn          func(context.Context, *pb.UpdateFundRequest, ...grpc.CallOption) (*pb.FundResponse, error)
-	deleteFundFn          func(context.Context, *pb.DeleteFundRequest, ...grpc.CallOption) (*pb.DeleteFundResponse, error)
-	investFundFn          func(context.Context, *pb.InvestFundRequest, ...grpc.CallOption) (*pb.FundResponse, error)
-	withdrawFundFn        func(context.Context, *pb.WithdrawFundRequest, ...grpc.CallOption) (*pb.FundResponse, error)
-	getBankPositionsFn    func(context.Context, *pb.GetBankPositionsRequest, ...grpc.CallOption) (*pb.GetBankPositionsResponse, error)
-	validateFundAccountFn func(context.Context, *pb.ValidateFundAccountRequest, ...grpc.CallOption) (*pb.ValidateFundAccountResponse, error)
-	updateFundHoldingFn   func(context.Context, *pb.UpdateFundHoldingRequest, ...grpc.CallOption) (*pb.UpdateFundHoldingResponse, error)
-	getMyPositionsFn      func(context.Context, *pb.GetMyPositionsRequest, ...grpc.CallOption) (*pb.GetMyPositionsResponse, error)
+	pingFn                   func(context.Context, *pb.PingRequest, ...grpc.CallOption) (*pb.PingResponse, error)
+	createFundFn             func(context.Context, *pb.CreateFundRequest, ...grpc.CallOption) (*pb.FundResponse, error)
+	listFundsFn              func(context.Context, *pb.ListFundsRequest, ...grpc.CallOption) (*pb.ListFundsResponse, error)
+	getFundFn                func(context.Context, *pb.GetFundRequest, ...grpc.CallOption) (*pb.FundResponse, error)
+	updateFundFn             func(context.Context, *pb.UpdateFundRequest, ...grpc.CallOption) (*pb.FundResponse, error)
+	deleteFundFn             func(context.Context, *pb.DeleteFundRequest, ...grpc.CallOption) (*pb.DeleteFundResponse, error)
+	investFundFn             func(context.Context, *pb.InvestFundRequest, ...grpc.CallOption) (*pb.FundResponse, error)
+	withdrawFundFn           func(context.Context, *pb.WithdrawFundRequest, ...grpc.CallOption) (*pb.FundResponse, error)
+	getBankPositionsFn       func(context.Context, *pb.GetBankPositionsRequest, ...grpc.CallOption) (*pb.GetBankPositionsResponse, error)
+	validateFundAccountFn    func(context.Context, *pb.ValidateFundAccountRequest, ...grpc.CallOption) (*pb.ValidateFundAccountResponse, error)
+	updateFundHoldingFn      func(context.Context, *pb.UpdateFundHoldingRequest, ...grpc.CallOption) (*pb.UpdateFundHoldingResponse, error)
+	getMyPositionsFn         func(context.Context, *pb.GetMyPositionsRequest, ...grpc.CallOption) (*pb.GetMyPositionsResponse, error)
+	transferFundsByManagerFn func(context.Context, *pb.TransferFundsByManagerRequest, ...grpc.CallOption) (*pb.TransferFundsByManagerResponse, error)
 }
 
 func (s *stubFundClient) Ping(ctx context.Context, in *pb.PingRequest, opts ...grpc.CallOption) (*pb.PingResponse, error) {
@@ -116,6 +117,12 @@ func (s *stubFundClient) GetMyPositions(ctx context.Context, in *pb.GetMyPositio
 		return s.getMyPositionsFn(ctx, in, opts...)
 	}
 	return nil, fmt.Errorf("not implemented")
+}
+func (s *stubFundClient) TransferFundsByManager(ctx context.Context, in *pb.TransferFundsByManagerRequest, opts ...grpc.CallOption) (*pb.TransferFundsByManagerResponse, error) {
+	if s.transferFundsByManagerFn != nil {
+		return s.transferFundsByManagerFn(ctx, in, opts...)
+	}
+	return &pb.TransferFundsByManagerResponse{}, nil
 }
 
 // sampleFund returns a sample FundResponse.

--- a/services/api-gateway/main.go
+++ b/services/api-gateway/main.go
@@ -122,7 +122,7 @@ func main() {
 	r.GET("/employees/:id", middleware.RequireRole("ADMIN"), handlers.GetEmployeeById(employeeClient))
 	r.GET("/employees", middleware.RequireRole("ADMIN"), handlers.GetEmployees(employeeClient))
 	r.GET("/employees/search", middleware.RequireRole("ADMIN"), handlers.SearchEmployees(employeeClient))
-	r.PUT("/employees/:id", middleware.RequireRole("ADMIN"), handlers.UpdateEmployee(employeeClient))
+	r.PUT("/employees/:id", middleware.RequireRole("ADMIN"), handlers.UpdateEmployee(employeeClient, fundClient))
 	r.POST("/employees", middleware.RequireRole("ADMIN"), handlers.CreateEmployee(employeeClient, authClient, emailClient))
 	r.GET("/api/actuaries", middleware.RequireRole("SUPERVISOR"), handlers.GetActuaries(employeeClient))
 	r.PUT("/api/actuaries/:id/limit", middleware.RequireRole("SUPERVISOR"), handlers.SetAgentLimit(employeeClient))

--- a/services/fund-service/handlers/grpc_server.go
+++ b/services/fund-service/handlers/grpc_server.go
@@ -501,6 +501,17 @@ func (s *FundServer) UpdateFundHolding(ctx context.Context, req *pb.UpdateFundHo
 	return &pb.UpdateFundHoldingResponse{}, nil
 }
 
+func (s *FundServer) TransferFundsByManager(ctx context.Context, req *pb.TransferFundsByManagerRequest) (*pb.TransferFundsByManagerResponse, error) {
+	res, err := s.DB.ExecContext(ctx,
+		`UPDATE investment_funds SET manager_id = $1 WHERE manager_id = $2 AND active = TRUE`,
+		req.NewManagerId, req.OldManagerId)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "transfer funds: %v", err)
+	}
+	n, _ := res.RowsAffected()
+	return &pb.TransferFundsByManagerResponse{FundsTransferred: n}, nil
+}
+
 func (s *FundServer) GetMyPositions(ctx context.Context, req *pb.GetMyPositionsRequest) (*pb.GetMyPositionsResponse, error) {
 	rows, err := s.DB.QueryContext(ctx, `
 		SELECT cfp.fund_id,

--- a/services/fund-service/handlers/grpc_server_test.go
+++ b/services/fund-service/handlers/grpc_server_test.go
@@ -679,6 +679,38 @@ func TestUpdateFundHolding_Sell(t *testing.T) {
 	require.NoError(t, fundMock.ExpectationsWereMet())
 }
 
+func TestTransferFundsByManager_Happy(t *testing.T) {
+	s, fundMock, _, _ := newFundServer(t, &mockAccountClient{})
+
+	fundMock.ExpectExec("UPDATE investment_funds SET manager_id").
+		WithArgs(int64(99), int64(7)).
+		WillReturnResult(sqlmock.NewResult(0, 2))
+
+	resp, err := s.TransferFundsByManager(context.Background(), &pb.TransferFundsByManagerRequest{
+		OldManagerId: 7,
+		NewManagerId: 99,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), resp.FundsTransferred)
+	require.NoError(t, fundMock.ExpectationsWereMet())
+}
+
+func TestTransferFundsByManager_NoFunds(t *testing.T) {
+	s, fundMock, _, _ := newFundServer(t, &mockAccountClient{})
+
+	fundMock.ExpectExec("UPDATE investment_funds SET manager_id").
+		WithArgs(int64(99), int64(7)).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	resp, err := s.TransferFundsByManager(context.Background(), &pb.TransferFundsByManagerRequest{
+		OldManagerId: 7,
+		NewManagerId: 99,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), resp.FundsTransferred)
+	require.NoError(t, fundMock.ExpectationsWereMet())
+}
+
 func TestGetMyPositions_Empty(t *testing.T) {
 	s, fundMock, _, _ := newFundServer(t, &mockAccountClient{})
 

--- a/shared/pb/fund/fund.pb.go
+++ b/shared/pb/fund/fund.pb.go
@@ -1125,6 +1125,102 @@ func (x *GetMyPositionsResponse) GetPositions() []*ClientFundPosition {
 	return nil
 }
 
+type TransferFundsByManagerRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	OldManagerId  int64                  `protobuf:"varint,1,opt,name=old_manager_id,json=oldManagerId,proto3" json:"old_manager_id,omitempty"`
+	NewManagerId  int64                  `protobuf:"varint,2,opt,name=new_manager_id,json=newManagerId,proto3" json:"new_manager_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TransferFundsByManagerRequest) Reset() {
+	*x = TransferFundsByManagerRequest{}
+	mi := &file_fund_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TransferFundsByManagerRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TransferFundsByManagerRequest) ProtoMessage() {}
+
+func (x *TransferFundsByManagerRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_fund_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TransferFundsByManagerRequest.ProtoReflect.Descriptor instead.
+func (*TransferFundsByManagerRequest) Descriptor() ([]byte, []int) {
+	return file_fund_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *TransferFundsByManagerRequest) GetOldManagerId() int64 {
+	if x != nil {
+		return x.OldManagerId
+	}
+	return 0
+}
+
+func (x *TransferFundsByManagerRequest) GetNewManagerId() int64 {
+	if x != nil {
+		return x.NewManagerId
+	}
+	return 0
+}
+
+type TransferFundsByManagerResponse struct {
+	state            protoimpl.MessageState `protogen:"open.v1"`
+	FundsTransferred int64                  `protobuf:"varint,1,opt,name=funds_transferred,json=fundsTransferred,proto3" json:"funds_transferred,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *TransferFundsByManagerResponse) Reset() {
+	*x = TransferFundsByManagerResponse{}
+	mi := &file_fund_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TransferFundsByManagerResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TransferFundsByManagerResponse) ProtoMessage() {}
+
+func (x *TransferFundsByManagerResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_fund_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TransferFundsByManagerResponse.ProtoReflect.Descriptor instead.
+func (*TransferFundsByManagerResponse) Descriptor() ([]byte, []int) {
+	return file_fund_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *TransferFundsByManagerResponse) GetFundsTransferred() int64 {
+	if x != nil {
+		return x.FundsTransferred
+	}
+	return 0
+}
+
 type ValidateFundAccountRequest struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
 	FundId         int64                  `protobuf:"varint,1,opt,name=fund_id,json=fundId,proto3" json:"fund_id,omitempty"`
@@ -1136,7 +1232,7 @@ type ValidateFundAccountRequest struct {
 
 func (x *ValidateFundAccountRequest) Reset() {
 	*x = ValidateFundAccountRequest{}
-	mi := &file_fund_proto_msgTypes[18]
+	mi := &file_fund_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1148,7 +1244,7 @@ func (x *ValidateFundAccountRequest) String() string {
 func (*ValidateFundAccountRequest) ProtoMessage() {}
 
 func (x *ValidateFundAccountRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fund_proto_msgTypes[18]
+	mi := &file_fund_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1161,7 +1257,7 @@ func (x *ValidateFundAccountRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ValidateFundAccountRequest.ProtoReflect.Descriptor instead.
 func (*ValidateFundAccountRequest) Descriptor() ([]byte, []int) {
-	return file_fund_proto_rawDescGZIP(), []int{18}
+	return file_fund_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *ValidateFundAccountRequest) GetFundId() int64 {
@@ -1196,7 +1292,7 @@ type ValidateFundAccountResponse struct {
 
 func (x *ValidateFundAccountResponse) Reset() {
 	*x = ValidateFundAccountResponse{}
-	mi := &file_fund_proto_msgTypes[19]
+	mi := &file_fund_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1208,7 +1304,7 @@ func (x *ValidateFundAccountResponse) String() string {
 func (*ValidateFundAccountResponse) ProtoMessage() {}
 
 func (x *ValidateFundAccountResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fund_proto_msgTypes[19]
+	mi := &file_fund_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1221,7 +1317,7 @@ func (x *ValidateFundAccountResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ValidateFundAccountResponse.ProtoReflect.Descriptor instead.
 func (*ValidateFundAccountResponse) Descriptor() ([]byte, []int) {
-	return file_fund_proto_rawDescGZIP(), []int{19}
+	return file_fund_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *ValidateFundAccountResponse) GetAccountId() int64 {
@@ -1258,7 +1354,7 @@ type UpdateFundHoldingRequest struct {
 
 func (x *UpdateFundHoldingRequest) Reset() {
 	*x = UpdateFundHoldingRequest{}
-	mi := &file_fund_proto_msgTypes[20]
+	mi := &file_fund_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1270,7 +1366,7 @@ func (x *UpdateFundHoldingRequest) String() string {
 func (*UpdateFundHoldingRequest) ProtoMessage() {}
 
 func (x *UpdateFundHoldingRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fund_proto_msgTypes[20]
+	mi := &file_fund_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1283,7 +1379,7 @@ func (x *UpdateFundHoldingRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateFundHoldingRequest.ProtoReflect.Descriptor instead.
 func (*UpdateFundHoldingRequest) Descriptor() ([]byte, []int) {
-	return file_fund_proto_rawDescGZIP(), []int{20}
+	return file_fund_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *UpdateFundHoldingRequest) GetFundId() int64 {
@@ -1329,7 +1425,7 @@ type UpdateFundHoldingResponse struct {
 
 func (x *UpdateFundHoldingResponse) Reset() {
 	*x = UpdateFundHoldingResponse{}
-	mi := &file_fund_proto_msgTypes[21]
+	mi := &file_fund_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1341,7 +1437,7 @@ func (x *UpdateFundHoldingResponse) String() string {
 func (*UpdateFundHoldingResponse) ProtoMessage() {}
 
 func (x *UpdateFundHoldingResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fund_proto_msgTypes[21]
+	mi := &file_fund_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1354,7 +1450,7 @@ func (x *UpdateFundHoldingResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateFundHoldingResponse.ProtoReflect.Descriptor instead.
 func (*UpdateFundHoldingResponse) Descriptor() ([]byte, []int) {
-	return file_fund_proto_rawDescGZIP(), []int{21}
+	return file_fund_proto_rawDescGZIP(), []int{23}
 }
 
 var File_fund_proto protoreflect.FileDescriptor
@@ -1449,7 +1545,12 @@ const file_fund_proto_rawDesc = "" +
 	"\vclient_type\x18\x02 \x01(\tR\n" +
 	"clientType\"P\n" +
 	"\x16GetMyPositionsResponse\x126\n" +
-	"\tpositions\x18\x01 \x03(\v2\x18.fund.ClientFundPositionR\tpositions\"}\n" +
+	"\tpositions\x18\x01 \x03(\v2\x18.fund.ClientFundPositionR\tpositions\"k\n" +
+	"\x1dTransferFundsByManagerRequest\x12$\n" +
+	"\x0eold_manager_id\x18\x01 \x01(\x03R\foldManagerId\x12$\n" +
+	"\x0enew_manager_id\x18\x02 \x01(\x03R\fnewManagerId\"M\n" +
+	"\x1eTransferFundsByManagerResponse\x12+\n" +
+	"\x11funds_transferred\x18\x01 \x01(\x03R\x10fundsTransferred\"}\n" +
 	"\x1aValidateFundAccountRequest\x12\x17\n" +
 	"\afund_id\x18\x01 \x01(\x03R\x06fundId\x12\x1d\n" +
 	"\n" +
@@ -1467,7 +1568,7 @@ const file_fund_proto_rawDesc = "" +
 	"\bquantity\x18\x03 \x01(\x03R\bquantity\x12\x14\n" +
 	"\x05price\x18\x04 \x01(\x01R\x05price\x12\x1c\n" +
 	"\tdirection\x18\x05 \x01(\tR\tdirection\"\x1b\n" +
-	"\x19UpdateFundHoldingResponse2\xb2\x06\n" +
+	"\x19UpdateFundHoldingResponse2\x97\a\n" +
 	"\vFundService\x12-\n" +
 	"\x04Ping\x12\x11.fund.PingRequest\x1a\x12.fund.PingResponse\x129\n" +
 	"\n" +
@@ -1482,7 +1583,8 @@ const file_fund_proto_rawDesc = "" +
 	"InvestFund\x12\x17.fund.InvestFundRequest\x1a\x12.fund.FundResponse\x12=\n" +
 	"\fWithdrawFund\x12\x19.fund.WithdrawFundRequest\x1a\x12.fund.FundResponse\x12Q\n" +
 	"\x10GetBankPositions\x12\x1d.fund.GetBankPositionsRequest\x1a\x1e.fund.GetBankPositionsResponse\x12K\n" +
-	"\x0eGetMyPositions\x12\x1b.fund.GetMyPositionsRequest\x1a\x1c.fund.GetMyPositionsResponse\x12Z\n" +
+	"\x0eGetMyPositions\x12\x1b.fund.GetMyPositionsRequest\x1a\x1c.fund.GetMyPositionsResponse\x12c\n" +
+	"\x16TransferFundsByManager\x12#.fund.TransferFundsByManagerRequest\x1a$.fund.TransferFundsByManagerResponse\x12Z\n" +
 	"\x13ValidateFundAccount\x12 .fund.ValidateFundAccountRequest\x1a!.fund.ValidateFundAccountResponse\x12T\n" +
 	"\x11UpdateFundHolding\x12\x1e.fund.UpdateFundHoldingRequest\x1a\x1f.fund.UpdateFundHoldingResponseB9Z7github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/fundb\x06proto3"
 
@@ -1498,30 +1600,32 @@ func file_fund_proto_rawDescGZIP() []byte {
 	return file_fund_proto_rawDescData
 }
 
-var file_fund_proto_msgTypes = make([]protoimpl.MessageInfo, 22)
+var file_fund_proto_msgTypes = make([]protoimpl.MessageInfo, 24)
 var file_fund_proto_goTypes = []any{
-	(*PingRequest)(nil),                 // 0: fund.PingRequest
-	(*PingResponse)(nil),                // 1: fund.PingResponse
-	(*CreateFundRequest)(nil),           // 2: fund.CreateFundRequest
-	(*UpdateFundRequest)(nil),           // 3: fund.UpdateFundRequest
-	(*DeleteFundRequest)(nil),           // 4: fund.DeleteFundRequest
-	(*DeleteFundResponse)(nil),          // 5: fund.DeleteFundResponse
-	(*ListFundsRequest)(nil),            // 6: fund.ListFundsRequest
-	(*GetFundRequest)(nil),              // 7: fund.GetFundRequest
-	(*FundResponse)(nil),                // 8: fund.FundResponse
-	(*ListFundsResponse)(nil),           // 9: fund.ListFundsResponse
-	(*InvestFundRequest)(nil),           // 10: fund.InvestFundRequest
-	(*WithdrawFundRequest)(nil),         // 11: fund.WithdrawFundRequest
-	(*BankFundPosition)(nil),            // 12: fund.BankFundPosition
-	(*GetBankPositionsRequest)(nil),     // 13: fund.GetBankPositionsRequest
-	(*GetBankPositionsResponse)(nil),    // 14: fund.GetBankPositionsResponse
-	(*ClientFundPosition)(nil),          // 15: fund.ClientFundPosition
-	(*GetMyPositionsRequest)(nil),       // 16: fund.GetMyPositionsRequest
-	(*GetMyPositionsResponse)(nil),      // 17: fund.GetMyPositionsResponse
-	(*ValidateFundAccountRequest)(nil),  // 18: fund.ValidateFundAccountRequest
-	(*ValidateFundAccountResponse)(nil), // 19: fund.ValidateFundAccountResponse
-	(*UpdateFundHoldingRequest)(nil),    // 20: fund.UpdateFundHoldingRequest
-	(*UpdateFundHoldingResponse)(nil),   // 21: fund.UpdateFundHoldingResponse
+	(*PingRequest)(nil),                    // 0: fund.PingRequest
+	(*PingResponse)(nil),                   // 1: fund.PingResponse
+	(*CreateFundRequest)(nil),              // 2: fund.CreateFundRequest
+	(*UpdateFundRequest)(nil),              // 3: fund.UpdateFundRequest
+	(*DeleteFundRequest)(nil),              // 4: fund.DeleteFundRequest
+	(*DeleteFundResponse)(nil),             // 5: fund.DeleteFundResponse
+	(*ListFundsRequest)(nil),               // 6: fund.ListFundsRequest
+	(*GetFundRequest)(nil),                 // 7: fund.GetFundRequest
+	(*FundResponse)(nil),                   // 8: fund.FundResponse
+	(*ListFundsResponse)(nil),              // 9: fund.ListFundsResponse
+	(*InvestFundRequest)(nil),              // 10: fund.InvestFundRequest
+	(*WithdrawFundRequest)(nil),            // 11: fund.WithdrawFundRequest
+	(*BankFundPosition)(nil),               // 12: fund.BankFundPosition
+	(*GetBankPositionsRequest)(nil),        // 13: fund.GetBankPositionsRequest
+	(*GetBankPositionsResponse)(nil),       // 14: fund.GetBankPositionsResponse
+	(*ClientFundPosition)(nil),             // 15: fund.ClientFundPosition
+	(*GetMyPositionsRequest)(nil),          // 16: fund.GetMyPositionsRequest
+	(*GetMyPositionsResponse)(nil),         // 17: fund.GetMyPositionsResponse
+	(*TransferFundsByManagerRequest)(nil),  // 18: fund.TransferFundsByManagerRequest
+	(*TransferFundsByManagerResponse)(nil), // 19: fund.TransferFundsByManagerResponse
+	(*ValidateFundAccountRequest)(nil),     // 20: fund.ValidateFundAccountRequest
+	(*ValidateFundAccountResponse)(nil),    // 21: fund.ValidateFundAccountResponse
+	(*UpdateFundHoldingRequest)(nil),       // 22: fund.UpdateFundHoldingRequest
+	(*UpdateFundHoldingResponse)(nil),      // 23: fund.UpdateFundHoldingResponse
 }
 var file_fund_proto_depIdxs = []int32{
 	8,  // 0: fund.ListFundsResponse.funds:type_name -> fund.FundResponse
@@ -1537,22 +1641,24 @@ var file_fund_proto_depIdxs = []int32{
 	11, // 10: fund.FundService.WithdrawFund:input_type -> fund.WithdrawFundRequest
 	13, // 11: fund.FundService.GetBankPositions:input_type -> fund.GetBankPositionsRequest
 	16, // 12: fund.FundService.GetMyPositions:input_type -> fund.GetMyPositionsRequest
-	18, // 13: fund.FundService.ValidateFundAccount:input_type -> fund.ValidateFundAccountRequest
-	20, // 14: fund.FundService.UpdateFundHolding:input_type -> fund.UpdateFundHoldingRequest
-	1,  // 15: fund.FundService.Ping:output_type -> fund.PingResponse
-	8,  // 16: fund.FundService.CreateFund:output_type -> fund.FundResponse
-	9,  // 17: fund.FundService.ListFunds:output_type -> fund.ListFundsResponse
-	8,  // 18: fund.FundService.GetFund:output_type -> fund.FundResponse
-	8,  // 19: fund.FundService.UpdateFund:output_type -> fund.FundResponse
-	5,  // 20: fund.FundService.DeleteFund:output_type -> fund.DeleteFundResponse
-	8,  // 21: fund.FundService.InvestFund:output_type -> fund.FundResponse
-	8,  // 22: fund.FundService.WithdrawFund:output_type -> fund.FundResponse
-	14, // 23: fund.FundService.GetBankPositions:output_type -> fund.GetBankPositionsResponse
-	17, // 24: fund.FundService.GetMyPositions:output_type -> fund.GetMyPositionsResponse
-	19, // 25: fund.FundService.ValidateFundAccount:output_type -> fund.ValidateFundAccountResponse
-	21, // 26: fund.FundService.UpdateFundHolding:output_type -> fund.UpdateFundHoldingResponse
-	15, // [15:27] is the sub-list for method output_type
-	3,  // [3:15] is the sub-list for method input_type
+	18, // 13: fund.FundService.TransferFundsByManager:input_type -> fund.TransferFundsByManagerRequest
+	20, // 14: fund.FundService.ValidateFundAccount:input_type -> fund.ValidateFundAccountRequest
+	22, // 15: fund.FundService.UpdateFundHolding:input_type -> fund.UpdateFundHoldingRequest
+	1,  // 16: fund.FundService.Ping:output_type -> fund.PingResponse
+	8,  // 17: fund.FundService.CreateFund:output_type -> fund.FundResponse
+	9,  // 18: fund.FundService.ListFunds:output_type -> fund.ListFundsResponse
+	8,  // 19: fund.FundService.GetFund:output_type -> fund.FundResponse
+	8,  // 20: fund.FundService.UpdateFund:output_type -> fund.FundResponse
+	5,  // 21: fund.FundService.DeleteFund:output_type -> fund.DeleteFundResponse
+	8,  // 22: fund.FundService.InvestFund:output_type -> fund.FundResponse
+	8,  // 23: fund.FundService.WithdrawFund:output_type -> fund.FundResponse
+	14, // 24: fund.FundService.GetBankPositions:output_type -> fund.GetBankPositionsResponse
+	17, // 25: fund.FundService.GetMyPositions:output_type -> fund.GetMyPositionsResponse
+	19, // 26: fund.FundService.TransferFundsByManager:output_type -> fund.TransferFundsByManagerResponse
+	21, // 27: fund.FundService.ValidateFundAccount:output_type -> fund.ValidateFundAccountResponse
+	23, // 28: fund.FundService.UpdateFundHolding:output_type -> fund.UpdateFundHoldingResponse
+	16, // [16:29] is the sub-list for method output_type
+	3,  // [3:16] is the sub-list for method input_type
 	3,  // [3:3] is the sub-list for extension type_name
 	3,  // [3:3] is the sub-list for extension extendee
 	0,  // [0:3] is the sub-list for field type_name
@@ -1569,7 +1675,7 @@ func file_fund_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_fund_proto_rawDesc), len(file_fund_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   22,
+			NumMessages:   24,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/shared/pb/fund/fund_grpc.pb.go
+++ b/shared/pb/fund/fund_grpc.pb.go
@@ -19,18 +19,19 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	FundService_Ping_FullMethodName                = "/fund.FundService/Ping"
-	FundService_CreateFund_FullMethodName          = "/fund.FundService/CreateFund"
-	FundService_ListFunds_FullMethodName           = "/fund.FundService/ListFunds"
-	FundService_GetFund_FullMethodName             = "/fund.FundService/GetFund"
-	FundService_UpdateFund_FullMethodName          = "/fund.FundService/UpdateFund"
-	FundService_DeleteFund_FullMethodName          = "/fund.FundService/DeleteFund"
-	FundService_InvestFund_FullMethodName          = "/fund.FundService/InvestFund"
-	FundService_WithdrawFund_FullMethodName        = "/fund.FundService/WithdrawFund"
-	FundService_GetBankPositions_FullMethodName    = "/fund.FundService/GetBankPositions"
-	FundService_GetMyPositions_FullMethodName      = "/fund.FundService/GetMyPositions"
-	FundService_ValidateFundAccount_FullMethodName = "/fund.FundService/ValidateFundAccount"
-	FundService_UpdateFundHolding_FullMethodName   = "/fund.FundService/UpdateFundHolding"
+	FundService_Ping_FullMethodName                   = "/fund.FundService/Ping"
+	FundService_CreateFund_FullMethodName             = "/fund.FundService/CreateFund"
+	FundService_ListFunds_FullMethodName              = "/fund.FundService/ListFunds"
+	FundService_GetFund_FullMethodName                = "/fund.FundService/GetFund"
+	FundService_UpdateFund_FullMethodName             = "/fund.FundService/UpdateFund"
+	FundService_DeleteFund_FullMethodName             = "/fund.FundService/DeleteFund"
+	FundService_InvestFund_FullMethodName             = "/fund.FundService/InvestFund"
+	FundService_WithdrawFund_FullMethodName           = "/fund.FundService/WithdrawFund"
+	FundService_GetBankPositions_FullMethodName       = "/fund.FundService/GetBankPositions"
+	FundService_GetMyPositions_FullMethodName         = "/fund.FundService/GetMyPositions"
+	FundService_TransferFundsByManager_FullMethodName = "/fund.FundService/TransferFundsByManager"
+	FundService_ValidateFundAccount_FullMethodName    = "/fund.FundService/ValidateFundAccount"
+	FundService_UpdateFundHolding_FullMethodName      = "/fund.FundService/UpdateFundHolding"
 )
 
 // FundServiceClient is the client API for FundService service.
@@ -47,6 +48,7 @@ type FundServiceClient interface {
 	WithdrawFund(ctx context.Context, in *WithdrawFundRequest, opts ...grpc.CallOption) (*FundResponse, error)
 	GetBankPositions(ctx context.Context, in *GetBankPositionsRequest, opts ...grpc.CallOption) (*GetBankPositionsResponse, error)
 	GetMyPositions(ctx context.Context, in *GetMyPositionsRequest, opts ...grpc.CallOption) (*GetMyPositionsResponse, error)
+	TransferFundsByManager(ctx context.Context, in *TransferFundsByManagerRequest, opts ...grpc.CallOption) (*TransferFundsByManagerResponse, error)
 	ValidateFundAccount(ctx context.Context, in *ValidateFundAccountRequest, opts ...grpc.CallOption) (*ValidateFundAccountResponse, error)
 	UpdateFundHolding(ctx context.Context, in *UpdateFundHoldingRequest, opts ...grpc.CallOption) (*UpdateFundHoldingResponse, error)
 }
@@ -159,6 +161,16 @@ func (c *fundServiceClient) GetMyPositions(ctx context.Context, in *GetMyPositio
 	return out, nil
 }
 
+func (c *fundServiceClient) TransferFundsByManager(ctx context.Context, in *TransferFundsByManagerRequest, opts ...grpc.CallOption) (*TransferFundsByManagerResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(TransferFundsByManagerResponse)
+	err := c.cc.Invoke(ctx, FundService_TransferFundsByManager_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *fundServiceClient) ValidateFundAccount(ctx context.Context, in *ValidateFundAccountRequest, opts ...grpc.CallOption) (*ValidateFundAccountResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(ValidateFundAccountResponse)
@@ -193,6 +205,7 @@ type FundServiceServer interface {
 	WithdrawFund(context.Context, *WithdrawFundRequest) (*FundResponse, error)
 	GetBankPositions(context.Context, *GetBankPositionsRequest) (*GetBankPositionsResponse, error)
 	GetMyPositions(context.Context, *GetMyPositionsRequest) (*GetMyPositionsResponse, error)
+	TransferFundsByManager(context.Context, *TransferFundsByManagerRequest) (*TransferFundsByManagerResponse, error)
 	ValidateFundAccount(context.Context, *ValidateFundAccountRequest) (*ValidateFundAccountResponse, error)
 	UpdateFundHolding(context.Context, *UpdateFundHoldingRequest) (*UpdateFundHoldingResponse, error)
 	mustEmbedUnimplementedFundServiceServer()
@@ -234,6 +247,9 @@ func (UnimplementedFundServiceServer) GetBankPositions(context.Context, *GetBank
 }
 func (UnimplementedFundServiceServer) GetMyPositions(context.Context, *GetMyPositionsRequest) (*GetMyPositionsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetMyPositions not implemented")
+}
+func (UnimplementedFundServiceServer) TransferFundsByManager(context.Context, *TransferFundsByManagerRequest) (*TransferFundsByManagerResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method TransferFundsByManager not implemented")
 }
 func (UnimplementedFundServiceServer) ValidateFundAccount(context.Context, *ValidateFundAccountRequest) (*ValidateFundAccountResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ValidateFundAccount not implemented")
@@ -442,6 +458,24 @@ func _FundService_GetMyPositions_Handler(srv interface{}, ctx context.Context, d
 	return interceptor(ctx, in, info, handler)
 }
 
+func _FundService_TransferFundsByManager_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(TransferFundsByManagerRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(FundServiceServer).TransferFundsByManager(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: FundService_TransferFundsByManager_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(FundServiceServer).TransferFundsByManager(ctx, req.(*TransferFundsByManagerRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _FundService_ValidateFundAccount_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(ValidateFundAccountRequest)
 	if err := dec(in); err != nil {
@@ -524,6 +558,10 @@ var FundService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetMyPositions",
 			Handler:    _FundService_GetMyPositions_Handler,
+		},
+		{
+			MethodName: "TransferFundsByManager",
+			Handler:    _FundService_TransferFundsByManager_Handler,
 		},
 		{
 			MethodName: "ValidateFundAccount",

--- a/shared/proto/fund.proto
+++ b/shared/proto/fund.proto
@@ -13,6 +13,7 @@ service FundService {
   rpc WithdrawFund(WithdrawFundRequest) returns (FundResponse);
   rpc GetBankPositions(GetBankPositionsRequest) returns (GetBankPositionsResponse);
   rpc GetMyPositions(GetMyPositionsRequest) returns (GetMyPositionsResponse);
+  rpc TransferFundsByManager(TransferFundsByManagerRequest) returns (TransferFundsByManagerResponse);
   rpc ValidateFundAccount(ValidateFundAccountRequest) returns (ValidateFundAccountResponse);
   rpc UpdateFundHolding(UpdateFundHoldingRequest) returns (UpdateFundHoldingResponse);
 }
@@ -120,6 +121,16 @@ message GetMyPositionsRequest {
 }
 message GetMyPositionsResponse {
   repeated ClientFundPosition positions = 1;
+}
+
+// ── TransferFundsByManager ────────────────────────────────────────────────────
+
+message TransferFundsByManagerRequest {
+  int64 old_manager_id = 1;
+  int64 new_manager_id = 2;
+}
+message TransferFundsByManagerResponse {
+  int64 funds_transferred = 1;
 }
 
 // ── ValidateFundAccount ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds `TransferFundsByManager` RPC to `fund-service` — single `UPDATE investment_funds SET manager_id` scoped to active funds, atomic within fund-service DB
- Extends the API Gateway `UpdateEmployee` handler to accept a `fundClient`; when the new permissions list omits `SUPERVISOR`, it calls `TransferFundsByManager(supervisorId → adminId)` **before** the permission update, so a transfer failure leaves permissions untouched
- Updates `main.go` to wire `fundClient` into `UpdateEmployee`

## Test plan

- [ ] `TestTransferFundsByManager_Happy` (gRPC) — 2 funds transferred, correct row count returned
- [ ] `TestTransferFundsByManager_NoFunds` (gRPC) — 0 rows affected, no error
- [ ] `TestUpdateEmployee_SupervisorRemovedTransfersFunds` (gateway) — admin token, SUPERVISOR removed → transfer called with correct IDs, 200 returned
- [ ] `TestUpdateEmployee_SupervisorRemovedFundTransferFails` (gateway) — transfer fails → 500, employee update NOT called
- [ ] `TestUpdateEmployee_SupervisorKeptNoTransfer` (gateway) — SUPERVISOR kept → fund client NOT called, 200 returned
- [ ] All existing `UpdateEmployee` tests continue to pass

Closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)