### PR TITLE
feat: fund redeem Case 2 auto-liquidation + withdrawAll (#232)

### DIFF
--- a/services/api-gateway/handlers/bank_profit_test.go
+++ b/services/api-gateway/handlers/bank_profit_test.go
@@ -216,9 +216,9 @@ func TestBankInvestFund_GrpcError(t *testing.T) {
 func TestBankRedeemFund_Happy(t *testing.T) {
 	var capturedReq *pb_fund.WithdrawFundRequest
 	svc := &stubFundClient{
-		withdrawFundFn: func(_ context.Context, req *pb_fund.WithdrawFundRequest, _ ...grpc.CallOption) (*pb_fund.FundResponse, error) {
+		withdrawFundFn: func(_ context.Context, req *pb_fund.WithdrawFundRequest, _ ...grpc.CallOption) (*pb_fund.WithdrawFundResponse, error) {
 			capturedReq = req
-			return sampleFund(), nil
+			return &pb_fund.WithdrawFundResponse{Pending: false, Fund: sampleFund()}, nil
 		},
 	}
 
@@ -245,7 +245,7 @@ func TestBankRedeemFund_BadBody(t *testing.T) {
 
 func TestBankRedeemFund_GrpcError(t *testing.T) {
 	svc := &stubFundClient{
-		withdrawFundFn: func(_ context.Context, _ *pb_fund.WithdrawFundRequest, _ ...grpc.CallOption) (*pb_fund.FundResponse, error) {
+		withdrawFundFn: func(_ context.Context, _ *pb_fund.WithdrawFundRequest, _ ...grpc.CallOption) (*pb_fund.WithdrawFundResponse, error) {
 			return nil, status.Error(codes.NotFound, "position not found")
 		},
 	}

--- a/services/api-gateway/handlers/fund.go
+++ b/services/api-gateway/handlers/fund.go
@@ -314,10 +314,16 @@ func WithdrawFund(client pb.FundServiceClient) gin.HandlerFunc {
 		var req struct {
 			DestinationAccountId int64   `json:"destinationAccountId" binding:"required"`
 			Amount               float64 `json:"amount"`
+			WithdrawAll          bool    `json:"withdrawAll"`
 		}
 		if err := c.ShouldBindJSON(&req); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
+		}
+
+		amount := req.Amount
+		if req.WithdrawAll {
+			amount = 0
 		}
 
 		ctx, cancel := context.WithTimeout(c.Request.Context(), 15*time.Second)
@@ -328,13 +334,17 @@ func WithdrawFund(client pb.FundServiceClient) gin.HandlerFunc {
 			ClientId:             userID,
 			ClientType:           clientType,
 			DestinationAccountId: req.DestinationAccountId,
-			Amount:               req.Amount,
+			Amount:               amount,
 		})
 		if err != nil {
 			mapFundError(c, err)
 			return
 		}
-		c.JSON(http.StatusOK, fundToJSON(resp))
+		if resp.Pending {
+			c.JSON(http.StatusAccepted, gin.H{"message": resp.Message})
+			return
+		}
+		c.JSON(http.StatusOK, fundToJSON(resp.Fund))
 	}
 }
 
@@ -461,7 +471,7 @@ func BankRedeemFund(client pb.FundServiceClient) gin.HandlerFunc {
 			mapFundError(c, err)
 			return
 		}
-		c.JSON(http.StatusOK, fundToJSON(resp))
+		c.JSON(http.StatusOK, fundToJSON(resp.Fund))
 	}
 }
 

--- a/services/api-gateway/handlers/fund_test.go
+++ b/services/api-gateway/handlers/fund_test.go
@@ -33,20 +33,21 @@ func makeSupervisorToken() string {
 // ---- stub fund client ----
 
 type stubFundClient struct {
-	pingFn                   func(context.Context, *pb.PingRequest, ...grpc.CallOption) (*pb.PingResponse, error)
-	createFundFn             func(context.Context, *pb.CreateFundRequest, ...grpc.CallOption) (*pb.FundResponse, error)
-	listFundsFn              func(context.Context, *pb.ListFundsRequest, ...grpc.CallOption) (*pb.ListFundsResponse, error)
-	getFundFn                func(context.Context, *pb.GetFundRequest, ...grpc.CallOption) (*pb.FundResponse, error)
-	updateFundFn             func(context.Context, *pb.UpdateFundRequest, ...grpc.CallOption) (*pb.FundResponse, error)
-	deleteFundFn             func(context.Context, *pb.DeleteFundRequest, ...grpc.CallOption) (*pb.DeleteFundResponse, error)
-	investFundFn             func(context.Context, *pb.InvestFundRequest, ...grpc.CallOption) (*pb.FundResponse, error)
-	withdrawFundFn           func(context.Context, *pb.WithdrawFundRequest, ...grpc.CallOption) (*pb.FundResponse, error)
-	getBankPositionsFn       func(context.Context, *pb.GetBankPositionsRequest, ...grpc.CallOption) (*pb.GetBankPositionsResponse, error)
-	validateFundAccountFn    func(context.Context, *pb.ValidateFundAccountRequest, ...grpc.CallOption) (*pb.ValidateFundAccountResponse, error)
-	updateFundHoldingFn      func(context.Context, *pb.UpdateFundHoldingRequest, ...grpc.CallOption) (*pb.UpdateFundHoldingResponse, error)
-	getMyPositionsFn         func(context.Context, *pb.GetMyPositionsRequest, ...grpc.CallOption) (*pb.GetMyPositionsResponse, error)
-	transferFundsByManagerFn func(context.Context, *pb.TransferFundsByManagerRequest, ...grpc.CallOption) (*pb.TransferFundsByManagerResponse, error)
-	getFundPortfolioFn       func(context.Context, *pb.GetFundPortfolioRequest, ...grpc.CallOption) (*pb.GetFundPortfolioResponse, error)
+	pingFn                    func(context.Context, *pb.PingRequest, ...grpc.CallOption) (*pb.PingResponse, error)
+	createFundFn              func(context.Context, *pb.CreateFundRequest, ...grpc.CallOption) (*pb.FundResponse, error)
+	listFundsFn               func(context.Context, *pb.ListFundsRequest, ...grpc.CallOption) (*pb.ListFundsResponse, error)
+	getFundFn                 func(context.Context, *pb.GetFundRequest, ...grpc.CallOption) (*pb.FundResponse, error)
+	updateFundFn              func(context.Context, *pb.UpdateFundRequest, ...grpc.CallOption) (*pb.FundResponse, error)
+	deleteFundFn              func(context.Context, *pb.DeleteFundRequest, ...grpc.CallOption) (*pb.DeleteFundResponse, error)
+	investFundFn              func(context.Context, *pb.InvestFundRequest, ...grpc.CallOption) (*pb.FundResponse, error)
+	withdrawFundFn            func(context.Context, *pb.WithdrawFundRequest, ...grpc.CallOption) (*pb.WithdrawFundResponse, error)
+	checkPendingWithdrawalsFn func(context.Context, *pb.CheckPendingWithdrawalsRequest, ...grpc.CallOption) (*pb.CheckPendingWithdrawalsResponse, error)
+	getBankPositionsFn        func(context.Context, *pb.GetBankPositionsRequest, ...grpc.CallOption) (*pb.GetBankPositionsResponse, error)
+	validateFundAccountFn     func(context.Context, *pb.ValidateFundAccountRequest, ...grpc.CallOption) (*pb.ValidateFundAccountResponse, error)
+	updateFundHoldingFn       func(context.Context, *pb.UpdateFundHoldingRequest, ...grpc.CallOption) (*pb.UpdateFundHoldingResponse, error)
+	getMyPositionsFn          func(context.Context, *pb.GetMyPositionsRequest, ...grpc.CallOption) (*pb.GetMyPositionsResponse, error)
+	transferFundsByManagerFn  func(context.Context, *pb.TransferFundsByManagerRequest, ...grpc.CallOption) (*pb.TransferFundsByManagerResponse, error)
+	getFundPortfolioFn        func(context.Context, *pb.GetFundPortfolioRequest, ...grpc.CallOption) (*pb.GetFundPortfolioResponse, error)
 }
 
 func (s *stubFundClient) Ping(ctx context.Context, in *pb.PingRequest, opts ...grpc.CallOption) (*pb.PingResponse, error) {
@@ -91,11 +92,17 @@ func (s *stubFundClient) InvestFund(ctx context.Context, in *pb.InvestFundReques
 	}
 	return nil, fmt.Errorf("not implemented")
 }
-func (s *stubFundClient) WithdrawFund(ctx context.Context, in *pb.WithdrawFundRequest, opts ...grpc.CallOption) (*pb.FundResponse, error) {
+func (s *stubFundClient) WithdrawFund(ctx context.Context, in *pb.WithdrawFundRequest, opts ...grpc.CallOption) (*pb.WithdrawFundResponse, error) {
 	if s.withdrawFundFn != nil {
 		return s.withdrawFundFn(ctx, in, opts...)
 	}
 	return nil, fmt.Errorf("not implemented")
+}
+func (s *stubFundClient) CheckPendingWithdrawals(ctx context.Context, in *pb.CheckPendingWithdrawalsRequest, opts ...grpc.CallOption) (*pb.CheckPendingWithdrawalsResponse, error) {
+	if s.checkPendingWithdrawalsFn != nil {
+		return s.checkPendingWithdrawalsFn(ctx, in, opts...)
+	}
+	return &pb.CheckPendingWithdrawalsResponse{}, nil
 }
 func (s *stubFundClient) GetBankPositions(ctx context.Context, in *pb.GetBankPositionsRequest, opts ...grpc.CallOption) (*pb.GetBankPositionsResponse, error) {
 	if s.getBankPositionsFn != nil {
@@ -695,5 +702,65 @@ func TestSellFundSecurities_Success(t *testing.T) {
 	}
 	if resp["orderId"] != float64(55) {
 		t.Fatalf("unexpected orderId: %v", resp["orderId"])
+	}
+}
+
+// ---- WithdrawFund gateway tests ----
+
+var withdrawBody = `{"destinationAccountId":99,"amount":1000}`
+var withdrawAllBody = `{"destinationAccountId":99,"withdrawAll":true}`
+
+func TestWithdrawFund_ImmediateSuccess(t *testing.T) {
+	svc := &stubFundClient{
+		withdrawFundFn: func(_ context.Context, req *pb.WithdrawFundRequest, _ ...grpc.CallOption) (*pb.WithdrawFundResponse, error) {
+			return &pb.WithdrawFundResponse{Pending: false, Fund: sampleFund()}, nil
+		},
+	}
+	w := serveHandlerFull(WithdrawFund(svc), "POST", "/investment/funds/:id/redeem", "/investment/funds/1/redeem", withdrawBody, makeClientToken())
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if resp["name"] != "Test Fund" {
+		t.Fatalf("unexpected name: %v", resp["name"])
+	}
+}
+
+func TestWithdrawFund_Pending202(t *testing.T) {
+	svc := &stubFundClient{
+		withdrawFundFn: func(_ context.Context, req *pb.WithdrawFundRequest, _ ...grpc.CallOption) (*pb.WithdrawFundResponse, error) {
+			return &pb.WithdrawFundResponse{Pending: true, Message: "Payment will arrive once orders are executed"}, nil
+		},
+	}
+	w := serveHandlerFull(WithdrawFund(svc), "POST", "/investment/funds/:id/redeem", "/investment/funds/1/redeem", withdrawBody, makeClientToken())
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("expected 202 got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if resp["message"] != "Payment will arrive once orders are executed" {
+		t.Fatalf("unexpected message: %v", resp["message"])
+	}
+}
+
+func TestWithdrawFund_WithdrawAll_SendsZeroAmount(t *testing.T) {
+	var capturedAmount float64
+	svc := &stubFundClient{
+		withdrawFundFn: func(_ context.Context, req *pb.WithdrawFundRequest, _ ...grpc.CallOption) (*pb.WithdrawFundResponse, error) {
+			capturedAmount = req.Amount
+			return &pb.WithdrawFundResponse{Pending: false, Fund: sampleFund()}, nil
+		},
+	}
+	w := serveHandlerFull(WithdrawFund(svc), "POST", "/investment/funds/:id/redeem", "/investment/funds/1/redeem", withdrawAllBody, makeClientToken())
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d: %s", w.Code, w.Body.String())
+	}
+	if capturedAmount != 0 {
+		t.Fatalf("expected amount=0 for withdrawAll, got %v", capturedAmount)
 	}
 }

--- a/services/fund-service/db/schema.sql
+++ b/services/fund-service/db/schema.sql
@@ -31,12 +31,13 @@ CREATE TABLE IF NOT EXISTS fund_portfolio_positions (
 );
 
 CREATE TABLE IF NOT EXISTS client_fund_transactions (
-    id        BIGSERIAL PRIMARY KEY,
-    client_id BIGINT        NOT NULL,
-    client_type VARCHAR(10) NOT NULL DEFAULT 'CLIENT',
-    fund_id   BIGINT        NOT NULL REFERENCES investment_funds(id),
-    amount    DECIMAL(18,4) NOT NULL,
-    is_inflow BOOLEAN       NOT NULL,
-    status    VARCHAR(20)   NOT NULL DEFAULT 'PENDING',
-    timestamp TIMESTAMP     NOT NULL DEFAULT NOW()
+    id                     BIGSERIAL PRIMARY KEY,
+    client_id              BIGINT        NOT NULL,
+    client_type            VARCHAR(10)   NOT NULL DEFAULT 'CLIENT',
+    fund_id                BIGINT        NOT NULL REFERENCES investment_funds(id),
+    amount                 DECIMAL(18,4) NOT NULL,
+    is_inflow              BOOLEAN       NOT NULL,
+    status                 VARCHAR(20)   NOT NULL DEFAULT 'PENDING',
+    destination_account_id BIGINT,
+    timestamp              TIMESTAMP     NOT NULL DEFAULT NOW()
 );

--- a/services/fund-service/handlers/grpc_server.go
+++ b/services/fund-service/handlers/grpc_server.go
@@ -8,6 +8,7 @@ import (
 
 	pb_account "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/account"
 	pb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/fund"
+	pb_order "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/order"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -18,6 +19,7 @@ type FundServer struct {
 	AccountDB     *sql.DB // account_db
 	EmployeeDB    *sql.DB // employee_db
 	AccountClient pb_account.AccountServiceClient
+	OrderClient   pb_order.OrderServiceClient
 }
 
 func (s *FundServer) Ping(_ context.Context, _ *pb.PingRequest) (*pb.PingResponse, error) {
@@ -324,7 +326,7 @@ func (s *FundServer) InvestFund(ctx context.Context, req *pb.InvestFundRequest) 
 	return s.fetchFundByID(ctx, req.FundId, true)
 }
 
-func (s *FundServer) WithdrawFund(ctx context.Context, req *pb.WithdrawFundRequest) (*pb.FundResponse, error) {
+func (s *FundServer) WithdrawFund(ctx context.Context, req *pb.WithdrawFundRequest) (*pb.WithdrawFundResponse, error) {
 	var liquidAssets float64
 	var active bool
 	err := s.DB.QueryRowContext(ctx,
@@ -360,10 +362,17 @@ func (s *FundServer) WithdrawFund(ctx context.Context, req *pb.WithdrawFundReque
 	if amount > positionAmount {
 		return nil, status.Errorf(codes.InvalidArgument, "withdrawal amount %.2f exceeds position %.2f", amount, positionAmount)
 	}
+
+	// Case 2: insufficient liquidity
 	if amount > liquidAssets {
-		return nil, status.Error(codes.FailedPrecondition, "insufficient fund liquidity")
+		if req.ClientType != "CLIENT" {
+			return nil, status.Error(codes.FailedPrecondition, "insufficient fund liquidity")
+		}
+		// Auto-liquidate: sell portfolio positions until deficit is covered
+		return s.autoLiquidate(ctx, req, amount, liquidAssets)
 	}
 
+	// Case 1: sufficient liquidity — immediate settlement
 	_, err = s.AccountDB.ExecContext(ctx,
 		`UPDATE accounts SET balance = balance + $1, available_balance = available_balance + $1 WHERE id = $2`,
 		amount, req.DestinationAccountId,
@@ -428,7 +437,139 @@ func (s *FundServer) WithdrawFund(ctx context.Context, req *pb.WithdrawFundReque
 		return nil, status.Errorf(codes.Internal, "failed to commit: %v", err)
 	}
 
-	return s.fetchFundByID(ctx, req.FundId, true)
+	fund, err := s.fetchFundByID(ctx, req.FundId, true)
+	if err != nil {
+		return nil, err
+	}
+	return &pb.WithdrawFundResponse{Pending: false, Fund: fund}, nil
+}
+
+// autoLiquidate handles Case 2: sells portfolio positions to cover a withdrawal deficit,
+// stores a PENDING transaction, and returns a 202-style response.
+func (s *FundServer) autoLiquidate(ctx context.Context, req *pb.WithdrawFundRequest, amount, liquidAssets float64) (*pb.WithdrawFundResponse, error) {
+	var accountID, managerID int64
+	err := s.DB.QueryRowContext(ctx,
+		`SELECT account_id, manager_id FROM investment_funds WHERE id = $1`, req.FundId,
+	).Scan(&accountID, &managerID)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to fetch fund details: %v", err)
+	}
+
+	rows, err := s.DB.QueryContext(ctx,
+		`SELECT listing_id, quantity, average_cost FROM fund_portfolio_positions
+		 WHERE fund_id = $1 AND quantity > 0 ORDER BY quantity ASC`, req.FundId)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to fetch portfolio: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	deficit := amount - liquidAssets
+	var covered float64
+	for rows.Next() {
+		if covered >= deficit {
+			break
+		}
+		var listingID int64
+		var qty, avgCost float64
+		if err := rows.Scan(&listingID, &qty, &avgCost); err != nil {
+			return nil, status.Errorf(codes.Internal, "scan portfolio position: %v", err)
+		}
+		covered += qty * avgCost
+		if s.OrderClient != nil {
+			_, _ = s.OrderClient.CreateOrder(ctx, &pb_order.CreateOrderRequest{
+				UserId:    managerID,
+				UserType:  "EMPLOYEE",
+				AssetId:   listingID,
+				Quantity:  int32(qty),
+				AccountId: accountID,
+				Direction: "SELL",
+				FundId:    req.FundId,
+			})
+		}
+	}
+
+	_, err = s.DB.ExecContext(ctx,
+		`INSERT INTO client_fund_transactions
+		 (client_id, client_type, fund_id, amount, is_inflow, status, destination_account_id)
+		 VALUES ($1, $2, $3, $4, false, 'PENDING', $5)`,
+		req.ClientId, req.ClientType, req.FundId, amount, req.DestinationAccountId)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to insert pending transaction: %v", err)
+	}
+
+	return &pb.WithdrawFundResponse{
+		Pending: true,
+		Message: "Payment will arrive once orders are executed",
+	}, nil
+}
+
+func (s *FundServer) CheckPendingWithdrawals(ctx context.Context, req *pb.CheckPendingWithdrawalsRequest) (*pb.CheckPendingWithdrawalsResponse, error) {
+	var liquidAssets float64
+	if err := s.DB.QueryRowContext(ctx,
+		`SELECT liquid_assets FROM investment_funds WHERE id = $1`, req.FundId,
+	).Scan(&liquidAssets); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to fetch fund: %v", err)
+	}
+
+	rows, err := s.DB.QueryContext(ctx,
+		`SELECT id, client_id, client_type, amount, destination_account_id
+		 FROM client_fund_transactions
+		 WHERE fund_id = $1 AND is_inflow = false AND status = 'PENDING'
+		 ORDER BY timestamp ASC`, req.FundId)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to fetch pending transactions: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var completed int64
+	for rows.Next() {
+		var txID, clientID, destAccID int64
+		var clientType string
+		var txAmount float64
+		if err := rows.Scan(&txID, &clientID, &clientType, &txAmount, &destAccID); err != nil {
+			continue
+		}
+		if liquidAssets < txAmount {
+			continue
+		}
+
+		_, err = s.AccountDB.ExecContext(ctx,
+			`UPDATE accounts SET balance = balance + $1, available_balance = available_balance + $1 WHERE id = $2`,
+			txAmount, destAccID)
+		if err != nil {
+			continue
+		}
+
+		tx, err := s.DB.BeginTx(ctx, nil)
+		if err != nil {
+			// Undo account credit
+			_, _ = s.AccountDB.ExecContext(ctx,
+				`UPDATE accounts SET balance = balance - $1, available_balance = available_balance - $1 WHERE id = $2`,
+				txAmount, destAccID)
+			continue
+		}
+		_, _ = tx.ExecContext(ctx,
+			`UPDATE investment_funds SET liquid_assets = liquid_assets - $1 WHERE id = $2`,
+			txAmount, req.FundId)
+		_, _ = tx.ExecContext(ctx,
+			`UPDATE client_fund_positions
+			 SET total_invested_amount = total_invested_amount - $1, last_modified_at = NOW()
+			 WHERE fund_id = $2 AND client_id = $3 AND client_type = $4`,
+			txAmount, req.FundId, clientID, clientType)
+		_, _ = tx.ExecContext(ctx,
+			`UPDATE client_fund_transactions SET status = 'COMPLETED' WHERE id = $1`, txID)
+		if err := tx.Commit(); err != nil {
+			_ = tx.Rollback()
+			_, _ = s.AccountDB.ExecContext(ctx,
+				`UPDATE accounts SET balance = balance - $1, available_balance = available_balance - $1 WHERE id = $2`,
+				txAmount, destAccID)
+			continue
+		}
+
+		liquidAssets -= txAmount
+		completed++
+	}
+	return &pb.CheckPendingWithdrawalsResponse{Completed: completed}, nil
 }
 
 // isUniqueViolation checks if the error is a PostgreSQL unique constraint violation (error code 23505).

--- a/services/fund-service/handlers/grpc_server_test.go
+++ b/services/fund-service/handlers/grpc_server_test.go
@@ -16,6 +16,7 @@ import (
 
 	pb_account "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/account"
 	pb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/fund"
+	pb_order "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/order"
 )
 
 // ---- mock AccountServiceClient ----
@@ -52,10 +53,52 @@ func (m *mockAccountClient) GetBankAccounts(ctx context.Context, in *pb_account.
 	return nil, fmt.Errorf("not implemented")
 }
 
+// ---- mock OrderServiceClient ----
+
+type mockOrderClient struct {
+	createOrderFn func(context.Context, *pb_order.CreateOrderRequest, ...grpc.CallOption) (*pb_order.CreateOrderResponse, error)
+}
+
+func (m *mockOrderClient) Ping(ctx context.Context, in *pb_order.PingRequest, opts ...grpc.CallOption) (*pb_order.PingResponse, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+func (m *mockOrderClient) CreateOrder(ctx context.Context, in *pb_order.CreateOrderRequest, opts ...grpc.CallOption) (*pb_order.CreateOrderResponse, error) {
+	if m.createOrderFn != nil {
+		return m.createOrderFn(ctx, in, opts...)
+	}
+	return &pb_order.CreateOrderResponse{}, nil
+}
+func (m *mockOrderClient) ListOrders(ctx context.Context, in *pb_order.ListOrdersRequest, opts ...grpc.CallOption) (*pb_order.ListOrdersResponse, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+func (m *mockOrderClient) GetOrderById(ctx context.Context, in *pb_order.GetOrderByIdRequest, opts ...grpc.CallOption) (*pb_order.GetOrderByIdResponse, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+func (m *mockOrderClient) ApproveOrder(ctx context.Context, in *pb_order.ApproveOrderRequest, opts ...grpc.CallOption) (*pb_order.ApproveOrderResponse, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+func (m *mockOrderClient) DeclineOrder(ctx context.Context, in *pb_order.DeclineOrderRequest, opts ...grpc.CallOption) (*pb_order.DeclineOrderResponse, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+func (m *mockOrderClient) CancelOrder(ctx context.Context, in *pb_order.CancelOrderRequest, opts ...grpc.CallOption) (*pb_order.CancelOrderResponse, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+func (m *mockOrderClient) CancelOrderPortions(ctx context.Context, in *pb_order.CancelOrderPortionsRequest, opts ...grpc.CallOption) (*pb_order.CancelOrderPortionsResponse, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+func (m *mockOrderClient) GetActuaryProfits(ctx context.Context, in *pb_order.GetActuaryProfitsRequest, opts ...grpc.CallOption) (*pb_order.GetActuaryProfitsResponse, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
 // ---- helpers ----
 
-// newFundServer creates a FundServer with mocked fund DB, account DB, and employee DB.
+// newFundServer creates a FundServer with mocked DBs and no OrderClient.
 func newFundServer(t *testing.T, acctClient pb_account.AccountServiceClient) (*FundServer, sqlmock.Sqlmock, sqlmock.Sqlmock, sqlmock.Sqlmock) {
+	return newFundServerFull(t, acctClient, nil)
+}
+
+// newFundServerFull creates a FundServer with mocked DBs and an optional OrderClient.
+func newFundServerFull(t *testing.T, acctClient pb_account.AccountServiceClient, orderClient pb_order.OrderServiceClient) (*FundServer, sqlmock.Sqlmock, sqlmock.Sqlmock, sqlmock.Sqlmock) {
 	t.Helper()
 	fundDB, fundMock, err := sqlmock.New()
 	require.NoError(t, err)
@@ -73,6 +116,7 @@ func newFundServer(t *testing.T, acctClient pb_account.AccountServiceClient) (*F
 		AccountDB:     accountDB,
 		EmployeeDB:    employeeDB,
 		AccountClient: acctClient,
+		OrderClient:   orderClient,
 	}, fundMock, accountDBMock, empMock
 }
 
@@ -795,5 +839,186 @@ func TestGetFundPortfolio_Happy(t *testing.T) {
 	assert.InDelta(t, 50.0, resp.Positions[0].Quantity, 0.001)
 	assert.InDelta(t, 125.0, resp.Positions[0].AverageCost, 0.001)
 	assert.Equal(t, "2026-04-01", resp.Positions[0].AcquisitionDate)
+	require.NoError(t, fundMock.ExpectationsWereMet())
+}
+
+// ── WithdrawFund ──────────────────────────────────────────────────────────────
+
+func TestWithdrawFund_Case1_Immediate(t *testing.T) {
+	s, fundMock, accountDBMock, empMock := newFundServer(t, &mockAccountClient{})
+
+	// SELECT fund: liquid_assets=500000, active=true
+	fundMock.ExpectQuery("SELECT liquid_assets, active FROM investment_funds").
+		WithArgs(int64(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active"}).AddRow(500000.0, true))
+	// SELECT position
+	fundMock.ExpectQuery("SELECT total_invested_amount FROM client_fund_positions").
+		WillReturnRows(sqlmock.NewRows([]string{"total_invested_amount"}).AddRow(1000.0))
+	// Credit destination account
+	accountDBMock.ExpectExec("UPDATE accounts SET balance").
+		WithArgs(1000.0, int64(99)).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	// DB tx
+	fundMock.ExpectBegin()
+	fundMock.ExpectExec("UPDATE investment_funds SET liquid_assets = liquid_assets -").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	fundMock.ExpectExec("UPDATE client_fund_positions SET total_invested_amount").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	fundMock.ExpectExec("INSERT INTO client_fund_transactions").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	fundMock.ExpectCommit()
+	// fetchFundByID
+	addFetchFundRows(fundMock, accountDBMock, empMock, 1, "Test Fund", 100, 5)
+
+	resp, err := s.WithdrawFund(context.Background(), &pb.WithdrawFundRequest{
+		FundId: 1, ClientId: 7, ClientType: "CLIENT",
+		DestinationAccountId: 99, Amount: 1000.0,
+	})
+	require.NoError(t, err)
+	assert.False(t, resp.Pending)
+	assert.NotNil(t, resp.Fund)
+	assert.Equal(t, int64(1), resp.Fund.Id)
+}
+
+func TestWithdrawFund_Case1_WithdrawAll(t *testing.T) {
+	// amount=0 means withdraw full position
+	s, fundMock, accountDBMock, empMock := newFundServer(t, &mockAccountClient{})
+
+	fundMock.ExpectQuery("SELECT liquid_assets, active FROM investment_funds").
+		WithArgs(int64(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active"}).AddRow(500000.0, true))
+	fundMock.ExpectQuery("SELECT total_invested_amount FROM client_fund_positions").
+		WillReturnRows(sqlmock.NewRows([]string{"total_invested_amount"}).AddRow(2500.0))
+	accountDBMock.ExpectExec("UPDATE accounts SET balance").
+		WithArgs(2500.0, int64(99)).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	fundMock.ExpectBegin()
+	fundMock.ExpectExec("UPDATE investment_funds SET liquid_assets = liquid_assets -").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	fundMock.ExpectExec("UPDATE client_fund_positions SET total_invested_amount").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	fundMock.ExpectExec("INSERT INTO client_fund_transactions").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	fundMock.ExpectCommit()
+	addFetchFundRows(fundMock, accountDBMock, empMock, 1, "Test Fund", 100, 5)
+
+	resp, err := s.WithdrawFund(context.Background(), &pb.WithdrawFundRequest{
+		FundId: 1, ClientId: 7, ClientType: "CLIENT",
+		DestinationAccountId: 99, Amount: 0, // withdraw all
+	})
+	require.NoError(t, err)
+	assert.False(t, resp.Pending)
+	assert.NotNil(t, resp.Fund)
+}
+
+func TestWithdrawFund_Case2_ClientAutoLiquidate(t *testing.T) {
+	var createOrderCalled bool
+	order := &mockOrderClient{
+		createOrderFn: func(_ context.Context, req *pb_order.CreateOrderRequest, _ ...grpc.CallOption) (*pb_order.CreateOrderResponse, error) {
+			createOrderCalled = true
+			assert.Equal(t, "SELL", req.Direction)
+			assert.Equal(t, int64(1), req.FundId)
+			return &pb_order.CreateOrderResponse{}, nil
+		},
+	}
+	s, fundMock, _, _ := newFundServerFull(t, &mockAccountClient{}, order)
+
+	// liquid_assets=100 < amount=1000 → Case 2
+	fundMock.ExpectQuery("SELECT liquid_assets, active FROM investment_funds").
+		WithArgs(int64(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active"}).AddRow(100.0, true))
+	fundMock.ExpectQuery("SELECT total_invested_amount FROM client_fund_positions").
+		WillReturnRows(sqlmock.NewRows([]string{"total_invested_amount"}).AddRow(1000.0))
+	// fetch account_id, manager_id for SELL orders
+	fundMock.ExpectQuery("SELECT account_id, manager_id FROM investment_funds").
+		WithArgs(int64(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"account_id", "manager_id"}).AddRow(int64(42), int64(5)))
+	// portfolio positions
+	fundMock.ExpectQuery("SELECT listing_id, quantity, average_cost FROM fund_portfolio_positions").
+		WithArgs(int64(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"listing_id", "quantity", "average_cost"}).
+			AddRow(int64(10), 10.0, 100.0)) // 10*100=1000, covers deficit
+	// INSERT PENDING transaction
+	fundMock.ExpectExec("INSERT INTO client_fund_transactions").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	resp, err := s.WithdrawFund(context.Background(), &pb.WithdrawFundRequest{
+		FundId: 1, ClientId: 7, ClientType: "CLIENT",
+		DestinationAccountId: 99, Amount: 1000.0,
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.Pending)
+	assert.Equal(t, "Payment will arrive once orders are executed", resp.Message)
+	assert.True(t, createOrderCalled)
+	require.NoError(t, fundMock.ExpectationsWereMet())
+}
+
+func TestWithdrawFund_Case2_BankNoAutoLiquidate(t *testing.T) {
+	s, fundMock, _, _ := newFundServer(t, &mockAccountClient{})
+
+	// liquid_assets=100 < amount=1000, clientType=BANK → FailedPrecondition
+	fundMock.ExpectQuery("SELECT liquid_assets, active FROM investment_funds").
+		WithArgs(int64(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active"}).AddRow(100.0, true))
+	fundMock.ExpectQuery("SELECT total_invested_amount FROM client_fund_positions").
+		WillReturnRows(sqlmock.NewRows([]string{"total_invested_amount"}).AddRow(1000.0))
+
+	_, err := s.WithdrawFund(context.Background(), &pb.WithdrawFundRequest{
+		FundId: 1, ClientId: 0, ClientType: "BANK",
+		DestinationAccountId: 99, Amount: 1000.0,
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
+}
+
+// ── CheckPendingWithdrawals ───────────────────────────────────────────────────
+
+func TestCheckPendingWithdrawals_Completed(t *testing.T) {
+	s, fundMock, accountDBMock, _ := newFundServer(t, &mockAccountClient{})
+
+	// liquid_assets sufficient to cover the PENDING tx
+	fundMock.ExpectQuery("SELECT liquid_assets FROM investment_funds").
+		WithArgs(int64(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets"}).AddRow(5000.0))
+	// One PENDING outflow transaction
+	fundMock.ExpectQuery("SELECT id, client_id, client_type, amount, destination_account_id").
+		WithArgs(int64(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "client_id", "client_type", "amount", "destination_account_id"}).
+			AddRow(int64(1), int64(7), "CLIENT", 1000.0, int64(99)))
+	// Credit destination account
+	accountDBMock.ExpectExec("UPDATE accounts SET balance").
+		WithArgs(1000.0, int64(99)).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	// DB tx
+	fundMock.ExpectBegin()
+	fundMock.ExpectExec("UPDATE investment_funds SET liquid_assets = liquid_assets -").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	fundMock.ExpectExec("UPDATE client_fund_positions").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	fundMock.ExpectExec("UPDATE client_fund_transactions SET status = 'COMPLETED'").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	fundMock.ExpectCommit()
+
+	resp, err := s.CheckPendingWithdrawals(context.Background(), &pb.CheckPendingWithdrawalsRequest{FundId: 1})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), resp.Completed)
+	require.NoError(t, fundMock.ExpectationsWereMet())
+}
+
+func TestCheckPendingWithdrawals_StillInsufficient(t *testing.T) {
+	s, fundMock, _, _ := newFundServer(t, &mockAccountClient{})
+
+	// liquid_assets still too low
+	fundMock.ExpectQuery("SELECT liquid_assets FROM investment_funds").
+		WithArgs(int64(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets"}).AddRow(50.0))
+	fundMock.ExpectQuery("SELECT id, client_id, client_type, amount, destination_account_id").
+		WithArgs(int64(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "client_id", "client_type", "amount", "destination_account_id"}).
+			AddRow(int64(1), int64(7), "CLIENT", 1000.0, int64(99)))
+
+	resp, err := s.CheckPendingWithdrawals(context.Background(), &pb.CheckPendingWithdrawalsRequest{FundId: 1})
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), resp.Completed)
 	require.NoError(t, fundMock.ExpectationsWereMet())
 }

--- a/services/fund-service/main.go
+++ b/services/fund-service/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/RAF-SI-2025/EXBanka-4-Backend/services/fund-service/handlers"
 	pb_account "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/account"
 	pb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/fund"
+	pb_order "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/order"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
@@ -41,6 +42,13 @@ func main() {
 	defer func() { _ = accountConn.Close() }()
 	accountClient := pb_account.NewAccountServiceClient(accountConn)
 
+	orderConn, err := grpc.NewClient(os.Getenv("ORDER_SERVICE_ADDR"), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		log.Fatalf("failed to connect to order-service: %v", err)
+	}
+	defer func() { _ = orderConn.Close() }()
+	orderClient := pb_order.NewOrderServiceClient(orderConn)
+
 	lis, err := net.Listen("tcp", grpcPort)
 	if err != nil {
 		log.Fatalf("failed to listen on %s: %v", grpcPort, err)
@@ -52,6 +60,7 @@ func main() {
 		AccountDB:     accountDB,
 		EmployeeDB:    employeeDB,
 		AccountClient: accountClient,
+		OrderClient:   orderClient,
 	})
 
 	log.Printf("fund-service gRPC server listening on %s", grpcPort)

--- a/services/order-service/execution/scheduler.go
+++ b/services/order-service/execution/scheduler.go
@@ -244,6 +244,13 @@ func (s *Scheduler) executeOrder(order models.Order) {
 				log.Printf("order-scheduler: set done error for order %d: %v", order.ID, err)
 			}
 			log.Printf("order-scheduler: order %d fully executed", order.ID)
+			if order.FundID != 0 && order.Direction == "SELL" && s.FundClient != nil {
+				if _, err := s.FundClient.CheckPendingWithdrawals(ctx, &pb_fund.CheckPendingWithdrawalsRequest{
+					FundId: order.FundID,
+				}); err != nil {
+					log.Printf("order-scheduler: CheckPendingWithdrawals for fund %d error: %v", order.FundID, err)
+				}
+			}
 			return
 		}
 

--- a/shared/pb/fund/fund.pb.go
+++ b/shared/pb/fund/fund.pb.go
@@ -757,6 +757,154 @@ func (x *WithdrawFundRequest) GetAmount() float64 {
 	return 0
 }
 
+type WithdrawFundResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Pending       bool                   `protobuf:"varint,1,opt,name=pending,proto3" json:"pending,omitempty"` // true → 202 Accepted; false → 200 OK
+	Message       string                 `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+	Fund          *FundResponse          `protobuf:"bytes,3,opt,name=fund,proto3" json:"fund,omitempty"` // populated when pending=false
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *WithdrawFundResponse) Reset() {
+	*x = WithdrawFundResponse{}
+	mi := &file_fund_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WithdrawFundResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WithdrawFundResponse) ProtoMessage() {}
+
+func (x *WithdrawFundResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_fund_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WithdrawFundResponse.ProtoReflect.Descriptor instead.
+func (*WithdrawFundResponse) Descriptor() ([]byte, []int) {
+	return file_fund_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *WithdrawFundResponse) GetPending() bool {
+	if x != nil {
+		return x.Pending
+	}
+	return false
+}
+
+func (x *WithdrawFundResponse) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+func (x *WithdrawFundResponse) GetFund() *FundResponse {
+	if x != nil {
+		return x.Fund
+	}
+	return nil
+}
+
+type CheckPendingWithdrawalsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	FundId        int64                  `protobuf:"varint,1,opt,name=fund_id,json=fundId,proto3" json:"fund_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CheckPendingWithdrawalsRequest) Reset() {
+	*x = CheckPendingWithdrawalsRequest{}
+	mi := &file_fund_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CheckPendingWithdrawalsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CheckPendingWithdrawalsRequest) ProtoMessage() {}
+
+func (x *CheckPendingWithdrawalsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_fund_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CheckPendingWithdrawalsRequest.ProtoReflect.Descriptor instead.
+func (*CheckPendingWithdrawalsRequest) Descriptor() ([]byte, []int) {
+	return file_fund_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *CheckPendingWithdrawalsRequest) GetFundId() int64 {
+	if x != nil {
+		return x.FundId
+	}
+	return 0
+}
+
+type CheckPendingWithdrawalsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Completed     int64                  `protobuf:"varint,1,opt,name=completed,proto3" json:"completed,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CheckPendingWithdrawalsResponse) Reset() {
+	*x = CheckPendingWithdrawalsResponse{}
+	mi := &file_fund_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CheckPendingWithdrawalsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CheckPendingWithdrawalsResponse) ProtoMessage() {}
+
+func (x *CheckPendingWithdrawalsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_fund_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CheckPendingWithdrawalsResponse.ProtoReflect.Descriptor instead.
+func (*CheckPendingWithdrawalsResponse) Descriptor() ([]byte, []int) {
+	return file_fund_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *CheckPendingWithdrawalsResponse) GetCompleted() int64 {
+	if x != nil {
+		return x.Completed
+	}
+	return 0
+}
+
 type BankFundPosition struct {
 	state            protoimpl.MessageState `protogen:"open.v1"`
 	FundId           int64                  `protobuf:"varint,1,opt,name=fund_id,json=fundId,proto3" json:"fund_id,omitempty"`
@@ -771,7 +919,7 @@ type BankFundPosition struct {
 
 func (x *BankFundPosition) Reset() {
 	*x = BankFundPosition{}
-	mi := &file_fund_proto_msgTypes[12]
+	mi := &file_fund_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -783,7 +931,7 @@ func (x *BankFundPosition) String() string {
 func (*BankFundPosition) ProtoMessage() {}
 
 func (x *BankFundPosition) ProtoReflect() protoreflect.Message {
-	mi := &file_fund_proto_msgTypes[12]
+	mi := &file_fund_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -796,7 +944,7 @@ func (x *BankFundPosition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BankFundPosition.ProtoReflect.Descriptor instead.
 func (*BankFundPosition) Descriptor() ([]byte, []int) {
-	return file_fund_proto_rawDescGZIP(), []int{12}
+	return file_fund_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *BankFundPosition) GetFundId() int64 {
@@ -849,7 +997,7 @@ type GetBankPositionsRequest struct {
 
 func (x *GetBankPositionsRequest) Reset() {
 	*x = GetBankPositionsRequest{}
-	mi := &file_fund_proto_msgTypes[13]
+	mi := &file_fund_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -861,7 +1009,7 @@ func (x *GetBankPositionsRequest) String() string {
 func (*GetBankPositionsRequest) ProtoMessage() {}
 
 func (x *GetBankPositionsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fund_proto_msgTypes[13]
+	mi := &file_fund_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -874,7 +1022,7 @@ func (x *GetBankPositionsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBankPositionsRequest.ProtoReflect.Descriptor instead.
 func (*GetBankPositionsRequest) Descriptor() ([]byte, []int) {
-	return file_fund_proto_rawDescGZIP(), []int{13}
+	return file_fund_proto_rawDescGZIP(), []int{16}
 }
 
 type GetBankPositionsResponse struct {
@@ -886,7 +1034,7 @@ type GetBankPositionsResponse struct {
 
 func (x *GetBankPositionsResponse) Reset() {
 	*x = GetBankPositionsResponse{}
-	mi := &file_fund_proto_msgTypes[14]
+	mi := &file_fund_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -898,7 +1046,7 @@ func (x *GetBankPositionsResponse) String() string {
 func (*GetBankPositionsResponse) ProtoMessage() {}
 
 func (x *GetBankPositionsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fund_proto_msgTypes[14]
+	mi := &file_fund_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -911,7 +1059,7 @@ func (x *GetBankPositionsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBankPositionsResponse.ProtoReflect.Descriptor instead.
 func (*GetBankPositionsResponse) Descriptor() ([]byte, []int) {
-	return file_fund_proto_rawDescGZIP(), []int{14}
+	return file_fund_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *GetBankPositionsResponse) GetPositions() []*BankFundPosition {
@@ -938,7 +1086,7 @@ type ClientFundPosition struct {
 
 func (x *ClientFundPosition) Reset() {
 	*x = ClientFundPosition{}
-	mi := &file_fund_proto_msgTypes[15]
+	mi := &file_fund_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -950,7 +1098,7 @@ func (x *ClientFundPosition) String() string {
 func (*ClientFundPosition) ProtoMessage() {}
 
 func (x *ClientFundPosition) ProtoReflect() protoreflect.Message {
-	mi := &file_fund_proto_msgTypes[15]
+	mi := &file_fund_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -963,7 +1111,7 @@ func (x *ClientFundPosition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClientFundPosition.ProtoReflect.Descriptor instead.
 func (*ClientFundPosition) Descriptor() ([]byte, []int) {
-	return file_fund_proto_rawDescGZIP(), []int{15}
+	return file_fund_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *ClientFundPosition) GetFundId() int64 {
@@ -1039,7 +1187,7 @@ type GetMyPositionsRequest struct {
 
 func (x *GetMyPositionsRequest) Reset() {
 	*x = GetMyPositionsRequest{}
-	mi := &file_fund_proto_msgTypes[16]
+	mi := &file_fund_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1051,7 +1199,7 @@ func (x *GetMyPositionsRequest) String() string {
 func (*GetMyPositionsRequest) ProtoMessage() {}
 
 func (x *GetMyPositionsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fund_proto_msgTypes[16]
+	mi := &file_fund_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1064,7 +1212,7 @@ func (x *GetMyPositionsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetMyPositionsRequest.ProtoReflect.Descriptor instead.
 func (*GetMyPositionsRequest) Descriptor() ([]byte, []int) {
-	return file_fund_proto_rawDescGZIP(), []int{16}
+	return file_fund_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *GetMyPositionsRequest) GetClientId() int64 {
@@ -1090,7 +1238,7 @@ type GetMyPositionsResponse struct {
 
 func (x *GetMyPositionsResponse) Reset() {
 	*x = GetMyPositionsResponse{}
-	mi := &file_fund_proto_msgTypes[17]
+	mi := &file_fund_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1102,7 +1250,7 @@ func (x *GetMyPositionsResponse) String() string {
 func (*GetMyPositionsResponse) ProtoMessage() {}
 
 func (x *GetMyPositionsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fund_proto_msgTypes[17]
+	mi := &file_fund_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1115,7 +1263,7 @@ func (x *GetMyPositionsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetMyPositionsResponse.ProtoReflect.Descriptor instead.
 func (*GetMyPositionsResponse) Descriptor() ([]byte, []int) {
-	return file_fund_proto_rawDescGZIP(), []int{17}
+	return file_fund_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *GetMyPositionsResponse) GetPositions() []*ClientFundPosition {
@@ -1135,7 +1283,7 @@ type TransferFundsByManagerRequest struct {
 
 func (x *TransferFundsByManagerRequest) Reset() {
 	*x = TransferFundsByManagerRequest{}
-	mi := &file_fund_proto_msgTypes[18]
+	mi := &file_fund_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1147,7 +1295,7 @@ func (x *TransferFundsByManagerRequest) String() string {
 func (*TransferFundsByManagerRequest) ProtoMessage() {}
 
 func (x *TransferFundsByManagerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fund_proto_msgTypes[18]
+	mi := &file_fund_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1160,7 +1308,7 @@ func (x *TransferFundsByManagerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TransferFundsByManagerRequest.ProtoReflect.Descriptor instead.
 func (*TransferFundsByManagerRequest) Descriptor() ([]byte, []int) {
-	return file_fund_proto_rawDescGZIP(), []int{18}
+	return file_fund_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *TransferFundsByManagerRequest) GetOldManagerId() int64 {
@@ -1186,7 +1334,7 @@ type TransferFundsByManagerResponse struct {
 
 func (x *TransferFundsByManagerResponse) Reset() {
 	*x = TransferFundsByManagerResponse{}
-	mi := &file_fund_proto_msgTypes[19]
+	mi := &file_fund_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1198,7 +1346,7 @@ func (x *TransferFundsByManagerResponse) String() string {
 func (*TransferFundsByManagerResponse) ProtoMessage() {}
 
 func (x *TransferFundsByManagerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fund_proto_msgTypes[19]
+	mi := &file_fund_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1211,7 +1359,7 @@ func (x *TransferFundsByManagerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TransferFundsByManagerResponse.ProtoReflect.Descriptor instead.
 func (*TransferFundsByManagerResponse) Descriptor() ([]byte, []int) {
-	return file_fund_proto_rawDescGZIP(), []int{19}
+	return file_fund_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *TransferFundsByManagerResponse) GetFundsTransferred() int64 {
@@ -1232,7 +1380,7 @@ type ValidateFundAccountRequest struct {
 
 func (x *ValidateFundAccountRequest) Reset() {
 	*x = ValidateFundAccountRequest{}
-	mi := &file_fund_proto_msgTypes[20]
+	mi := &file_fund_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1244,7 +1392,7 @@ func (x *ValidateFundAccountRequest) String() string {
 func (*ValidateFundAccountRequest) ProtoMessage() {}
 
 func (x *ValidateFundAccountRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fund_proto_msgTypes[20]
+	mi := &file_fund_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1257,7 +1405,7 @@ func (x *ValidateFundAccountRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ValidateFundAccountRequest.ProtoReflect.Descriptor instead.
 func (*ValidateFundAccountRequest) Descriptor() ([]byte, []int) {
-	return file_fund_proto_rawDescGZIP(), []int{20}
+	return file_fund_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *ValidateFundAccountRequest) GetFundId() int64 {
@@ -1292,7 +1440,7 @@ type ValidateFundAccountResponse struct {
 
 func (x *ValidateFundAccountResponse) Reset() {
 	*x = ValidateFundAccountResponse{}
-	mi := &file_fund_proto_msgTypes[21]
+	mi := &file_fund_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1304,7 +1452,7 @@ func (x *ValidateFundAccountResponse) String() string {
 func (*ValidateFundAccountResponse) ProtoMessage() {}
 
 func (x *ValidateFundAccountResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fund_proto_msgTypes[21]
+	mi := &file_fund_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1317,7 +1465,7 @@ func (x *ValidateFundAccountResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ValidateFundAccountResponse.ProtoReflect.Descriptor instead.
 func (*ValidateFundAccountResponse) Descriptor() ([]byte, []int) {
-	return file_fund_proto_rawDescGZIP(), []int{21}
+	return file_fund_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *ValidateFundAccountResponse) GetAccountId() int64 {
@@ -1353,7 +1501,7 @@ type FundPortfolioPosition struct {
 
 func (x *FundPortfolioPosition) Reset() {
 	*x = FundPortfolioPosition{}
-	mi := &file_fund_proto_msgTypes[22]
+	mi := &file_fund_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1365,7 +1513,7 @@ func (x *FundPortfolioPosition) String() string {
 func (*FundPortfolioPosition) ProtoMessage() {}
 
 func (x *FundPortfolioPosition) ProtoReflect() protoreflect.Message {
-	mi := &file_fund_proto_msgTypes[22]
+	mi := &file_fund_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1378,7 +1526,7 @@ func (x *FundPortfolioPosition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FundPortfolioPosition.ProtoReflect.Descriptor instead.
 func (*FundPortfolioPosition) Descriptor() ([]byte, []int) {
-	return file_fund_proto_rawDescGZIP(), []int{22}
+	return file_fund_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *FundPortfolioPosition) GetListingId() int64 {
@@ -1418,7 +1566,7 @@ type GetFundPortfolioRequest struct {
 
 func (x *GetFundPortfolioRequest) Reset() {
 	*x = GetFundPortfolioRequest{}
-	mi := &file_fund_proto_msgTypes[23]
+	mi := &file_fund_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1430,7 +1578,7 @@ func (x *GetFundPortfolioRequest) String() string {
 func (*GetFundPortfolioRequest) ProtoMessage() {}
 
 func (x *GetFundPortfolioRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fund_proto_msgTypes[23]
+	mi := &file_fund_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1443,7 +1591,7 @@ func (x *GetFundPortfolioRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetFundPortfolioRequest.ProtoReflect.Descriptor instead.
 func (*GetFundPortfolioRequest) Descriptor() ([]byte, []int) {
-	return file_fund_proto_rawDescGZIP(), []int{23}
+	return file_fund_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *GetFundPortfolioRequest) GetFundId() int64 {
@@ -1462,7 +1610,7 @@ type GetFundPortfolioResponse struct {
 
 func (x *GetFundPortfolioResponse) Reset() {
 	*x = GetFundPortfolioResponse{}
-	mi := &file_fund_proto_msgTypes[24]
+	mi := &file_fund_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1474,7 +1622,7 @@ func (x *GetFundPortfolioResponse) String() string {
 func (*GetFundPortfolioResponse) ProtoMessage() {}
 
 func (x *GetFundPortfolioResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fund_proto_msgTypes[24]
+	mi := &file_fund_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1487,7 +1635,7 @@ func (x *GetFundPortfolioResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetFundPortfolioResponse.ProtoReflect.Descriptor instead.
 func (*GetFundPortfolioResponse) Descriptor() ([]byte, []int) {
-	return file_fund_proto_rawDescGZIP(), []int{24}
+	return file_fund_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *GetFundPortfolioResponse) GetPositions() []*FundPortfolioPosition {
@@ -1510,7 +1658,7 @@ type UpdateFundHoldingRequest struct {
 
 func (x *UpdateFundHoldingRequest) Reset() {
 	*x = UpdateFundHoldingRequest{}
-	mi := &file_fund_proto_msgTypes[25]
+	mi := &file_fund_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1522,7 +1670,7 @@ func (x *UpdateFundHoldingRequest) String() string {
 func (*UpdateFundHoldingRequest) ProtoMessage() {}
 
 func (x *UpdateFundHoldingRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fund_proto_msgTypes[25]
+	mi := &file_fund_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1535,7 +1683,7 @@ func (x *UpdateFundHoldingRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateFundHoldingRequest.ProtoReflect.Descriptor instead.
 func (*UpdateFundHoldingRequest) Descriptor() ([]byte, []int) {
-	return file_fund_proto_rawDescGZIP(), []int{25}
+	return file_fund_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *UpdateFundHoldingRequest) GetFundId() int64 {
@@ -1581,7 +1729,7 @@ type UpdateFundHoldingResponse struct {
 
 func (x *UpdateFundHoldingResponse) Reset() {
 	*x = UpdateFundHoldingResponse{}
-	mi := &file_fund_proto_msgTypes[26]
+	mi := &file_fund_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1593,7 +1741,7 @@ func (x *UpdateFundHoldingResponse) String() string {
 func (*UpdateFundHoldingResponse) ProtoMessage() {}
 
 func (x *UpdateFundHoldingResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fund_proto_msgTypes[26]
+	mi := &file_fund_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1606,7 +1754,7 @@ func (x *UpdateFundHoldingResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateFundHoldingResponse.ProtoReflect.Descriptor instead.
 func (*UpdateFundHoldingResponse) Descriptor() ([]byte, []int) {
-	return file_fund_proto_rawDescGZIP(), []int{26}
+	return file_fund_proto_rawDescGZIP(), []int{29}
 }
 
 var File_fund_proto protoreflect.FileDescriptor
@@ -1673,7 +1821,15 @@ const file_fund_proto_rawDesc = "" +
 	"\vclient_type\x18\x03 \x01(\tR\n" +
 	"clientType\x124\n" +
 	"\x16destination_account_id\x18\x04 \x01(\x03R\x14destinationAccountId\x12\x16\n" +
-	"\x06amount\x18\x05 \x01(\x01R\x06amount\"\xde\x01\n" +
+	"\x06amount\x18\x05 \x01(\x01R\x06amount\"r\n" +
+	"\x14WithdrawFundResponse\x12\x18\n" +
+	"\apending\x18\x01 \x01(\bR\apending\x12\x18\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage\x12&\n" +
+	"\x04fund\x18\x03 \x01(\v2\x12.fund.FundResponseR\x04fund\"9\n" +
+	"\x1eCheckPendingWithdrawalsRequest\x12\x17\n" +
+	"\afund_id\x18\x01 \x01(\x03R\x06fundId\"?\n" +
+	"\x1fCheckPendingWithdrawalsResponse\x12\x1c\n" +
+	"\tcompleted\x18\x01 \x01(\x03R\tcompleted\"\xde\x01\n" +
 	"\x10BankFundPosition\x12\x17\n" +
 	"\afund_id\x18\x01 \x01(\x03R\x06fundId\x12\x1b\n" +
 	"\tfund_name\x18\x02 \x01(\tR\bfundName\x12!\n" +
@@ -1734,7 +1890,7 @@ const file_fund_proto_rawDesc = "" +
 	"\bquantity\x18\x03 \x01(\x03R\bquantity\x12\x14\n" +
 	"\x05price\x18\x04 \x01(\x01R\x05price\x12\x1c\n" +
 	"\tdirection\x18\x05 \x01(\tR\tdirection\"\x1b\n" +
-	"\x19UpdateFundHoldingResponse2\xea\a\n" +
+	"\x19UpdateFundHoldingResponse2\xda\b\n" +
 	"\vFundService\x12-\n" +
 	"\x04Ping\x12\x11.fund.PingRequest\x1a\x12.fund.PingResponse\x129\n" +
 	"\n" +
@@ -1746,8 +1902,9 @@ const file_fund_proto_rawDesc = "" +
 	"\n" +
 	"DeleteFund\x12\x17.fund.DeleteFundRequest\x1a\x18.fund.DeleteFundResponse\x129\n" +
 	"\n" +
-	"InvestFund\x12\x17.fund.InvestFundRequest\x1a\x12.fund.FundResponse\x12=\n" +
-	"\fWithdrawFund\x12\x19.fund.WithdrawFundRequest\x1a\x12.fund.FundResponse\x12Q\n" +
+	"InvestFund\x12\x17.fund.InvestFundRequest\x1a\x12.fund.FundResponse\x12E\n" +
+	"\fWithdrawFund\x12\x19.fund.WithdrawFundRequest\x1a\x1a.fund.WithdrawFundResponse\x12f\n" +
+	"\x17CheckPendingWithdrawals\x12$.fund.CheckPendingWithdrawalsRequest\x1a%.fund.CheckPendingWithdrawalsResponse\x12Q\n" +
 	"\x10GetBankPositions\x12\x1d.fund.GetBankPositionsRequest\x1a\x1e.fund.GetBankPositionsResponse\x12K\n" +
 	"\x0eGetMyPositions\x12\x1b.fund.GetMyPositionsRequest\x1a\x1c.fund.GetMyPositionsResponse\x12c\n" +
 	"\x16TransferFundsByManager\x12#.fund.TransferFundsByManagerRequest\x1a$.fund.TransferFundsByManagerResponse\x12Z\n" +
@@ -1767,74 +1924,80 @@ func file_fund_proto_rawDescGZIP() []byte {
 	return file_fund_proto_rawDescData
 }
 
-var file_fund_proto_msgTypes = make([]protoimpl.MessageInfo, 27)
+var file_fund_proto_msgTypes = make([]protoimpl.MessageInfo, 30)
 var file_fund_proto_goTypes = []any{
-	(*PingRequest)(nil),                    // 0: fund.PingRequest
-	(*PingResponse)(nil),                   // 1: fund.PingResponse
-	(*CreateFundRequest)(nil),              // 2: fund.CreateFundRequest
-	(*UpdateFundRequest)(nil),              // 3: fund.UpdateFundRequest
-	(*DeleteFundRequest)(nil),              // 4: fund.DeleteFundRequest
-	(*DeleteFundResponse)(nil),             // 5: fund.DeleteFundResponse
-	(*ListFundsRequest)(nil),               // 6: fund.ListFundsRequest
-	(*GetFundRequest)(nil),                 // 7: fund.GetFundRequest
-	(*FundResponse)(nil),                   // 8: fund.FundResponse
-	(*ListFundsResponse)(nil),              // 9: fund.ListFundsResponse
-	(*InvestFundRequest)(nil),              // 10: fund.InvestFundRequest
-	(*WithdrawFundRequest)(nil),            // 11: fund.WithdrawFundRequest
-	(*BankFundPosition)(nil),               // 12: fund.BankFundPosition
-	(*GetBankPositionsRequest)(nil),        // 13: fund.GetBankPositionsRequest
-	(*GetBankPositionsResponse)(nil),       // 14: fund.GetBankPositionsResponse
-	(*ClientFundPosition)(nil),             // 15: fund.ClientFundPosition
-	(*GetMyPositionsRequest)(nil),          // 16: fund.GetMyPositionsRequest
-	(*GetMyPositionsResponse)(nil),         // 17: fund.GetMyPositionsResponse
-	(*TransferFundsByManagerRequest)(nil),  // 18: fund.TransferFundsByManagerRequest
-	(*TransferFundsByManagerResponse)(nil), // 19: fund.TransferFundsByManagerResponse
-	(*ValidateFundAccountRequest)(nil),     // 20: fund.ValidateFundAccountRequest
-	(*ValidateFundAccountResponse)(nil),    // 21: fund.ValidateFundAccountResponse
-	(*FundPortfolioPosition)(nil),          // 22: fund.FundPortfolioPosition
-	(*GetFundPortfolioRequest)(nil),        // 23: fund.GetFundPortfolioRequest
-	(*GetFundPortfolioResponse)(nil),       // 24: fund.GetFundPortfolioResponse
-	(*UpdateFundHoldingRequest)(nil),       // 25: fund.UpdateFundHoldingRequest
-	(*UpdateFundHoldingResponse)(nil),      // 26: fund.UpdateFundHoldingResponse
+	(*PingRequest)(nil),                     // 0: fund.PingRequest
+	(*PingResponse)(nil),                    // 1: fund.PingResponse
+	(*CreateFundRequest)(nil),               // 2: fund.CreateFundRequest
+	(*UpdateFundRequest)(nil),               // 3: fund.UpdateFundRequest
+	(*DeleteFundRequest)(nil),               // 4: fund.DeleteFundRequest
+	(*DeleteFundResponse)(nil),              // 5: fund.DeleteFundResponse
+	(*ListFundsRequest)(nil),                // 6: fund.ListFundsRequest
+	(*GetFundRequest)(nil),                  // 7: fund.GetFundRequest
+	(*FundResponse)(nil),                    // 8: fund.FundResponse
+	(*ListFundsResponse)(nil),               // 9: fund.ListFundsResponse
+	(*InvestFundRequest)(nil),               // 10: fund.InvestFundRequest
+	(*WithdrawFundRequest)(nil),             // 11: fund.WithdrawFundRequest
+	(*WithdrawFundResponse)(nil),            // 12: fund.WithdrawFundResponse
+	(*CheckPendingWithdrawalsRequest)(nil),  // 13: fund.CheckPendingWithdrawalsRequest
+	(*CheckPendingWithdrawalsResponse)(nil), // 14: fund.CheckPendingWithdrawalsResponse
+	(*BankFundPosition)(nil),                // 15: fund.BankFundPosition
+	(*GetBankPositionsRequest)(nil),         // 16: fund.GetBankPositionsRequest
+	(*GetBankPositionsResponse)(nil),        // 17: fund.GetBankPositionsResponse
+	(*ClientFundPosition)(nil),              // 18: fund.ClientFundPosition
+	(*GetMyPositionsRequest)(nil),           // 19: fund.GetMyPositionsRequest
+	(*GetMyPositionsResponse)(nil),          // 20: fund.GetMyPositionsResponse
+	(*TransferFundsByManagerRequest)(nil),   // 21: fund.TransferFundsByManagerRequest
+	(*TransferFundsByManagerResponse)(nil),  // 22: fund.TransferFundsByManagerResponse
+	(*ValidateFundAccountRequest)(nil),      // 23: fund.ValidateFundAccountRequest
+	(*ValidateFundAccountResponse)(nil),     // 24: fund.ValidateFundAccountResponse
+	(*FundPortfolioPosition)(nil),           // 25: fund.FundPortfolioPosition
+	(*GetFundPortfolioRequest)(nil),         // 26: fund.GetFundPortfolioRequest
+	(*GetFundPortfolioResponse)(nil),        // 27: fund.GetFundPortfolioResponse
+	(*UpdateFundHoldingRequest)(nil),        // 28: fund.UpdateFundHoldingRequest
+	(*UpdateFundHoldingResponse)(nil),       // 29: fund.UpdateFundHoldingResponse
 }
 var file_fund_proto_depIdxs = []int32{
 	8,  // 0: fund.ListFundsResponse.funds:type_name -> fund.FundResponse
-	12, // 1: fund.GetBankPositionsResponse.positions:type_name -> fund.BankFundPosition
-	15, // 2: fund.GetMyPositionsResponse.positions:type_name -> fund.ClientFundPosition
-	22, // 3: fund.GetFundPortfolioResponse.positions:type_name -> fund.FundPortfolioPosition
-	0,  // 4: fund.FundService.Ping:input_type -> fund.PingRequest
-	2,  // 5: fund.FundService.CreateFund:input_type -> fund.CreateFundRequest
-	6,  // 6: fund.FundService.ListFunds:input_type -> fund.ListFundsRequest
-	7,  // 7: fund.FundService.GetFund:input_type -> fund.GetFundRequest
-	3,  // 8: fund.FundService.UpdateFund:input_type -> fund.UpdateFundRequest
-	4,  // 9: fund.FundService.DeleteFund:input_type -> fund.DeleteFundRequest
-	10, // 10: fund.FundService.InvestFund:input_type -> fund.InvestFundRequest
-	11, // 11: fund.FundService.WithdrawFund:input_type -> fund.WithdrawFundRequest
-	13, // 12: fund.FundService.GetBankPositions:input_type -> fund.GetBankPositionsRequest
-	16, // 13: fund.FundService.GetMyPositions:input_type -> fund.GetMyPositionsRequest
-	18, // 14: fund.FundService.TransferFundsByManager:input_type -> fund.TransferFundsByManagerRequest
-	20, // 15: fund.FundService.ValidateFundAccount:input_type -> fund.ValidateFundAccountRequest
-	25, // 16: fund.FundService.UpdateFundHolding:input_type -> fund.UpdateFundHoldingRequest
-	23, // 17: fund.FundService.GetFundPortfolio:input_type -> fund.GetFundPortfolioRequest
-	1,  // 18: fund.FundService.Ping:output_type -> fund.PingResponse
-	8,  // 19: fund.FundService.CreateFund:output_type -> fund.FundResponse
-	9,  // 20: fund.FundService.ListFunds:output_type -> fund.ListFundsResponse
-	8,  // 21: fund.FundService.GetFund:output_type -> fund.FundResponse
-	8,  // 22: fund.FundService.UpdateFund:output_type -> fund.FundResponse
-	5,  // 23: fund.FundService.DeleteFund:output_type -> fund.DeleteFundResponse
-	8,  // 24: fund.FundService.InvestFund:output_type -> fund.FundResponse
-	8,  // 25: fund.FundService.WithdrawFund:output_type -> fund.FundResponse
-	14, // 26: fund.FundService.GetBankPositions:output_type -> fund.GetBankPositionsResponse
-	17, // 27: fund.FundService.GetMyPositions:output_type -> fund.GetMyPositionsResponse
-	19, // 28: fund.FundService.TransferFundsByManager:output_type -> fund.TransferFundsByManagerResponse
-	21, // 29: fund.FundService.ValidateFundAccount:output_type -> fund.ValidateFundAccountResponse
-	26, // 30: fund.FundService.UpdateFundHolding:output_type -> fund.UpdateFundHoldingResponse
-	24, // 31: fund.FundService.GetFundPortfolio:output_type -> fund.GetFundPortfolioResponse
-	18, // [18:32] is the sub-list for method output_type
-	4,  // [4:18] is the sub-list for method input_type
-	4,  // [4:4] is the sub-list for extension type_name
-	4,  // [4:4] is the sub-list for extension extendee
-	0,  // [0:4] is the sub-list for field type_name
+	8,  // 1: fund.WithdrawFundResponse.fund:type_name -> fund.FundResponse
+	15, // 2: fund.GetBankPositionsResponse.positions:type_name -> fund.BankFundPosition
+	18, // 3: fund.GetMyPositionsResponse.positions:type_name -> fund.ClientFundPosition
+	25, // 4: fund.GetFundPortfolioResponse.positions:type_name -> fund.FundPortfolioPosition
+	0,  // 5: fund.FundService.Ping:input_type -> fund.PingRequest
+	2,  // 6: fund.FundService.CreateFund:input_type -> fund.CreateFundRequest
+	6,  // 7: fund.FundService.ListFunds:input_type -> fund.ListFundsRequest
+	7,  // 8: fund.FundService.GetFund:input_type -> fund.GetFundRequest
+	3,  // 9: fund.FundService.UpdateFund:input_type -> fund.UpdateFundRequest
+	4,  // 10: fund.FundService.DeleteFund:input_type -> fund.DeleteFundRequest
+	10, // 11: fund.FundService.InvestFund:input_type -> fund.InvestFundRequest
+	11, // 12: fund.FundService.WithdrawFund:input_type -> fund.WithdrawFundRequest
+	13, // 13: fund.FundService.CheckPendingWithdrawals:input_type -> fund.CheckPendingWithdrawalsRequest
+	16, // 14: fund.FundService.GetBankPositions:input_type -> fund.GetBankPositionsRequest
+	19, // 15: fund.FundService.GetMyPositions:input_type -> fund.GetMyPositionsRequest
+	21, // 16: fund.FundService.TransferFundsByManager:input_type -> fund.TransferFundsByManagerRequest
+	23, // 17: fund.FundService.ValidateFundAccount:input_type -> fund.ValidateFundAccountRequest
+	28, // 18: fund.FundService.UpdateFundHolding:input_type -> fund.UpdateFundHoldingRequest
+	26, // 19: fund.FundService.GetFundPortfolio:input_type -> fund.GetFundPortfolioRequest
+	1,  // 20: fund.FundService.Ping:output_type -> fund.PingResponse
+	8,  // 21: fund.FundService.CreateFund:output_type -> fund.FundResponse
+	9,  // 22: fund.FundService.ListFunds:output_type -> fund.ListFundsResponse
+	8,  // 23: fund.FundService.GetFund:output_type -> fund.FundResponse
+	8,  // 24: fund.FundService.UpdateFund:output_type -> fund.FundResponse
+	5,  // 25: fund.FundService.DeleteFund:output_type -> fund.DeleteFundResponse
+	8,  // 26: fund.FundService.InvestFund:output_type -> fund.FundResponse
+	12, // 27: fund.FundService.WithdrawFund:output_type -> fund.WithdrawFundResponse
+	14, // 28: fund.FundService.CheckPendingWithdrawals:output_type -> fund.CheckPendingWithdrawalsResponse
+	17, // 29: fund.FundService.GetBankPositions:output_type -> fund.GetBankPositionsResponse
+	20, // 30: fund.FundService.GetMyPositions:output_type -> fund.GetMyPositionsResponse
+	22, // 31: fund.FundService.TransferFundsByManager:output_type -> fund.TransferFundsByManagerResponse
+	24, // 32: fund.FundService.ValidateFundAccount:output_type -> fund.ValidateFundAccountResponse
+	29, // 33: fund.FundService.UpdateFundHolding:output_type -> fund.UpdateFundHoldingResponse
+	27, // 34: fund.FundService.GetFundPortfolio:output_type -> fund.GetFundPortfolioResponse
+	20, // [20:35] is the sub-list for method output_type
+	5,  // [5:20] is the sub-list for method input_type
+	5,  // [5:5] is the sub-list for extension type_name
+	5,  // [5:5] is the sub-list for extension extendee
+	0,  // [0:5] is the sub-list for field type_name
 }
 
 func init() { file_fund_proto_init() }
@@ -1848,7 +2011,7 @@ func file_fund_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_fund_proto_rawDesc), len(file_fund_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   27,
+			NumMessages:   30,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/shared/pb/fund/fund_grpc.pb.go
+++ b/shared/pb/fund/fund_grpc.pb.go
@@ -19,20 +19,21 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	FundService_Ping_FullMethodName                   = "/fund.FundService/Ping"
-	FundService_CreateFund_FullMethodName             = "/fund.FundService/CreateFund"
-	FundService_ListFunds_FullMethodName              = "/fund.FundService/ListFunds"
-	FundService_GetFund_FullMethodName                = "/fund.FundService/GetFund"
-	FundService_UpdateFund_FullMethodName             = "/fund.FundService/UpdateFund"
-	FundService_DeleteFund_FullMethodName             = "/fund.FundService/DeleteFund"
-	FundService_InvestFund_FullMethodName             = "/fund.FundService/InvestFund"
-	FundService_WithdrawFund_FullMethodName           = "/fund.FundService/WithdrawFund"
-	FundService_GetBankPositions_FullMethodName       = "/fund.FundService/GetBankPositions"
-	FundService_GetMyPositions_FullMethodName         = "/fund.FundService/GetMyPositions"
-	FundService_TransferFundsByManager_FullMethodName = "/fund.FundService/TransferFundsByManager"
-	FundService_ValidateFundAccount_FullMethodName    = "/fund.FundService/ValidateFundAccount"
-	FundService_UpdateFundHolding_FullMethodName      = "/fund.FundService/UpdateFundHolding"
-	FundService_GetFundPortfolio_FullMethodName       = "/fund.FundService/GetFundPortfolio"
+	FundService_Ping_FullMethodName                    = "/fund.FundService/Ping"
+	FundService_CreateFund_FullMethodName              = "/fund.FundService/CreateFund"
+	FundService_ListFunds_FullMethodName               = "/fund.FundService/ListFunds"
+	FundService_GetFund_FullMethodName                 = "/fund.FundService/GetFund"
+	FundService_UpdateFund_FullMethodName              = "/fund.FundService/UpdateFund"
+	FundService_DeleteFund_FullMethodName              = "/fund.FundService/DeleteFund"
+	FundService_InvestFund_FullMethodName              = "/fund.FundService/InvestFund"
+	FundService_WithdrawFund_FullMethodName            = "/fund.FundService/WithdrawFund"
+	FundService_CheckPendingWithdrawals_FullMethodName = "/fund.FundService/CheckPendingWithdrawals"
+	FundService_GetBankPositions_FullMethodName        = "/fund.FundService/GetBankPositions"
+	FundService_GetMyPositions_FullMethodName          = "/fund.FundService/GetMyPositions"
+	FundService_TransferFundsByManager_FullMethodName  = "/fund.FundService/TransferFundsByManager"
+	FundService_ValidateFundAccount_FullMethodName     = "/fund.FundService/ValidateFundAccount"
+	FundService_UpdateFundHolding_FullMethodName       = "/fund.FundService/UpdateFundHolding"
+	FundService_GetFundPortfolio_FullMethodName        = "/fund.FundService/GetFundPortfolio"
 )
 
 // FundServiceClient is the client API for FundService service.
@@ -46,7 +47,8 @@ type FundServiceClient interface {
 	UpdateFund(ctx context.Context, in *UpdateFundRequest, opts ...grpc.CallOption) (*FundResponse, error)
 	DeleteFund(ctx context.Context, in *DeleteFundRequest, opts ...grpc.CallOption) (*DeleteFundResponse, error)
 	InvestFund(ctx context.Context, in *InvestFundRequest, opts ...grpc.CallOption) (*FundResponse, error)
-	WithdrawFund(ctx context.Context, in *WithdrawFundRequest, opts ...grpc.CallOption) (*FundResponse, error)
+	WithdrawFund(ctx context.Context, in *WithdrawFundRequest, opts ...grpc.CallOption) (*WithdrawFundResponse, error)
+	CheckPendingWithdrawals(ctx context.Context, in *CheckPendingWithdrawalsRequest, opts ...grpc.CallOption) (*CheckPendingWithdrawalsResponse, error)
 	GetBankPositions(ctx context.Context, in *GetBankPositionsRequest, opts ...grpc.CallOption) (*GetBankPositionsResponse, error)
 	GetMyPositions(ctx context.Context, in *GetMyPositionsRequest, opts ...grpc.CallOption) (*GetMyPositionsResponse, error)
 	TransferFundsByManager(ctx context.Context, in *TransferFundsByManagerRequest, opts ...grpc.CallOption) (*TransferFundsByManagerResponse, error)
@@ -133,10 +135,20 @@ func (c *fundServiceClient) InvestFund(ctx context.Context, in *InvestFundReques
 	return out, nil
 }
 
-func (c *fundServiceClient) WithdrawFund(ctx context.Context, in *WithdrawFundRequest, opts ...grpc.CallOption) (*FundResponse, error) {
+func (c *fundServiceClient) WithdrawFund(ctx context.Context, in *WithdrawFundRequest, opts ...grpc.CallOption) (*WithdrawFundResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(FundResponse)
+	out := new(WithdrawFundResponse)
 	err := c.cc.Invoke(ctx, FundService_WithdrawFund_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *fundServiceClient) CheckPendingWithdrawals(ctx context.Context, in *CheckPendingWithdrawalsRequest, opts ...grpc.CallOption) (*CheckPendingWithdrawalsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(CheckPendingWithdrawalsResponse)
+	err := c.cc.Invoke(ctx, FundService_CheckPendingWithdrawals_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +226,8 @@ type FundServiceServer interface {
 	UpdateFund(context.Context, *UpdateFundRequest) (*FundResponse, error)
 	DeleteFund(context.Context, *DeleteFundRequest) (*DeleteFundResponse, error)
 	InvestFund(context.Context, *InvestFundRequest) (*FundResponse, error)
-	WithdrawFund(context.Context, *WithdrawFundRequest) (*FundResponse, error)
+	WithdrawFund(context.Context, *WithdrawFundRequest) (*WithdrawFundResponse, error)
+	CheckPendingWithdrawals(context.Context, *CheckPendingWithdrawalsRequest) (*CheckPendingWithdrawalsResponse, error)
 	GetBankPositions(context.Context, *GetBankPositionsRequest) (*GetBankPositionsResponse, error)
 	GetMyPositions(context.Context, *GetMyPositionsRequest) (*GetMyPositionsResponse, error)
 	TransferFundsByManager(context.Context, *TransferFundsByManagerRequest) (*TransferFundsByManagerResponse, error)
@@ -252,8 +265,11 @@ func (UnimplementedFundServiceServer) DeleteFund(context.Context, *DeleteFundReq
 func (UnimplementedFundServiceServer) InvestFund(context.Context, *InvestFundRequest) (*FundResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method InvestFund not implemented")
 }
-func (UnimplementedFundServiceServer) WithdrawFund(context.Context, *WithdrawFundRequest) (*FundResponse, error) {
+func (UnimplementedFundServiceServer) WithdrawFund(context.Context, *WithdrawFundRequest) (*WithdrawFundResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method WithdrawFund not implemented")
+}
+func (UnimplementedFundServiceServer) CheckPendingWithdrawals(context.Context, *CheckPendingWithdrawalsRequest) (*CheckPendingWithdrawalsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method CheckPendingWithdrawals not implemented")
 }
 func (UnimplementedFundServiceServer) GetBankPositions(context.Context, *GetBankPositionsRequest) (*GetBankPositionsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetBankPositions not implemented")
@@ -438,6 +454,24 @@ func _FundService_WithdrawFund_Handler(srv interface{}, ctx context.Context, dec
 	return interceptor(ctx, in, info, handler)
 }
 
+func _FundService_CheckPendingWithdrawals_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CheckPendingWithdrawalsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(FundServiceServer).CheckPendingWithdrawals(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: FundService_CheckPendingWithdrawals_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(FundServiceServer).CheckPendingWithdrawals(ctx, req.(*CheckPendingWithdrawalsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _FundService_GetBankPositions_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(GetBankPositionsRequest)
 	if err := dec(in); err != nil {
@@ -584,6 +618,10 @@ var FundService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "WithdrawFund",
 			Handler:    _FundService_WithdrawFund_Handler,
+		},
+		{
+			MethodName: "CheckPendingWithdrawals",
+			Handler:    _FundService_CheckPendingWithdrawals_Handler,
 		},
 		{
 			MethodName: "GetBankPositions",

--- a/shared/proto/fund.proto
+++ b/shared/proto/fund.proto
@@ -10,7 +10,8 @@ service FundService {
   rpc UpdateFund(UpdateFundRequest) returns (FundResponse);
   rpc DeleteFund(DeleteFundRequest) returns (DeleteFundResponse);
   rpc InvestFund(InvestFundRequest) returns (FundResponse);
-  rpc WithdrawFund(WithdrawFundRequest) returns (FundResponse);
+  rpc WithdrawFund(WithdrawFundRequest) returns (WithdrawFundResponse);
+  rpc CheckPendingWithdrawals(CheckPendingWithdrawalsRequest) returns (CheckPendingWithdrawalsResponse);
   rpc GetBankPositions(GetBankPositionsRequest) returns (GetBankPositionsResponse);
   rpc GetMyPositions(GetMyPositionsRequest) returns (GetMyPositionsResponse);
   rpc TransferFundsByManager(TransferFundsByManagerRequest) returns (TransferFundsByManagerResponse);
@@ -87,6 +88,15 @@ message WithdrawFundRequest {
   int64  destination_account_id = 4;
   double amount                 = 5; // 0 = full position
 }
+
+message WithdrawFundResponse {
+  bool         pending = 1; // true → 202 Accepted; false → 200 OK
+  string       message = 2;
+  FundResponse fund    = 3; // populated when pending=false
+}
+
+message CheckPendingWithdrawalsRequest  { int64 fund_id   = 1; }
+message CheckPendingWithdrawalsResponse { int64 completed = 1; }
 
 // ── GetBankPositions ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- **Case 2 auto-liquidation**: when `liquid_assets < amount` and `clientType=CLIENT`, `WithdrawFund` now automatically sells the fund's portfolio positions (smallest quantity first) via SELL orders to order-service, inserts a `PENDING` transaction with `destination_account_id`, and returns 202 Accepted. BANK redemptions still return `FailedPrecondition`.
- **`withdrawAll` flag**: the HTTP handler accepts `"withdrawAll": true` in the request body to redeem the client's full position (passes `amount=0` to gRPC, which the fund-service already interprets as full position).
- **`CheckPendingWithdrawals` RPC**: new fund-service endpoint called by the order-service scheduler after a fund SELL order fully executes — credits the destination account and marks the PENDING transaction as COMPLETED.

## Changes

| File | Change |
|---|---|
| `shared/proto/fund.proto` | New `WithdrawFundResponse`, new `CheckPendingWithdrawals` RPC |
| `shared/pb/fund/` | Regenerated proto bindings |
| `services/fund-service/db/schema.sql` | `destination_account_id BIGINT` on `client_fund_transactions` |
| `services/fund-service/handlers/grpc_server.go` | Case 2 `autoLiquidate`, `CheckPendingWithdrawals`, `OrderClient` field |
| `services/fund-service/main.go` | Connect to `ORDER_SERVICE_ADDR` |
| `services/order-service/execution/scheduler.go` | Call `CheckPendingWithdrawals` after fund SELL order completes |
| `services/api-gateway/handlers/fund.go` | `withdrawAll` flag, 202 response, `BankRedeemFund` updated |
| Tests | 7 new fund-service tests + 3 new gateway tests; `bank_profit_test.go` updated |

## Test plan

- [ ] `go test ./services/fund-service/handlers/...` — all pass
- [ ] `go test ./services/api-gateway/handlers/...` — all pass
- [ ] `go build ./services/fund-service/... ./services/api-gateway/... ./services/order-service/...` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)