### PR TITLE
feat: fund portfolio buy/sell securities endpoints (#233)

### DIFF
--- a/services/api-gateway/handlers/fund.go
+++ b/services/api-gateway/handlers/fund.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/RAF-SI-2025/EXBanka-4-Backend/services/api-gateway/middleware"
 	pb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/fund"
+	pb_order "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/order"
+	pb_sec "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/securities"
 	"github.com/gin-gonic/gin"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -460,6 +462,241 @@ func BankRedeemFund(client pb.FundServiceClient) gin.HandlerFunc {
 			return
 		}
 		c.JSON(http.StatusOK, fundToJSON(resp))
+	}
+}
+
+func GetFundSecurities(fundClient pb.FundServiceClient, secClient pb_sec.SecuritiesServiceClient) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid fund id"})
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 15*time.Second)
+		defer cancel()
+
+		portfolio, err := fundClient.GetFundPortfolio(ctx, &pb.GetFundPortfolioRequest{FundId: id})
+		if err != nil {
+			mapFundError(c, err)
+			return
+		}
+
+		result := make([]gin.H, 0, len(portfolio.Positions))
+		for _, pos := range portfolio.Positions {
+			secResp, err := secClient.GetListingById(ctx, &pb_sec.GetListingByIdRequest{Id: pos.ListingId})
+			if err != nil || secResp.Summary == nil {
+				continue
+			}
+			s := secResp.Summary
+			result = append(result, gin.H{
+				"ticker":            s.Ticker,
+				"name":              s.Name,
+				"amount":            pos.Quantity,
+				"currentPrice":      s.Price,
+				"change":            s.ChangePercent,
+				"volume":            s.Volume,
+				"initialMarginCost": s.InitialMarginCost,
+				"acquisitionDate":   pos.AcquisitionDate,
+				"averageCost":       pos.AverageCost,
+			})
+		}
+		c.JSON(http.StatusOK, result)
+	}
+}
+
+func BuyFundSecurities(fundClient pb.FundServiceClient, secClient pb_sec.SecuritiesServiceClient, orderClient pb_order.OrderServiceClient) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid fund id"})
+			return
+		}
+		var body struct {
+			Ticker string `json:"ticker" binding:"required"`
+			Amount int32  `json:"amount" binding:"required"`
+		}
+		if err := c.ShouldBindJSON(&body); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+
+		userID, err := middleware.GetUserIDFromToken(c)
+		if err != nil {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "could not extract identity from token"})
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 15*time.Second)
+		defer cancel()
+
+		secResp, err := secClient.GetListings(ctx, &pb_sec.GetListingsRequest{TickerPrefix: body.Ticker, PageSize: 1})
+		if err != nil || len(secResp.Listings) == 0 {
+			c.JSON(http.StatusNotFound, gin.H{"error": "ticker not found"})
+			return
+		}
+		listing := secResp.Listings[0]
+
+		requiredAmount := float64(body.Amount) * listing.Price
+		var accountID int64
+
+		if middleware.CallerHasPermission(c, "ADMIN") {
+			fundResp, err := fundClient.GetFund(ctx, &pb.GetFundRequest{Id: id})
+			if err != nil {
+				mapFundError(c, err)
+				return
+			}
+			if fundResp.LiquidAssets < requiredAmount {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "insufficient fund liquidity"})
+				return
+			}
+			accountID = fundResp.AccountId
+		} else {
+			vResp, vErr := fundClient.ValidateFundAccount(ctx, &pb.ValidateFundAccountRequest{
+				FundId:         id,
+				ManagerId:      userID,
+				RequiredAmount: requiredAmount,
+			})
+			if vErr != nil {
+				switch status.Code(vErr) {
+				case codes.NotFound:
+					c.JSON(http.StatusNotFound, gin.H{"error": "fund not found"})
+				case codes.PermissionDenied:
+					c.JSON(http.StatusForbidden, gin.H{"error": "you are not the manager of this fund"})
+				default:
+					c.JSON(http.StatusInternalServerError, gin.H{"error": vErr.Error()})
+				}
+				return
+			}
+			if !vResp.IsLiquid {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "insufficient fund liquidity"})
+				return
+			}
+			accountID = vResp.AccountId
+		}
+
+		resp, err := orderClient.CreateOrder(ctx, &pb_order.CreateOrderRequest{
+			UserId:    userID,
+			UserType:  middleware.GetCallerRoleFromToken(c),
+			AssetId:   listing.Id,
+			Quantity:  body.Amount,
+			AccountId: accountID,
+			Direction: "BUY",
+			FundId:    id,
+		})
+		if err != nil {
+			orderError(c, err)
+			return
+		}
+		c.JSON(http.StatusCreated, gin.H{
+			"orderId":          resp.OrderId,
+			"orderType":        resp.OrderType,
+			"status":           resp.Status,
+			"approximatePrice": resp.ApproximatePrice,
+		})
+	}
+}
+
+func SellFundSecurities(fundClient pb.FundServiceClient, secClient pb_sec.SecuritiesServiceClient, orderClient pb_order.OrderServiceClient) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid fund id"})
+			return
+		}
+		var body struct {
+			Ticker string `json:"ticker" binding:"required"`
+			Amount int32  `json:"amount" binding:"required"`
+		}
+		if err := c.ShouldBindJSON(&body); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+
+		userID, err := middleware.GetUserIDFromToken(c)
+		if err != nil {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "could not extract identity from token"})
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 15*time.Second)
+		defer cancel()
+
+		secResp, err := secClient.GetListings(ctx, &pb_sec.GetListingsRequest{TickerPrefix: body.Ticker, PageSize: 1})
+		if err != nil || len(secResp.Listings) == 0 {
+			c.JSON(http.StatusNotFound, gin.H{"error": "ticker not found"})
+			return
+		}
+		listing := secResp.Listings[0]
+
+		portfolio, err := fundClient.GetFundPortfolio(ctx, &pb.GetFundPortfolioRequest{FundId: id})
+		if err != nil {
+			mapFundError(c, err)
+			return
+		}
+		var heldQty float64
+		for _, pos := range portfolio.Positions {
+			if pos.ListingId == listing.Id {
+				heldQty = pos.Quantity
+				break
+			}
+		}
+		if heldQty == 0 {
+			c.JSON(http.StatusNotFound, gin.H{"error": "fund does not hold this ticker"})
+			return
+		}
+		if heldQty < float64(body.Amount) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "insufficient amount in fund portfolio"})
+			return
+		}
+
+		var accountID int64
+		if middleware.CallerHasPermission(c, "ADMIN") {
+			fundResp, err := fundClient.GetFund(ctx, &pb.GetFundRequest{Id: id})
+			if err != nil {
+				mapFundError(c, err)
+				return
+			}
+			accountID = fundResp.AccountId
+		} else {
+			vResp, vErr := fundClient.ValidateFundAccount(ctx, &pb.ValidateFundAccountRequest{
+				FundId:         id,
+				ManagerId:      userID,
+				RequiredAmount: 0,
+			})
+			if vErr != nil {
+				switch status.Code(vErr) {
+				case codes.NotFound:
+					c.JSON(http.StatusNotFound, gin.H{"error": "fund not found"})
+				case codes.PermissionDenied:
+					c.JSON(http.StatusForbidden, gin.H{"error": "you are not the manager of this fund"})
+				default:
+					c.JSON(http.StatusInternalServerError, gin.H{"error": vErr.Error()})
+				}
+				return
+			}
+			accountID = vResp.AccountId
+		}
+
+		resp, err := orderClient.CreateOrder(ctx, &pb_order.CreateOrderRequest{
+			UserId:    userID,
+			UserType:  middleware.GetCallerRoleFromToken(c),
+			AssetId:   listing.Id,
+			Quantity:  body.Amount,
+			AccountId: accountID,
+			Direction: "SELL",
+			FundId:    id,
+		})
+		if err != nil {
+			orderError(c, err)
+			return
+		}
+		c.JSON(http.StatusCreated, gin.H{
+			"orderId":          resp.OrderId,
+			"orderType":        resp.OrderType,
+			"status":           resp.Status,
+			"approximatePrice": resp.ApproximatePrice,
+		})
 	}
 }
 

--- a/services/api-gateway/handlers/fund_test.go
+++ b/services/api-gateway/handlers/fund_test.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	pb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/fund"
+	pb_order "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/order"
+	pb_sec "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/securities"
 	"github.com/golang-jwt/jwt/v5"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -44,6 +46,7 @@ type stubFundClient struct {
 	updateFundHoldingFn      func(context.Context, *pb.UpdateFundHoldingRequest, ...grpc.CallOption) (*pb.UpdateFundHoldingResponse, error)
 	getMyPositionsFn         func(context.Context, *pb.GetMyPositionsRequest, ...grpc.CallOption) (*pb.GetMyPositionsResponse, error)
 	transferFundsByManagerFn func(context.Context, *pb.TransferFundsByManagerRequest, ...grpc.CallOption) (*pb.TransferFundsByManagerResponse, error)
+	getFundPortfolioFn       func(context.Context, *pb.GetFundPortfolioRequest, ...grpc.CallOption) (*pb.GetFundPortfolioResponse, error)
 }
 
 func (s *stubFundClient) Ping(ctx context.Context, in *pb.PingRequest, opts ...grpc.CallOption) (*pb.PingResponse, error) {
@@ -123,6 +126,12 @@ func (s *stubFundClient) TransferFundsByManager(ctx context.Context, in *pb.Tran
 		return s.transferFundsByManagerFn(ctx, in, opts...)
 	}
 	return &pb.TransferFundsByManagerResponse{}, nil
+}
+func (s *stubFundClient) GetFundPortfolio(ctx context.Context, in *pb.GetFundPortfolioRequest, opts ...grpc.CallOption) (*pb.GetFundPortfolioResponse, error) {
+	if s.getFundPortfolioFn != nil {
+		return s.getFundPortfolioFn(ctx, in, opts...)
+	}
+	return &pb.GetFundPortfolioResponse{}, nil
 }
 
 // sampleFund returns a sample FundResponse.
@@ -477,5 +486,214 @@ func TestGetMyPositions_Happy(t *testing.T) {
 	}
 	if resp[0]["profit"] != float64(40000) {
 		t.Fatalf("unexpected profit: %v", resp[0]["profit"])
+	}
+}
+
+// ---- GetFundSecurities tests ----
+
+func TestGetFundSecurities_Empty(t *testing.T) {
+	fund := &stubFundClient{
+		getFundPortfolioFn: func(_ context.Context, _ *pb.GetFundPortfolioRequest, _ ...grpc.CallOption) (*pb.GetFundPortfolioResponse, error) {
+			return &pb.GetFundPortfolioResponse{Positions: []*pb.FundPortfolioPosition{}}, nil
+		},
+	}
+	w := serveHandlerFull(GetFundSecurities(fund, &stubSecuritiesClient{}), "GET", "/investment/funds/:id/securities", "/investment/funds/1/securities", "", makeSupervisorToken())
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d: %s", w.Code, w.Body.String())
+	}
+	var resp []interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if len(resp) != 0 {
+		t.Fatalf("expected empty array, got %d items", len(resp))
+	}
+}
+
+func TestGetFundSecurities_Happy(t *testing.T) {
+	fund := &stubFundClient{
+		getFundPortfolioFn: func(_ context.Context, _ *pb.GetFundPortfolioRequest, _ ...grpc.CallOption) (*pb.GetFundPortfolioResponse, error) {
+			return &pb.GetFundPortfolioResponse{
+				Positions: []*pb.FundPortfolioPosition{
+					{ListingId: 10, Quantity: 50, AverageCost: 125.0, AcquisitionDate: "2026-04-01"},
+				},
+			}, nil
+		},
+	}
+	sec := &stubSecuritiesClient{
+		getListingByIdFn: func(_ context.Context, req *pb_sec.GetListingByIdRequest, _ ...grpc.CallOption) (*pb_sec.GetListingByIdResponse, error) {
+			return &pb_sec.GetListingByIdResponse{
+				Summary: &pb_sec.ListingSummary{
+					Id: 10, Ticker: "AAPL", Name: "Apple Inc.", Price: 175.0,
+					ChangePercent: 1.25, Volume: 50000, InitialMarginCost: 3500.0,
+				},
+			}, nil
+		},
+	}
+	w := serveHandlerFull(GetFundSecurities(fund, sec), "GET", "/investment/funds/:id/securities", "/investment/funds/1/securities", "", makeSupervisorToken())
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d: %s", w.Code, w.Body.String())
+	}
+	var resp []map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if len(resp) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(resp))
+	}
+	if resp[0]["ticker"] != "AAPL" {
+		t.Fatalf("unexpected ticker: %v", resp[0]["ticker"])
+	}
+	if resp[0]["acquisitionDate"] != "2026-04-01" {
+		t.Fatalf("unexpected acquisitionDate: %v", resp[0]["acquisitionDate"])
+	}
+}
+
+// ---- BuyFundSecurities tests ----
+
+var buyBody = `{"ticker":"AAPL","amount":10}`
+
+func TestBuyFundSecurities_TickerNotFound(t *testing.T) {
+	sec := &stubSecuritiesClient{
+		getListingsFn: func(_ context.Context, _ *pb_sec.GetListingsRequest, _ ...grpc.CallOption) (*pb_sec.GetListingsResponse, error) {
+			return &pb_sec.GetListingsResponse{Listings: []*pb_sec.ListingSummary{}}, nil
+		},
+	}
+	w := serveHandlerFull(BuyFundSecurities(&stubFundClient{}, sec, &stubOrderClient{}), "POST", "/investment/funds/:id/securities/buy", "/investment/funds/1/securities/buy", buyBody, makeSupervisorToken())
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestBuyFundSecurities_InsufficientLiquidity(t *testing.T) {
+	sec := &stubSecuritiesClient{
+		getListingsFn: func(_ context.Context, _ *pb_sec.GetListingsRequest, _ ...grpc.CallOption) (*pb_sec.GetListingsResponse, error) {
+			return &pb_sec.GetListingsResponse{Listings: []*pb_sec.ListingSummary{{Id: 10, Price: 175.0}}}, nil
+		},
+	}
+	fund := &stubFundClient{
+		validateFundAccountFn: func(_ context.Context, _ *pb.ValidateFundAccountRequest, _ ...grpc.CallOption) (*pb.ValidateFundAccountResponse, error) {
+			return &pb.ValidateFundAccountResponse{AccountId: 100, IsLiquid: false, LiquidAssets: 100.0}, nil
+		},
+	}
+	w := serveHandlerFull(BuyFundSecurities(fund, sec, &stubOrderClient{}), "POST", "/investment/funds/:id/securities/buy", "/investment/funds/1/securities/buy", buyBody, makeSupervisorToken())
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestBuyFundSecurities_NotManager(t *testing.T) {
+	sec := &stubSecuritiesClient{
+		getListingsFn: func(_ context.Context, _ *pb_sec.GetListingsRequest, _ ...grpc.CallOption) (*pb_sec.GetListingsResponse, error) {
+			return &pb_sec.GetListingsResponse{Listings: []*pb_sec.ListingSummary{{Id: 10, Price: 175.0}}}, nil
+		},
+	}
+	fund := &stubFundClient{
+		validateFundAccountFn: func(_ context.Context, _ *pb.ValidateFundAccountRequest, _ ...grpc.CallOption) (*pb.ValidateFundAccountResponse, error) {
+			return nil, status.Error(codes.PermissionDenied, "not the fund manager")
+		},
+	}
+	w := serveHandlerFull(BuyFundSecurities(fund, sec, &stubOrderClient{}), "POST", "/investment/funds/:id/securities/buy", "/investment/funds/1/securities/buy", buyBody, makeSupervisorToken())
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestBuyFundSecurities_Success(t *testing.T) {
+	sec := &stubSecuritiesClient{
+		getListingsFn: func(_ context.Context, _ *pb_sec.GetListingsRequest, _ ...grpc.CallOption) (*pb_sec.GetListingsResponse, error) {
+			return &pb_sec.GetListingsResponse{Listings: []*pb_sec.ListingSummary{{Id: 10, Price: 175.0}}}, nil
+		},
+	}
+	fund := &stubFundClient{
+		validateFundAccountFn: func(_ context.Context, _ *pb.ValidateFundAccountRequest, _ ...grpc.CallOption) (*pb.ValidateFundAccountResponse, error) {
+			return &pb.ValidateFundAccountResponse{AccountId: 100, IsLiquid: true, LiquidAssets: 99999.0}, nil
+		},
+	}
+	order := &stubOrderClient{
+		createOrderFn: func(_ context.Context, _ *pb_order.CreateOrderRequest, _ ...grpc.CallOption) (*pb_order.CreateOrderResponse, error) {
+			return &pb_order.CreateOrderResponse{OrderId: 42, OrderType: "MARKET", Status: "APPROVED"}, nil
+		},
+	}
+	w := serveHandlerFull(BuyFundSecurities(fund, sec, order), "POST", "/investment/funds/:id/securities/buy", "/investment/funds/1/securities/buy", buyBody, makeSupervisorToken())
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201 got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if resp["orderId"] != float64(42) {
+		t.Fatalf("unexpected orderId: %v", resp["orderId"])
+	}
+}
+
+// ---- SellFundSecurities tests ----
+
+var sellBody = `{"ticker":"AAPL","amount":5}`
+
+func TestSellFundSecurities_NoPosition(t *testing.T) {
+	sec := &stubSecuritiesClient{
+		getListingsFn: func(_ context.Context, _ *pb_sec.GetListingsRequest, _ ...grpc.CallOption) (*pb_sec.GetListingsResponse, error) {
+			return &pb_sec.GetListingsResponse{Listings: []*pb_sec.ListingSummary{{Id: 10, Price: 175.0}}}, nil
+		},
+	}
+	fund := &stubFundClient{} // getFundPortfolioFn returns empty by default
+	w := serveHandlerFull(SellFundSecurities(fund, sec, &stubOrderClient{}), "POST", "/investment/funds/:id/securities/sell", "/investment/funds/1/securities/sell", sellBody, makeSupervisorToken())
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestSellFundSecurities_InsufficientAmount(t *testing.T) {
+	sec := &stubSecuritiesClient{
+		getListingsFn: func(_ context.Context, _ *pb_sec.GetListingsRequest, _ ...grpc.CallOption) (*pb_sec.GetListingsResponse, error) {
+			return &pb_sec.GetListingsResponse{Listings: []*pb_sec.ListingSummary{{Id: 10, Price: 175.0}}}, nil
+		},
+	}
+	fund := &stubFundClient{
+		getFundPortfolioFn: func(_ context.Context, _ *pb.GetFundPortfolioRequest, _ ...grpc.CallOption) (*pb.GetFundPortfolioResponse, error) {
+			return &pb.GetFundPortfolioResponse{
+				Positions: []*pb.FundPortfolioPosition{{ListingId: 10, Quantity: 3}}, // only 3, selling 5
+			}, nil
+		},
+	}
+	w := serveHandlerFull(SellFundSecurities(fund, sec, &stubOrderClient{}), "POST", "/investment/funds/:id/securities/sell", "/investment/funds/1/securities/sell", sellBody, makeSupervisorToken())
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestSellFundSecurities_Success(t *testing.T) {
+	sec := &stubSecuritiesClient{
+		getListingsFn: func(_ context.Context, _ *pb_sec.GetListingsRequest, _ ...grpc.CallOption) (*pb_sec.GetListingsResponse, error) {
+			return &pb_sec.GetListingsResponse{Listings: []*pb_sec.ListingSummary{{Id: 10, Price: 175.0}}}, nil
+		},
+	}
+	fund := &stubFundClient{
+		getFundPortfolioFn: func(_ context.Context, _ *pb.GetFundPortfolioRequest, _ ...grpc.CallOption) (*pb.GetFundPortfolioResponse, error) {
+			return &pb.GetFundPortfolioResponse{
+				Positions: []*pb.FundPortfolioPosition{{ListingId: 10, Quantity: 50}},
+			}, nil
+		},
+		validateFundAccountFn: func(_ context.Context, _ *pb.ValidateFundAccountRequest, _ ...grpc.CallOption) (*pb.ValidateFundAccountResponse, error) {
+			return &pb.ValidateFundAccountResponse{AccountId: 100, IsLiquid: true}, nil
+		},
+	}
+	order := &stubOrderClient{
+		createOrderFn: func(_ context.Context, _ *pb_order.CreateOrderRequest, _ ...grpc.CallOption) (*pb_order.CreateOrderResponse, error) {
+			return &pb_order.CreateOrderResponse{OrderId: 55, OrderType: "MARKET", Status: "APPROVED"}, nil
+		},
+	}
+	w := serveHandlerFull(SellFundSecurities(fund, sec, order), "POST", "/investment/funds/:id/securities/sell", "/investment/funds/1/securities/sell", sellBody, makeSupervisorToken())
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201 got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if resp["orderId"] != float64(55) {
+		t.Fatalf("unexpected orderId: %v", resp["orderId"])
 	}
 }

--- a/services/api-gateway/main.go
+++ b/services/api-gateway/main.go
@@ -255,6 +255,9 @@ func main() {
 	r.POST("/investment/funds/:id/invest", middleware.RequireRole("CLIENT", "AGENT", "SUPERVISOR"), handlers.InvestFund(fundClient))
 	r.POST("/investment/funds/:id/withdraw", middleware.RequireRole("CLIENT", "AGENT", "SUPERVISOR"), handlers.WithdrawFund(fundClient))
 	r.GET("/client/funds/positions", middleware.RequireRole("CLIENT"), handlers.GetMyPositions(fundClient))
+	r.POST("/investment/funds/:id/securities/buy", middleware.RequireRole("SUPERVISOR"), handlers.BuyFundSecurities(fundClient, securitiesClient, orderClient))
+	r.POST("/investment/funds/:id/securities/sell", middleware.RequireRole("SUPERVISOR"), handlers.SellFundSecurities(fundClient, securitiesClient, orderClient))
+	r.GET("/investment/funds/:id/securities", middleware.RequireRole("SUPERVISOR"), handlers.GetFundSecurities(fundClient, securitiesClient))
 
 	r.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 	if err := r.Run(":8083"); err != nil {

--- a/services/fund-service/db/schema.sql
+++ b/services/fund-service/db/schema.sql
@@ -21,10 +21,12 @@ CREATE TABLE IF NOT EXISTS client_fund_positions (
 );
 
 CREATE TABLE IF NOT EXISTS fund_portfolio_positions (
-    id         BIGSERIAL PRIMARY KEY,
-    fund_id    BIGINT        NOT NULL REFERENCES investment_funds(id),
-    listing_id BIGINT        NOT NULL,
-    quantity   NUMERIC(20,6) NOT NULL DEFAULT 0,
+    id               BIGSERIAL PRIMARY KEY,
+    fund_id          BIGINT        NOT NULL REFERENCES investment_funds(id),
+    listing_id       BIGINT        NOT NULL,
+    quantity         NUMERIC(20,6) NOT NULL DEFAULT 0,
+    average_cost     DECIMAL(18,4) NOT NULL DEFAULT 0,
+    acquisition_date DATE          NOT NULL DEFAULT CURRENT_DATE,
     UNIQUE(fund_id, listing_id)
 );
 

--- a/services/fund-service/handlers/grpc_server.go
+++ b/services/fund-service/handlers/grpc_server.go
@@ -481,18 +481,31 @@ func (s *FundServer) UpdateFundHolding(ctx context.Context, req *pb.UpdateFundHo
 		return nil, status.Errorf(codes.Internal, "update liquid_assets: %v", err)
 	}
 
-	quantityDelta := req.Quantity
-	if req.Direction == "SELL" {
-		quantityDelta = -req.Quantity
-	}
-	_, err = tx.ExecContext(ctx, `
-		INSERT INTO fund_portfolio_positions (fund_id, listing_id, quantity)
-		VALUES ($1, $2, $3)
-		ON CONFLICT (fund_id, listing_id) DO UPDATE
-		  SET quantity = fund_portfolio_positions.quantity + EXCLUDED.quantity`,
-		req.FundId, req.ListingId, quantityDelta)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "upsert fund position: %v", err)
+	if req.Direction == "BUY" {
+		_, err = tx.ExecContext(ctx, `
+			INSERT INTO fund_portfolio_positions (fund_id, listing_id, quantity, average_cost, acquisition_date)
+			VALUES ($1, $2, $3, $4, CURRENT_DATE)
+			ON CONFLICT (fund_id, listing_id) DO UPDATE SET
+			  average_cost = (fund_portfolio_positions.quantity * fund_portfolio_positions.average_cost + $3 * $4)
+			               / (fund_portfolio_positions.quantity + $3),
+			  quantity     = fund_portfolio_positions.quantity + $3`,
+			req.FundId, req.ListingId, req.Quantity, req.Price)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "upsert fund position: %v", err)
+		}
+	} else {
+		_, err = tx.ExecContext(ctx,
+			`UPDATE fund_portfolio_positions SET quantity = quantity - $1 WHERE fund_id = $2 AND listing_id = $3`,
+			req.Quantity, req.FundId, req.ListingId)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "update fund position: %v", err)
+		}
+		_, err = tx.ExecContext(ctx,
+			`DELETE FROM fund_portfolio_positions WHERE fund_id = $1 AND listing_id = $2 AND quantity <= 0`,
+			req.FundId, req.ListingId)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "cleanup fund position: %v", err)
+		}
 	}
 
 	if err = tx.Commit(); err != nil {
@@ -642,4 +655,30 @@ func (s *FundServer) GetBankPositions(ctx context.Context, _ *pb.GetBankPosition
 		positions = []*pb.BankFundPosition{}
 	}
 	return &pb.GetBankPositionsResponse{Positions: positions}, nil
+}
+
+func (s *FundServer) GetFundPortfolio(ctx context.Context, req *pb.GetFundPortfolioRequest) (*pb.GetFundPortfolioResponse, error) {
+	rows, err := s.DB.QueryContext(ctx,
+		`SELECT listing_id, quantity, average_cost, acquisition_date
+		 FROM fund_portfolio_positions
+		 WHERE fund_id = $1 AND quantity > 0`, req.FundId)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "get fund portfolio: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var positions []*pb.FundPortfolioPosition
+	for rows.Next() {
+		var p pb.FundPortfolioPosition
+		var acqDate time.Time
+		if err := rows.Scan(&p.ListingId, &p.Quantity, &p.AverageCost, &acqDate); err != nil {
+			return nil, status.Errorf(codes.Internal, "scan position: %v", err)
+		}
+		p.AcquisitionDate = acqDate.Format("2006-01-02")
+		positions = append(positions, &p)
+	}
+	if positions == nil {
+		positions = []*pb.FundPortfolioPosition{}
+	}
+	return &pb.GetFundPortfolioResponse{Positions: positions}, nil
 }

--- a/services/fund-service/handlers/grpc_server_test.go
+++ b/services/fund-service/handlers/grpc_server_test.go
@@ -649,7 +649,7 @@ func TestUpdateFundHolding_Buy(t *testing.T) {
 		WithArgs(500.0, int64(1)).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	fundMock.ExpectExec("INSERT INTO fund_portfolio_positions").
-		WithArgs(int64(1), int64(10), int64(5)).
+		WithArgs(int64(1), int64(10), int64(5), 100.0).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	fundMock.ExpectCommit()
 
@@ -667,9 +667,12 @@ func TestUpdateFundHolding_Sell(t *testing.T) {
 	fundMock.ExpectExec("UPDATE investment_funds SET liquid_assets = liquid_assets \\+").
 		WithArgs(300.0, int64(1)).
 		WillReturnResult(sqlmock.NewResult(1, 1))
-	fundMock.ExpectExec("INSERT INTO fund_portfolio_positions").
-		WithArgs(int64(1), int64(10), int64(-3)).
+	fundMock.ExpectExec("UPDATE fund_portfolio_positions SET quantity = quantity -").
+		WithArgs(int64(3), int64(1), int64(10)).
 		WillReturnResult(sqlmock.NewResult(1, 1))
+	fundMock.ExpectExec("DELETE FROM fund_portfolio_positions").
+		WithArgs(int64(1), int64(10)).
+		WillReturnResult(sqlmock.NewResult(0, 0))
 	fundMock.ExpectCommit()
 
 	_, err := s.UpdateFundHolding(context.Background(), &pb.UpdateFundHoldingRequest{
@@ -756,5 +759,41 @@ func TestGetMyPositions_Happy(t *testing.T) {
 	assert.InDelta(t, 100.0, pos.FundPercentage, 0.01)
 	// profit = 50000 - 10000 = 40000
 	assert.InDelta(t, 40000.0, pos.Profit, 0.01)
+	require.NoError(t, fundMock.ExpectationsWereMet())
+}
+
+// ── GetFundPortfolio ──────────────────────────────────────────────────────────
+
+func TestGetFundPortfolio_Empty(t *testing.T) {
+	s, fundMock, _, _ := newFundServer(t, &mockAccountClient{})
+
+	cols := []string{"listing_id", "quantity", "average_cost", "acquisition_date"}
+	fundMock.ExpectQuery("SELECT listing_id, quantity, average_cost, acquisition_date").
+		WithArgs(int64(1)).
+		WillReturnRows(sqlmock.NewRows(cols))
+
+	resp, err := s.GetFundPortfolio(context.Background(), &pb.GetFundPortfolioRequest{FundId: 1})
+	require.NoError(t, err)
+	assert.Empty(t, resp.Positions)
+	require.NoError(t, fundMock.ExpectationsWereMet())
+}
+
+func TestGetFundPortfolio_Happy(t *testing.T) {
+	s, fundMock, _, _ := newFundServer(t, &mockAccountClient{})
+
+	acqDate := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	cols := []string{"listing_id", "quantity", "average_cost", "acquisition_date"}
+	rows := sqlmock.NewRows(cols).AddRow(int64(10), 50.0, 125.0, acqDate)
+	fundMock.ExpectQuery("SELECT listing_id, quantity, average_cost, acquisition_date").
+		WithArgs(int64(1)).
+		WillReturnRows(rows)
+
+	resp, err := s.GetFundPortfolio(context.Background(), &pb.GetFundPortfolioRequest{FundId: 1})
+	require.NoError(t, err)
+	require.Len(t, resp.Positions, 1)
+	assert.Equal(t, int64(10), resp.Positions[0].ListingId)
+	assert.InDelta(t, 50.0, resp.Positions[0].Quantity, 0.001)
+	assert.InDelta(t, 125.0, resp.Positions[0].AverageCost, 0.001)
+	assert.Equal(t, "2026-04-01", resp.Positions[0].AcquisitionDate)
 	require.NoError(t, fundMock.ExpectationsWereMet())
 }

--- a/shared/pb/fund/fund.pb.go
+++ b/shared/pb/fund/fund.pb.go
@@ -1341,6 +1341,162 @@ func (x *ValidateFundAccountResponse) GetLiquidAssets() float64 {
 	return 0
 }
 
+type FundPortfolioPosition struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	ListingId       int64                  `protobuf:"varint,1,opt,name=listing_id,json=listingId,proto3" json:"listing_id,omitempty"`
+	Quantity        float64                `protobuf:"fixed64,2,opt,name=quantity,proto3" json:"quantity,omitempty"`
+	AverageCost     float64                `protobuf:"fixed64,3,opt,name=average_cost,json=averageCost,proto3" json:"average_cost,omitempty"`
+	AcquisitionDate string                 `protobuf:"bytes,4,opt,name=acquisition_date,json=acquisitionDate,proto3" json:"acquisition_date,omitempty"` // "YYYY-MM-DD"
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *FundPortfolioPosition) Reset() {
+	*x = FundPortfolioPosition{}
+	mi := &file_fund_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *FundPortfolioPosition) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FundPortfolioPosition) ProtoMessage() {}
+
+func (x *FundPortfolioPosition) ProtoReflect() protoreflect.Message {
+	mi := &file_fund_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FundPortfolioPosition.ProtoReflect.Descriptor instead.
+func (*FundPortfolioPosition) Descriptor() ([]byte, []int) {
+	return file_fund_proto_rawDescGZIP(), []int{22}
+}
+
+func (x *FundPortfolioPosition) GetListingId() int64 {
+	if x != nil {
+		return x.ListingId
+	}
+	return 0
+}
+
+func (x *FundPortfolioPosition) GetQuantity() float64 {
+	if x != nil {
+		return x.Quantity
+	}
+	return 0
+}
+
+func (x *FundPortfolioPosition) GetAverageCost() float64 {
+	if x != nil {
+		return x.AverageCost
+	}
+	return 0
+}
+
+func (x *FundPortfolioPosition) GetAcquisitionDate() string {
+	if x != nil {
+		return x.AcquisitionDate
+	}
+	return ""
+}
+
+type GetFundPortfolioRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	FundId        int64                  `protobuf:"varint,1,opt,name=fund_id,json=fundId,proto3" json:"fund_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetFundPortfolioRequest) Reset() {
+	*x = GetFundPortfolioRequest{}
+	mi := &file_fund_proto_msgTypes[23]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetFundPortfolioRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetFundPortfolioRequest) ProtoMessage() {}
+
+func (x *GetFundPortfolioRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_fund_proto_msgTypes[23]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetFundPortfolioRequest.ProtoReflect.Descriptor instead.
+func (*GetFundPortfolioRequest) Descriptor() ([]byte, []int) {
+	return file_fund_proto_rawDescGZIP(), []int{23}
+}
+
+func (x *GetFundPortfolioRequest) GetFundId() int64 {
+	if x != nil {
+		return x.FundId
+	}
+	return 0
+}
+
+type GetFundPortfolioResponse struct {
+	state         protoimpl.MessageState   `protogen:"open.v1"`
+	Positions     []*FundPortfolioPosition `protobuf:"bytes,1,rep,name=positions,proto3" json:"positions,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetFundPortfolioResponse) Reset() {
+	*x = GetFundPortfolioResponse{}
+	mi := &file_fund_proto_msgTypes[24]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetFundPortfolioResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetFundPortfolioResponse) ProtoMessage() {}
+
+func (x *GetFundPortfolioResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_fund_proto_msgTypes[24]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetFundPortfolioResponse.ProtoReflect.Descriptor instead.
+func (*GetFundPortfolioResponse) Descriptor() ([]byte, []int) {
+	return file_fund_proto_rawDescGZIP(), []int{24}
+}
+
+func (x *GetFundPortfolioResponse) GetPositions() []*FundPortfolioPosition {
+	if x != nil {
+		return x.Positions
+	}
+	return nil
+}
+
 type UpdateFundHoldingRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	FundId        int64                  `protobuf:"varint,1,opt,name=fund_id,json=fundId,proto3" json:"fund_id,omitempty"`
@@ -1354,7 +1510,7 @@ type UpdateFundHoldingRequest struct {
 
 func (x *UpdateFundHoldingRequest) Reset() {
 	*x = UpdateFundHoldingRequest{}
-	mi := &file_fund_proto_msgTypes[22]
+	mi := &file_fund_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1366,7 +1522,7 @@ func (x *UpdateFundHoldingRequest) String() string {
 func (*UpdateFundHoldingRequest) ProtoMessage() {}
 
 func (x *UpdateFundHoldingRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fund_proto_msgTypes[22]
+	mi := &file_fund_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1379,7 +1535,7 @@ func (x *UpdateFundHoldingRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateFundHoldingRequest.ProtoReflect.Descriptor instead.
 func (*UpdateFundHoldingRequest) Descriptor() ([]byte, []int) {
-	return file_fund_proto_rawDescGZIP(), []int{22}
+	return file_fund_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *UpdateFundHoldingRequest) GetFundId() int64 {
@@ -1425,7 +1581,7 @@ type UpdateFundHoldingResponse struct {
 
 func (x *UpdateFundHoldingResponse) Reset() {
 	*x = UpdateFundHoldingResponse{}
-	mi := &file_fund_proto_msgTypes[23]
+	mi := &file_fund_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1437,7 +1593,7 @@ func (x *UpdateFundHoldingResponse) String() string {
 func (*UpdateFundHoldingResponse) ProtoMessage() {}
 
 func (x *UpdateFundHoldingResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fund_proto_msgTypes[23]
+	mi := &file_fund_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1450,7 +1606,7 @@ func (x *UpdateFundHoldingResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateFundHoldingResponse.ProtoReflect.Descriptor instead.
 func (*UpdateFundHoldingResponse) Descriptor() ([]byte, []int) {
-	return file_fund_proto_rawDescGZIP(), []int{23}
+	return file_fund_proto_rawDescGZIP(), []int{26}
 }
 
 var File_fund_proto protoreflect.FileDescriptor
@@ -1560,7 +1716,17 @@ const file_fund_proto_rawDesc = "" +
 	"\n" +
 	"account_id\x18\x01 \x01(\x03R\taccountId\x12\x1b\n" +
 	"\tis_liquid\x18\x02 \x01(\bR\bisLiquid\x12#\n" +
-	"\rliquid_assets\x18\x03 \x01(\x01R\fliquidAssets\"\xa2\x01\n" +
+	"\rliquid_assets\x18\x03 \x01(\x01R\fliquidAssets\"\xa0\x01\n" +
+	"\x15FundPortfolioPosition\x12\x1d\n" +
+	"\n" +
+	"listing_id\x18\x01 \x01(\x03R\tlistingId\x12\x1a\n" +
+	"\bquantity\x18\x02 \x01(\x01R\bquantity\x12!\n" +
+	"\faverage_cost\x18\x03 \x01(\x01R\vaverageCost\x12)\n" +
+	"\x10acquisition_date\x18\x04 \x01(\tR\x0facquisitionDate\"2\n" +
+	"\x17GetFundPortfolioRequest\x12\x17\n" +
+	"\afund_id\x18\x01 \x01(\x03R\x06fundId\"U\n" +
+	"\x18GetFundPortfolioResponse\x129\n" +
+	"\tpositions\x18\x01 \x03(\v2\x1b.fund.FundPortfolioPositionR\tpositions\"\xa2\x01\n" +
 	"\x18UpdateFundHoldingRequest\x12\x17\n" +
 	"\afund_id\x18\x01 \x01(\x03R\x06fundId\x12\x1d\n" +
 	"\n" +
@@ -1568,7 +1734,7 @@ const file_fund_proto_rawDesc = "" +
 	"\bquantity\x18\x03 \x01(\x03R\bquantity\x12\x14\n" +
 	"\x05price\x18\x04 \x01(\x01R\x05price\x12\x1c\n" +
 	"\tdirection\x18\x05 \x01(\tR\tdirection\"\x1b\n" +
-	"\x19UpdateFundHoldingResponse2\x97\a\n" +
+	"\x19UpdateFundHoldingResponse2\xea\a\n" +
 	"\vFundService\x12-\n" +
 	"\x04Ping\x12\x11.fund.PingRequest\x1a\x12.fund.PingResponse\x129\n" +
 	"\n" +
@@ -1586,7 +1752,8 @@ const file_fund_proto_rawDesc = "" +
 	"\x0eGetMyPositions\x12\x1b.fund.GetMyPositionsRequest\x1a\x1c.fund.GetMyPositionsResponse\x12c\n" +
 	"\x16TransferFundsByManager\x12#.fund.TransferFundsByManagerRequest\x1a$.fund.TransferFundsByManagerResponse\x12Z\n" +
 	"\x13ValidateFundAccount\x12 .fund.ValidateFundAccountRequest\x1a!.fund.ValidateFundAccountResponse\x12T\n" +
-	"\x11UpdateFundHolding\x12\x1e.fund.UpdateFundHoldingRequest\x1a\x1f.fund.UpdateFundHoldingResponseB9Z7github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/fundb\x06proto3"
+	"\x11UpdateFundHolding\x12\x1e.fund.UpdateFundHoldingRequest\x1a\x1f.fund.UpdateFundHoldingResponse\x12Q\n" +
+	"\x10GetFundPortfolio\x12\x1d.fund.GetFundPortfolioRequest\x1a\x1e.fund.GetFundPortfolioResponseB9Z7github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/fundb\x06proto3"
 
 var (
 	file_fund_proto_rawDescOnce sync.Once
@@ -1600,7 +1767,7 @@ func file_fund_proto_rawDescGZIP() []byte {
 	return file_fund_proto_rawDescData
 }
 
-var file_fund_proto_msgTypes = make([]protoimpl.MessageInfo, 24)
+var file_fund_proto_msgTypes = make([]protoimpl.MessageInfo, 27)
 var file_fund_proto_goTypes = []any{
 	(*PingRequest)(nil),                    // 0: fund.PingRequest
 	(*PingResponse)(nil),                   // 1: fund.PingResponse
@@ -1624,44 +1791,50 @@ var file_fund_proto_goTypes = []any{
 	(*TransferFundsByManagerResponse)(nil), // 19: fund.TransferFundsByManagerResponse
 	(*ValidateFundAccountRequest)(nil),     // 20: fund.ValidateFundAccountRequest
 	(*ValidateFundAccountResponse)(nil),    // 21: fund.ValidateFundAccountResponse
-	(*UpdateFundHoldingRequest)(nil),       // 22: fund.UpdateFundHoldingRequest
-	(*UpdateFundHoldingResponse)(nil),      // 23: fund.UpdateFundHoldingResponse
+	(*FundPortfolioPosition)(nil),          // 22: fund.FundPortfolioPosition
+	(*GetFundPortfolioRequest)(nil),        // 23: fund.GetFundPortfolioRequest
+	(*GetFundPortfolioResponse)(nil),       // 24: fund.GetFundPortfolioResponse
+	(*UpdateFundHoldingRequest)(nil),       // 25: fund.UpdateFundHoldingRequest
+	(*UpdateFundHoldingResponse)(nil),      // 26: fund.UpdateFundHoldingResponse
 }
 var file_fund_proto_depIdxs = []int32{
 	8,  // 0: fund.ListFundsResponse.funds:type_name -> fund.FundResponse
 	12, // 1: fund.GetBankPositionsResponse.positions:type_name -> fund.BankFundPosition
 	15, // 2: fund.GetMyPositionsResponse.positions:type_name -> fund.ClientFundPosition
-	0,  // 3: fund.FundService.Ping:input_type -> fund.PingRequest
-	2,  // 4: fund.FundService.CreateFund:input_type -> fund.CreateFundRequest
-	6,  // 5: fund.FundService.ListFunds:input_type -> fund.ListFundsRequest
-	7,  // 6: fund.FundService.GetFund:input_type -> fund.GetFundRequest
-	3,  // 7: fund.FundService.UpdateFund:input_type -> fund.UpdateFundRequest
-	4,  // 8: fund.FundService.DeleteFund:input_type -> fund.DeleteFundRequest
-	10, // 9: fund.FundService.InvestFund:input_type -> fund.InvestFundRequest
-	11, // 10: fund.FundService.WithdrawFund:input_type -> fund.WithdrawFundRequest
-	13, // 11: fund.FundService.GetBankPositions:input_type -> fund.GetBankPositionsRequest
-	16, // 12: fund.FundService.GetMyPositions:input_type -> fund.GetMyPositionsRequest
-	18, // 13: fund.FundService.TransferFundsByManager:input_type -> fund.TransferFundsByManagerRequest
-	20, // 14: fund.FundService.ValidateFundAccount:input_type -> fund.ValidateFundAccountRequest
-	22, // 15: fund.FundService.UpdateFundHolding:input_type -> fund.UpdateFundHoldingRequest
-	1,  // 16: fund.FundService.Ping:output_type -> fund.PingResponse
-	8,  // 17: fund.FundService.CreateFund:output_type -> fund.FundResponse
-	9,  // 18: fund.FundService.ListFunds:output_type -> fund.ListFundsResponse
-	8,  // 19: fund.FundService.GetFund:output_type -> fund.FundResponse
-	8,  // 20: fund.FundService.UpdateFund:output_type -> fund.FundResponse
-	5,  // 21: fund.FundService.DeleteFund:output_type -> fund.DeleteFundResponse
-	8,  // 22: fund.FundService.InvestFund:output_type -> fund.FundResponse
-	8,  // 23: fund.FundService.WithdrawFund:output_type -> fund.FundResponse
-	14, // 24: fund.FundService.GetBankPositions:output_type -> fund.GetBankPositionsResponse
-	17, // 25: fund.FundService.GetMyPositions:output_type -> fund.GetMyPositionsResponse
-	19, // 26: fund.FundService.TransferFundsByManager:output_type -> fund.TransferFundsByManagerResponse
-	21, // 27: fund.FundService.ValidateFundAccount:output_type -> fund.ValidateFundAccountResponse
-	23, // 28: fund.FundService.UpdateFundHolding:output_type -> fund.UpdateFundHoldingResponse
-	16, // [16:29] is the sub-list for method output_type
-	3,  // [3:16] is the sub-list for method input_type
-	3,  // [3:3] is the sub-list for extension type_name
-	3,  // [3:3] is the sub-list for extension extendee
-	0,  // [0:3] is the sub-list for field type_name
+	22, // 3: fund.GetFundPortfolioResponse.positions:type_name -> fund.FundPortfolioPosition
+	0,  // 4: fund.FundService.Ping:input_type -> fund.PingRequest
+	2,  // 5: fund.FundService.CreateFund:input_type -> fund.CreateFundRequest
+	6,  // 6: fund.FundService.ListFunds:input_type -> fund.ListFundsRequest
+	7,  // 7: fund.FundService.GetFund:input_type -> fund.GetFundRequest
+	3,  // 8: fund.FundService.UpdateFund:input_type -> fund.UpdateFundRequest
+	4,  // 9: fund.FundService.DeleteFund:input_type -> fund.DeleteFundRequest
+	10, // 10: fund.FundService.InvestFund:input_type -> fund.InvestFundRequest
+	11, // 11: fund.FundService.WithdrawFund:input_type -> fund.WithdrawFundRequest
+	13, // 12: fund.FundService.GetBankPositions:input_type -> fund.GetBankPositionsRequest
+	16, // 13: fund.FundService.GetMyPositions:input_type -> fund.GetMyPositionsRequest
+	18, // 14: fund.FundService.TransferFundsByManager:input_type -> fund.TransferFundsByManagerRequest
+	20, // 15: fund.FundService.ValidateFundAccount:input_type -> fund.ValidateFundAccountRequest
+	25, // 16: fund.FundService.UpdateFundHolding:input_type -> fund.UpdateFundHoldingRequest
+	23, // 17: fund.FundService.GetFundPortfolio:input_type -> fund.GetFundPortfolioRequest
+	1,  // 18: fund.FundService.Ping:output_type -> fund.PingResponse
+	8,  // 19: fund.FundService.CreateFund:output_type -> fund.FundResponse
+	9,  // 20: fund.FundService.ListFunds:output_type -> fund.ListFundsResponse
+	8,  // 21: fund.FundService.GetFund:output_type -> fund.FundResponse
+	8,  // 22: fund.FundService.UpdateFund:output_type -> fund.FundResponse
+	5,  // 23: fund.FundService.DeleteFund:output_type -> fund.DeleteFundResponse
+	8,  // 24: fund.FundService.InvestFund:output_type -> fund.FundResponse
+	8,  // 25: fund.FundService.WithdrawFund:output_type -> fund.FundResponse
+	14, // 26: fund.FundService.GetBankPositions:output_type -> fund.GetBankPositionsResponse
+	17, // 27: fund.FundService.GetMyPositions:output_type -> fund.GetMyPositionsResponse
+	19, // 28: fund.FundService.TransferFundsByManager:output_type -> fund.TransferFundsByManagerResponse
+	21, // 29: fund.FundService.ValidateFundAccount:output_type -> fund.ValidateFundAccountResponse
+	26, // 30: fund.FundService.UpdateFundHolding:output_type -> fund.UpdateFundHoldingResponse
+	24, // 31: fund.FundService.GetFundPortfolio:output_type -> fund.GetFundPortfolioResponse
+	18, // [18:32] is the sub-list for method output_type
+	4,  // [4:18] is the sub-list for method input_type
+	4,  // [4:4] is the sub-list for extension type_name
+	4,  // [4:4] is the sub-list for extension extendee
+	0,  // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_fund_proto_init() }
@@ -1675,7 +1848,7 @@ func file_fund_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_fund_proto_rawDesc), len(file_fund_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   24,
+			NumMessages:   27,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/shared/pb/fund/fund_grpc.pb.go
+++ b/shared/pb/fund/fund_grpc.pb.go
@@ -32,6 +32,7 @@ const (
 	FundService_TransferFundsByManager_FullMethodName = "/fund.FundService/TransferFundsByManager"
 	FundService_ValidateFundAccount_FullMethodName    = "/fund.FundService/ValidateFundAccount"
 	FundService_UpdateFundHolding_FullMethodName      = "/fund.FundService/UpdateFundHolding"
+	FundService_GetFundPortfolio_FullMethodName       = "/fund.FundService/GetFundPortfolio"
 )
 
 // FundServiceClient is the client API for FundService service.
@@ -51,6 +52,7 @@ type FundServiceClient interface {
 	TransferFundsByManager(ctx context.Context, in *TransferFundsByManagerRequest, opts ...grpc.CallOption) (*TransferFundsByManagerResponse, error)
 	ValidateFundAccount(ctx context.Context, in *ValidateFundAccountRequest, opts ...grpc.CallOption) (*ValidateFundAccountResponse, error)
 	UpdateFundHolding(ctx context.Context, in *UpdateFundHoldingRequest, opts ...grpc.CallOption) (*UpdateFundHoldingResponse, error)
+	GetFundPortfolio(ctx context.Context, in *GetFundPortfolioRequest, opts ...grpc.CallOption) (*GetFundPortfolioResponse, error)
 }
 
 type fundServiceClient struct {
@@ -191,6 +193,16 @@ func (c *fundServiceClient) UpdateFundHolding(ctx context.Context, in *UpdateFun
 	return out, nil
 }
 
+func (c *fundServiceClient) GetFundPortfolio(ctx context.Context, in *GetFundPortfolioRequest, opts ...grpc.CallOption) (*GetFundPortfolioResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetFundPortfolioResponse)
+	err := c.cc.Invoke(ctx, FundService_GetFundPortfolio_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // FundServiceServer is the server API for FundService service.
 // All implementations must embed UnimplementedFundServiceServer
 // for forward compatibility.
@@ -208,6 +220,7 @@ type FundServiceServer interface {
 	TransferFundsByManager(context.Context, *TransferFundsByManagerRequest) (*TransferFundsByManagerResponse, error)
 	ValidateFundAccount(context.Context, *ValidateFundAccountRequest) (*ValidateFundAccountResponse, error)
 	UpdateFundHolding(context.Context, *UpdateFundHoldingRequest) (*UpdateFundHoldingResponse, error)
+	GetFundPortfolio(context.Context, *GetFundPortfolioRequest) (*GetFundPortfolioResponse, error)
 	mustEmbedUnimplementedFundServiceServer()
 }
 
@@ -256,6 +269,9 @@ func (UnimplementedFundServiceServer) ValidateFundAccount(context.Context, *Vali
 }
 func (UnimplementedFundServiceServer) UpdateFundHolding(context.Context, *UpdateFundHoldingRequest) (*UpdateFundHoldingResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method UpdateFundHolding not implemented")
+}
+func (UnimplementedFundServiceServer) GetFundPortfolio(context.Context, *GetFundPortfolioRequest) (*GetFundPortfolioResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetFundPortfolio not implemented")
 }
 func (UnimplementedFundServiceServer) mustEmbedUnimplementedFundServiceServer() {}
 func (UnimplementedFundServiceServer) testEmbeddedByValue()                     {}
@@ -512,6 +528,24 @@ func _FundService_UpdateFundHolding_Handler(srv interface{}, ctx context.Context
 	return interceptor(ctx, in, info, handler)
 }
 
+func _FundService_GetFundPortfolio_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetFundPortfolioRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(FundServiceServer).GetFundPortfolio(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: FundService_GetFundPortfolio_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(FundServiceServer).GetFundPortfolio(ctx, req.(*GetFundPortfolioRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // FundService_ServiceDesc is the grpc.ServiceDesc for FundService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -570,6 +604,10 @@ var FundService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "UpdateFundHolding",
 			Handler:    _FundService_UpdateFundHolding_Handler,
+		},
+		{
+			MethodName: "GetFundPortfolio",
+			Handler:    _FundService_GetFundPortfolio_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/shared/proto/fund.proto
+++ b/shared/proto/fund.proto
@@ -16,6 +16,7 @@ service FundService {
   rpc TransferFundsByManager(TransferFundsByManagerRequest) returns (TransferFundsByManagerResponse);
   rpc ValidateFundAccount(ValidateFundAccountRequest) returns (ValidateFundAccountResponse);
   rpc UpdateFundHolding(UpdateFundHoldingRequest) returns (UpdateFundHoldingResponse);
+  rpc GetFundPortfolio(GetFundPortfolioRequest) returns (GetFundPortfolioResponse);
 }
 
 message PingRequest {}
@@ -145,6 +146,18 @@ message ValidateFundAccountResponse {
   bool   is_liquid     = 2;
   double liquid_assets = 3;
 }
+
+// ── GetFundPortfolio ──────────────────────────────────────────────────────────
+
+message FundPortfolioPosition {
+  int64  listing_id       = 1;
+  double quantity         = 2;
+  double average_cost     = 3;
+  string acquisition_date = 4; // "YYYY-MM-DD"
+}
+
+message GetFundPortfolioRequest  { int64 fund_id = 1; }
+message GetFundPortfolioResponse { repeated FundPortfolioPosition positions = 1; }
 
 // ── UpdateFundHolding ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Add `POST /investment/funds/:id/securities/buy` and `POST /investment/funds/:id/securities/sell` (SUPERVISOR/ADMIN) that look up a listing by ticker via securities-service, validate fund liquidity, and place an order through order-service
- Add `GET /investment/funds/:id/securities` returning fund portfolio positions with live price, change, volume, and initialMarginCost from securities-service
- Add `GetFundPortfolio` gRPC RPC in fund-service
- Extend `fund_portfolio_positions` schema with `average_cost` (weighted average across BUY fills) and `acquisition_date`
- Update `UpdateFundHolding`: BUY uses `INSERT...ON CONFLICT` with weighted avg cost; SELL uses `UPDATE` then `DELETE` if quantity reaches zero

## Test plan
- [ ] `go test ./services/fund-service/handlers/... -v` — `TestUpdateFundHolding_Buy`, `TestUpdateFundHolding_Sell`, `TestGetFundPortfolio_Empty`, `TestGetFundPortfolio_Happy`
- [ ] `go test ./services/api-gateway/handlers/... -run "TestGetFundSecurities|TestBuyFundSecurities|TestSellFundSecurities" -v` — 9 tests
- [ ] Buy with insufficient fund liquidity → 400
- [ ] Sell when fund does not hold ticker → 404
- [ ] Sell with insufficient amount → 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)