### PR TITLE
feat: fund performance history tracking (#224)

### DIFF
--- a/services/api-gateway/handlers/fund.go
+++ b/services/api-gateway/handlers/fund.go
@@ -747,3 +747,37 @@ func GetMyPositions(client pb.FundServiceClient) gin.HandlerFunc {
 		c.JSON(http.StatusOK, result)
 	}
 }
+
+func GetFundPerformanceHistory(client pb.FundServiceClient) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid fund id"})
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+		defer cancel()
+
+		resp, err := client.GetFundPerformanceHistory(ctx, &pb.GetFundPerformanceRequest{
+			FundId: id,
+			From:   c.Query("from"),
+			To:     c.Query("to"),
+		})
+		if err != nil {
+			mapFundError(c, err)
+			return
+		}
+
+		type record struct {
+			Date      string  `json:"date"`
+			FundValue float64 `json:"fundValue"`
+			Profit    float64 `json:"profit"`
+		}
+		out := make([]record, len(resp.Records))
+		for i, r := range resp.Records {
+			out[i] = record{Date: r.Date, FundValue: r.FundValue, Profit: r.Profit}
+		}
+		c.JSON(http.StatusOK, out)
+	}
+}

--- a/services/api-gateway/handlers/fund_test.go
+++ b/services/api-gateway/handlers/fund_test.go
@@ -33,21 +33,22 @@ func makeSupervisorToken() string {
 // ---- stub fund client ----
 
 type stubFundClient struct {
-	pingFn                    func(context.Context, *pb.PingRequest, ...grpc.CallOption) (*pb.PingResponse, error)
-	createFundFn              func(context.Context, *pb.CreateFundRequest, ...grpc.CallOption) (*pb.FundResponse, error)
-	listFundsFn               func(context.Context, *pb.ListFundsRequest, ...grpc.CallOption) (*pb.ListFundsResponse, error)
-	getFundFn                 func(context.Context, *pb.GetFundRequest, ...grpc.CallOption) (*pb.FundResponse, error)
-	updateFundFn              func(context.Context, *pb.UpdateFundRequest, ...grpc.CallOption) (*pb.FundResponse, error)
-	deleteFundFn              func(context.Context, *pb.DeleteFundRequest, ...grpc.CallOption) (*pb.DeleteFundResponse, error)
-	investFundFn              func(context.Context, *pb.InvestFundRequest, ...grpc.CallOption) (*pb.FundResponse, error)
-	withdrawFundFn            func(context.Context, *pb.WithdrawFundRequest, ...grpc.CallOption) (*pb.WithdrawFundResponse, error)
-	checkPendingWithdrawalsFn func(context.Context, *pb.CheckPendingWithdrawalsRequest, ...grpc.CallOption) (*pb.CheckPendingWithdrawalsResponse, error)
-	getBankPositionsFn        func(context.Context, *pb.GetBankPositionsRequest, ...grpc.CallOption) (*pb.GetBankPositionsResponse, error)
-	validateFundAccountFn     func(context.Context, *pb.ValidateFundAccountRequest, ...grpc.CallOption) (*pb.ValidateFundAccountResponse, error)
-	updateFundHoldingFn       func(context.Context, *pb.UpdateFundHoldingRequest, ...grpc.CallOption) (*pb.UpdateFundHoldingResponse, error)
-	getMyPositionsFn          func(context.Context, *pb.GetMyPositionsRequest, ...grpc.CallOption) (*pb.GetMyPositionsResponse, error)
-	transferFundsByManagerFn  func(context.Context, *pb.TransferFundsByManagerRequest, ...grpc.CallOption) (*pb.TransferFundsByManagerResponse, error)
-	getFundPortfolioFn        func(context.Context, *pb.GetFundPortfolioRequest, ...grpc.CallOption) (*pb.GetFundPortfolioResponse, error)
+	pingFn                      func(context.Context, *pb.PingRequest, ...grpc.CallOption) (*pb.PingResponse, error)
+	createFundFn                func(context.Context, *pb.CreateFundRequest, ...grpc.CallOption) (*pb.FundResponse, error)
+	listFundsFn                 func(context.Context, *pb.ListFundsRequest, ...grpc.CallOption) (*pb.ListFundsResponse, error)
+	getFundFn                   func(context.Context, *pb.GetFundRequest, ...grpc.CallOption) (*pb.FundResponse, error)
+	updateFundFn                func(context.Context, *pb.UpdateFundRequest, ...grpc.CallOption) (*pb.FundResponse, error)
+	deleteFundFn                func(context.Context, *pb.DeleteFundRequest, ...grpc.CallOption) (*pb.DeleteFundResponse, error)
+	investFundFn                func(context.Context, *pb.InvestFundRequest, ...grpc.CallOption) (*pb.FundResponse, error)
+	withdrawFundFn              func(context.Context, *pb.WithdrawFundRequest, ...grpc.CallOption) (*pb.WithdrawFundResponse, error)
+	checkPendingWithdrawalsFn   func(context.Context, *pb.CheckPendingWithdrawalsRequest, ...grpc.CallOption) (*pb.CheckPendingWithdrawalsResponse, error)
+	getBankPositionsFn          func(context.Context, *pb.GetBankPositionsRequest, ...grpc.CallOption) (*pb.GetBankPositionsResponse, error)
+	validateFundAccountFn       func(context.Context, *pb.ValidateFundAccountRequest, ...grpc.CallOption) (*pb.ValidateFundAccountResponse, error)
+	updateFundHoldingFn         func(context.Context, *pb.UpdateFundHoldingRequest, ...grpc.CallOption) (*pb.UpdateFundHoldingResponse, error)
+	getMyPositionsFn            func(context.Context, *pb.GetMyPositionsRequest, ...grpc.CallOption) (*pb.GetMyPositionsResponse, error)
+	transferFundsByManagerFn    func(context.Context, *pb.TransferFundsByManagerRequest, ...grpc.CallOption) (*pb.TransferFundsByManagerResponse, error)
+	getFundPortfolioFn          func(context.Context, *pb.GetFundPortfolioRequest, ...grpc.CallOption) (*pb.GetFundPortfolioResponse, error)
+	getFundPerformanceHistoryFn func(context.Context, *pb.GetFundPerformanceRequest, ...grpc.CallOption) (*pb.GetFundPerformanceResponse, error)
 }
 
 func (s *stubFundClient) Ping(ctx context.Context, in *pb.PingRequest, opts ...grpc.CallOption) (*pb.PingResponse, error) {
@@ -139,6 +140,12 @@ func (s *stubFundClient) GetFundPortfolio(ctx context.Context, in *pb.GetFundPor
 		return s.getFundPortfolioFn(ctx, in, opts...)
 	}
 	return &pb.GetFundPortfolioResponse{}, nil
+}
+func (s *stubFundClient) GetFundPerformanceHistory(ctx context.Context, in *pb.GetFundPerformanceRequest, opts ...grpc.CallOption) (*pb.GetFundPerformanceResponse, error) {
+	if s.getFundPerformanceHistoryFn != nil {
+		return s.getFundPerformanceHistoryFn(ctx, in, opts...)
+	}
+	return &pb.GetFundPerformanceResponse{}, nil
 }
 
 // sampleFund returns a sample FundResponse.
@@ -762,5 +769,66 @@ func TestWithdrawFund_WithdrawAll_SendsZeroAmount(t *testing.T) {
 	}
 	if capturedAmount != 0 {
 		t.Fatalf("expected amount=0 for withdrawAll, got %v", capturedAmount)
+	}
+}
+
+// ── GetFundPerformanceHistory ──────────────────────────────────────────────────
+
+func TestGetFundPerformanceHistory_Happy(t *testing.T) {
+	svc := &stubFundClient{
+		getFundPerformanceHistoryFn: func(_ context.Context, _ *pb.GetFundPerformanceRequest, _ ...grpc.CallOption) (*pb.GetFundPerformanceResponse, error) {
+			return &pb.GetFundPerformanceResponse{
+				Records: []*pb.PerformanceRecord{
+					{Date: "2025-01-01", FundValue: 100000.0, Profit: 5000.0},
+					{Date: "2025-01-02", FundValue: 102000.0, Profit: 7000.0},
+				},
+			}, nil
+		},
+	}
+	w := serveHandlerFull(GetFundPerformanceHistory(svc), "GET", "/investment/funds/:id/performance", "/investment/funds/1/performance?from=2025-01-01&to=2025-01-02", "", makeClientToken())
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d: %s", w.Code, w.Body.String())
+	}
+	var result []map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(result) != 2 {
+		t.Fatalf("expected 2 records, got %d", len(result))
+	}
+	if result[0]["date"] != "2025-01-01" {
+		t.Errorf("expected date 2025-01-01, got %v", result[0]["date"])
+	}
+	if result[0]["fundValue"].(float64) != 100000.0 {
+		t.Errorf("unexpected fundValue: %v", result[0]["fundValue"])
+	}
+	if result[0]["profit"].(float64) != 5000.0 {
+		t.Errorf("unexpected profit: %v", result[0]["profit"])
+	}
+}
+
+func TestGetFundPerformanceHistory_Empty(t *testing.T) {
+	svc := &stubFundClient{
+		getFundPerformanceHistoryFn: func(_ context.Context, _ *pb.GetFundPerformanceRequest, _ ...grpc.CallOption) (*pb.GetFundPerformanceResponse, error) {
+			return &pb.GetFundPerformanceResponse{Records: []*pb.PerformanceRecord{}}, nil
+		},
+	}
+	w := serveHandlerFull(GetFundPerformanceHistory(svc), "GET", "/investment/funds/:id/performance", "/investment/funds/1/performance", "", makeClientToken())
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d: %s", w.Code, w.Body.String())
+	}
+	var result []map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(result) != 0 {
+		t.Errorf("expected empty slice, got %d items", len(result))
+	}
+}
+
+func TestGetFundPerformanceHistory_BadId(t *testing.T) {
+	w := serveHandlerFull(GetFundPerformanceHistory(&stubFundClient{}), "GET", "/investment/funds/:id/performance", "/investment/funds/abc/performance", "", makeClientToken())
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 got %d", w.Code)
 	}
 }

--- a/services/api-gateway/main.go
+++ b/services/api-gateway/main.go
@@ -258,6 +258,7 @@ func main() {
 	r.POST("/investment/funds/:id/securities/buy", middleware.RequireRole("SUPERVISOR"), handlers.BuyFundSecurities(fundClient, securitiesClient, orderClient))
 	r.POST("/investment/funds/:id/securities/sell", middleware.RequireRole("SUPERVISOR"), handlers.SellFundSecurities(fundClient, securitiesClient, orderClient))
 	r.GET("/investment/funds/:id/securities", middleware.RequireRole("SUPERVISOR"), handlers.GetFundSecurities(fundClient, securitiesClient))
+	r.GET("/investment/funds/:id/performance", middleware.RequireRole("CLIENT", "AGENT", "SUPERVISOR"), handlers.GetFundPerformanceHistory(fundClient))
 
 	r.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 	if err := r.Run(":8083"); err != nil {

--- a/services/fund-service/db/schema.sql
+++ b/services/fund-service/db/schema.sql
@@ -41,3 +41,12 @@ CREATE TABLE IF NOT EXISTS client_fund_transactions (
     destination_account_id BIGINT,
     timestamp              TIMESTAMP     NOT NULL DEFAULT NOW()
 );
+
+CREATE TABLE IF NOT EXISTS fund_performance_history (
+    id         BIGSERIAL PRIMARY KEY,
+    fund_id    BIGINT        NOT NULL REFERENCES investment_funds(id),
+    date       DATE          NOT NULL,
+    fund_value DECIMAL(18,4) NOT NULL,
+    profit     DECIMAL(18,4) NOT NULL,
+    UNIQUE(fund_id, date)
+);

--- a/services/fund-service/handlers/grpc_server.go
+++ b/services/fund-service/handlers/grpc_server.go
@@ -823,3 +823,30 @@ func (s *FundServer) GetFundPortfolio(ctx context.Context, req *pb.GetFundPortfo
 	}
 	return &pb.GetFundPortfolioResponse{Positions: positions}, nil
 }
+
+func (s *FundServer) GetFundPerformanceHistory(ctx context.Context, req *pb.GetFundPerformanceRequest) (*pb.GetFundPerformanceResponse, error) {
+	rows, err := s.DB.QueryContext(ctx,
+		`SELECT TO_CHAR(date, 'YYYY-MM-DD'), fund_value, profit
+		 FROM fund_performance_history
+		 WHERE fund_id = $1 AND date >= $2 AND date <= $3
+		 ORDER BY date ASC`,
+		req.FundId, req.From, req.To,
+	)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "query performance history: %v", err)
+	}
+	defer rows.Close()
+
+	var records []*pb.PerformanceRecord
+	for rows.Next() {
+		var r pb.PerformanceRecord
+		if err := rows.Scan(&r.Date, &r.FundValue, &r.Profit); err != nil {
+			return nil, status.Errorf(codes.Internal, "scan performance record: %v", err)
+		}
+		records = append(records, &r)
+	}
+	if records == nil {
+		records = []*pb.PerformanceRecord{}
+	}
+	return &pb.GetFundPerformanceResponse{Records: records}, nil
+}

--- a/services/fund-service/handlers/grpc_server_test.go
+++ b/services/fund-service/handlers/grpc_server_test.go
@@ -1022,3 +1022,55 @@ func TestCheckPendingWithdrawals_StillInsufficient(t *testing.T) {
 	assert.Equal(t, int64(0), resp.Completed)
 	require.NoError(t, fundMock.ExpectationsWereMet())
 }
+
+// ── GetFundPerformanceHistory ─────────────────────────────────────────────────
+
+func TestGetFundPerformanceHistory_Happy(t *testing.T) {
+	s, fundMock, _, _ := newFundServer(t, &mockAccountClient{})
+
+	fundMock.ExpectQuery(`SELECT TO_CHAR\(date, 'YYYY-MM-DD'\), fund_value, profit`).
+		WithArgs(int64(1), "2025-01-01", "2025-01-31").
+		WillReturnRows(sqlmock.NewRows([]string{"date", "fund_value", "profit"}).
+			AddRow("2025-01-01", 100000.0, 5000.0).
+			AddRow("2025-01-15", 102000.0, 7000.0))
+
+	resp, err := s.GetFundPerformanceHistory(context.Background(), &pb.GetFundPerformanceRequest{
+		FundId: 1, From: "2025-01-01", To: "2025-01-31",
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Records, 2)
+	assert.Equal(t, "2025-01-01", resp.Records[0].Date)
+	assert.InDelta(t, 100000.0, resp.Records[0].FundValue, 0.01)
+	assert.InDelta(t, 5000.0, resp.Records[0].Profit, 0.01)
+	assert.Equal(t, "2025-01-15", resp.Records[1].Date)
+	require.NoError(t, fundMock.ExpectationsWereMet())
+}
+
+func TestGetFundPerformanceHistory_Empty(t *testing.T) {
+	s, fundMock, _, _ := newFundServer(t, &mockAccountClient{})
+
+	fundMock.ExpectQuery(`SELECT TO_CHAR\(date, 'YYYY-MM-DD'\), fund_value, profit`).
+		WithArgs(int64(1), "2025-01-01", "2025-01-31").
+		WillReturnRows(sqlmock.NewRows([]string{"date", "fund_value", "profit"}))
+
+	resp, err := s.GetFundPerformanceHistory(context.Background(), &pb.GetFundPerformanceRequest{
+		FundId: 1, From: "2025-01-01", To: "2025-01-31",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, resp.Records)
+	require.NoError(t, fundMock.ExpectationsWereMet())
+}
+
+func TestGetFundPerformanceHistory_DBError(t *testing.T) {
+	s, fundMock, _, _ := newFundServer(t, &mockAccountClient{})
+
+	fundMock.ExpectQuery(`SELECT TO_CHAR\(date, 'YYYY-MM-DD'\), fund_value, profit`).
+		WithArgs(int64(1), "2025-01-01", "2025-01-31").
+		WillReturnError(fmt.Errorf("db down"))
+
+	_, err := s.GetFundPerformanceHistory(context.Background(), &pb.GetFundPerformanceRequest{
+		FundId: 1, From: "2025-01-01", To: "2025-01-31",
+	})
+	require.Error(t, err)
+	require.NoError(t, fundMock.ExpectationsWereMet())
+}

--- a/services/fund-service/main.go
+++ b/services/fund-service/main.go
@@ -7,6 +7,7 @@ import (
 
 	funddb "github.com/RAF-SI-2025/EXBanka-4-Backend/services/fund-service/db"
 	"github.com/RAF-SI-2025/EXBanka-4-Backend/services/fund-service/handlers"
+	"github.com/RAF-SI-2025/EXBanka-4-Backend/services/fund-service/scheduler"
 	pb_account "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/account"
 	pb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/fund"
 	pb_order "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/order"
@@ -62,6 +63,9 @@ func main() {
 		AccountClient: accountClient,
 		OrderClient:   orderClient,
 	})
+
+	sched := &scheduler.PerformanceScheduler{DB: fundDB}
+	sched.Start()
 
 	log.Printf("fund-service gRPC server listening on %s", grpcPort)
 	if err := srv.Serve(lis); err != nil {

--- a/services/fund-service/scheduler/scheduler.go
+++ b/services/fund-service/scheduler/scheduler.go
@@ -1,0 +1,68 @@
+package scheduler
+
+import (
+	"context"
+	"database/sql"
+	"log"
+	"time"
+)
+
+type PerformanceScheduler struct {
+	DB *sql.DB
+}
+
+func (s *PerformanceScheduler) Start() {
+	go s.loop()
+}
+
+func (s *PerformanceScheduler) loop() {
+	for {
+		now := time.Now()
+		next := time.Date(now.Year(), now.Month(), now.Day(), 18, 0, 0, 0, now.Location())
+		if !now.Before(next) {
+			next = next.Add(24 * time.Hour)
+		}
+		time.Sleep(time.Until(next))
+		s.snapshotAll(context.Background())
+	}
+}
+
+func (s *PerformanceScheduler) snapshotAll(ctx context.Context) {
+	rows, err := s.DB.QueryContext(ctx, `SELECT id FROM investment_funds WHERE active = true`)
+	if err != nil {
+		log.Printf("performance-scheduler: list funds error: %v", err)
+		return
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var fundID int64
+		if err := rows.Scan(&fundID); err != nil {
+			continue
+		}
+
+		var liquidAssets float64
+		if err := s.DB.QueryRowContext(ctx,
+			`SELECT liquid_assets FROM investment_funds WHERE id = $1`, fundID,
+		).Scan(&liquidAssets); err != nil {
+			log.Printf("performance-scheduler: fetch liquid_assets for fund %d: %v", fundID, err)
+			continue
+		}
+
+		var totalInvested float64
+		_ = s.DB.QueryRowContext(ctx,
+			`SELECT COALESCE(SUM(total_invested_amount), 0) FROM client_fund_positions WHERE fund_id = $1`, fundID,
+		).Scan(&totalInvested)
+
+		profit := liquidAssets - totalInvested
+
+		if _, err := s.DB.ExecContext(ctx,
+			`INSERT INTO fund_performance_history (fund_id, date, fund_value, profit)
+			 VALUES ($1, CURRENT_DATE, $2, $3)
+			 ON CONFLICT (fund_id, date) DO UPDATE SET fund_value = $2, profit = $3`,
+			fundID, liquidAssets, profit,
+		); err != nil {
+			log.Printf("performance-scheduler: upsert fund %d: %v", fundID, err)
+		}
+	}
+}

--- a/shared/pb/fund/fund.pb.go
+++ b/shared/pb/fund/fund.pb.go
@@ -1645,6 +1645,170 @@ func (x *GetFundPortfolioResponse) GetPositions() []*FundPortfolioPosition {
 	return nil
 }
 
+type PerformanceRecord struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Date          string                 `protobuf:"bytes,1,opt,name=date,proto3" json:"date,omitempty"`
+	FundValue     float64                `protobuf:"fixed64,2,opt,name=fund_value,json=fundValue,proto3" json:"fund_value,omitempty"`
+	Profit        float64                `protobuf:"fixed64,3,opt,name=profit,proto3" json:"profit,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PerformanceRecord) Reset() {
+	*x = PerformanceRecord{}
+	mi := &file_fund_proto_msgTypes[28]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PerformanceRecord) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PerformanceRecord) ProtoMessage() {}
+
+func (x *PerformanceRecord) ProtoReflect() protoreflect.Message {
+	mi := &file_fund_proto_msgTypes[28]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PerformanceRecord.ProtoReflect.Descriptor instead.
+func (*PerformanceRecord) Descriptor() ([]byte, []int) {
+	return file_fund_proto_rawDescGZIP(), []int{28}
+}
+
+func (x *PerformanceRecord) GetDate() string {
+	if x != nil {
+		return x.Date
+	}
+	return ""
+}
+
+func (x *PerformanceRecord) GetFundValue() float64 {
+	if x != nil {
+		return x.FundValue
+	}
+	return 0
+}
+
+func (x *PerformanceRecord) GetProfit() float64 {
+	if x != nil {
+		return x.Profit
+	}
+	return 0
+}
+
+type GetFundPerformanceRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	FundId        int64                  `protobuf:"varint,1,opt,name=fund_id,json=fundId,proto3" json:"fund_id,omitempty"`
+	From          string                 `protobuf:"bytes,2,opt,name=from,proto3" json:"from,omitempty"` // "YYYY-MM-DD"
+	To            string                 `protobuf:"bytes,3,opt,name=to,proto3" json:"to,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetFundPerformanceRequest) Reset() {
+	*x = GetFundPerformanceRequest{}
+	mi := &file_fund_proto_msgTypes[29]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetFundPerformanceRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetFundPerformanceRequest) ProtoMessage() {}
+
+func (x *GetFundPerformanceRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_fund_proto_msgTypes[29]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetFundPerformanceRequest.ProtoReflect.Descriptor instead.
+func (*GetFundPerformanceRequest) Descriptor() ([]byte, []int) {
+	return file_fund_proto_rawDescGZIP(), []int{29}
+}
+
+func (x *GetFundPerformanceRequest) GetFundId() int64 {
+	if x != nil {
+		return x.FundId
+	}
+	return 0
+}
+
+func (x *GetFundPerformanceRequest) GetFrom() string {
+	if x != nil {
+		return x.From
+	}
+	return ""
+}
+
+func (x *GetFundPerformanceRequest) GetTo() string {
+	if x != nil {
+		return x.To
+	}
+	return ""
+}
+
+type GetFundPerformanceResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Records       []*PerformanceRecord   `protobuf:"bytes,1,rep,name=records,proto3" json:"records,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetFundPerformanceResponse) Reset() {
+	*x = GetFundPerformanceResponse{}
+	mi := &file_fund_proto_msgTypes[30]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetFundPerformanceResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetFundPerformanceResponse) ProtoMessage() {}
+
+func (x *GetFundPerformanceResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_fund_proto_msgTypes[30]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetFundPerformanceResponse.ProtoReflect.Descriptor instead.
+func (*GetFundPerformanceResponse) Descriptor() ([]byte, []int) {
+	return file_fund_proto_rawDescGZIP(), []int{30}
+}
+
+func (x *GetFundPerformanceResponse) GetRecords() []*PerformanceRecord {
+	if x != nil {
+		return x.Records
+	}
+	return nil
+}
+
 type UpdateFundHoldingRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	FundId        int64                  `protobuf:"varint,1,opt,name=fund_id,json=fundId,proto3" json:"fund_id,omitempty"`
@@ -1658,7 +1822,7 @@ type UpdateFundHoldingRequest struct {
 
 func (x *UpdateFundHoldingRequest) Reset() {
 	*x = UpdateFundHoldingRequest{}
-	mi := &file_fund_proto_msgTypes[28]
+	mi := &file_fund_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1670,7 +1834,7 @@ func (x *UpdateFundHoldingRequest) String() string {
 func (*UpdateFundHoldingRequest) ProtoMessage() {}
 
 func (x *UpdateFundHoldingRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fund_proto_msgTypes[28]
+	mi := &file_fund_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1683,7 +1847,7 @@ func (x *UpdateFundHoldingRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateFundHoldingRequest.ProtoReflect.Descriptor instead.
 func (*UpdateFundHoldingRequest) Descriptor() ([]byte, []int) {
-	return file_fund_proto_rawDescGZIP(), []int{28}
+	return file_fund_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *UpdateFundHoldingRequest) GetFundId() int64 {
@@ -1729,7 +1893,7 @@ type UpdateFundHoldingResponse struct {
 
 func (x *UpdateFundHoldingResponse) Reset() {
 	*x = UpdateFundHoldingResponse{}
-	mi := &file_fund_proto_msgTypes[29]
+	mi := &file_fund_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1741,7 +1905,7 @@ func (x *UpdateFundHoldingResponse) String() string {
 func (*UpdateFundHoldingResponse) ProtoMessage() {}
 
 func (x *UpdateFundHoldingResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fund_proto_msgTypes[29]
+	mi := &file_fund_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1754,7 +1918,7 @@ func (x *UpdateFundHoldingResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateFundHoldingResponse.ProtoReflect.Descriptor instead.
 func (*UpdateFundHoldingResponse) Descriptor() ([]byte, []int) {
-	return file_fund_proto_rawDescGZIP(), []int{29}
+	return file_fund_proto_rawDescGZIP(), []int{32}
 }
 
 var File_fund_proto protoreflect.FileDescriptor
@@ -1882,7 +2046,18 @@ const file_fund_proto_rawDesc = "" +
 	"\x17GetFundPortfolioRequest\x12\x17\n" +
 	"\afund_id\x18\x01 \x01(\x03R\x06fundId\"U\n" +
 	"\x18GetFundPortfolioResponse\x129\n" +
-	"\tpositions\x18\x01 \x03(\v2\x1b.fund.FundPortfolioPositionR\tpositions\"\xa2\x01\n" +
+	"\tpositions\x18\x01 \x03(\v2\x1b.fund.FundPortfolioPositionR\tpositions\"^\n" +
+	"\x11PerformanceRecord\x12\x12\n" +
+	"\x04date\x18\x01 \x01(\tR\x04date\x12\x1d\n" +
+	"\n" +
+	"fund_value\x18\x02 \x01(\x01R\tfundValue\x12\x16\n" +
+	"\x06profit\x18\x03 \x01(\x01R\x06profit\"X\n" +
+	"\x19GetFundPerformanceRequest\x12\x17\n" +
+	"\afund_id\x18\x01 \x01(\x03R\x06fundId\x12\x12\n" +
+	"\x04from\x18\x02 \x01(\tR\x04from\x12\x0e\n" +
+	"\x02to\x18\x03 \x01(\tR\x02to\"O\n" +
+	"\x1aGetFundPerformanceResponse\x121\n" +
+	"\arecords\x18\x01 \x03(\v2\x17.fund.PerformanceRecordR\arecords\"\xa2\x01\n" +
 	"\x18UpdateFundHoldingRequest\x12\x17\n" +
 	"\afund_id\x18\x01 \x01(\x03R\x06fundId\x12\x1d\n" +
 	"\n" +
@@ -1890,7 +2065,7 @@ const file_fund_proto_rawDesc = "" +
 	"\bquantity\x18\x03 \x01(\x03R\bquantity\x12\x14\n" +
 	"\x05price\x18\x04 \x01(\x01R\x05price\x12\x1c\n" +
 	"\tdirection\x18\x05 \x01(\tR\tdirection\"\x1b\n" +
-	"\x19UpdateFundHoldingResponse2\xda\b\n" +
+	"\x19UpdateFundHoldingResponse2\xba\t\n" +
 	"\vFundService\x12-\n" +
 	"\x04Ping\x12\x11.fund.PingRequest\x1a\x12.fund.PingResponse\x129\n" +
 	"\n" +
@@ -1910,7 +2085,8 @@ const file_fund_proto_rawDesc = "" +
 	"\x16TransferFundsByManager\x12#.fund.TransferFundsByManagerRequest\x1a$.fund.TransferFundsByManagerResponse\x12Z\n" +
 	"\x13ValidateFundAccount\x12 .fund.ValidateFundAccountRequest\x1a!.fund.ValidateFundAccountResponse\x12T\n" +
 	"\x11UpdateFundHolding\x12\x1e.fund.UpdateFundHoldingRequest\x1a\x1f.fund.UpdateFundHoldingResponse\x12Q\n" +
-	"\x10GetFundPortfolio\x12\x1d.fund.GetFundPortfolioRequest\x1a\x1e.fund.GetFundPortfolioResponseB9Z7github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/fundb\x06proto3"
+	"\x10GetFundPortfolio\x12\x1d.fund.GetFundPortfolioRequest\x1a\x1e.fund.GetFundPortfolioResponse\x12^\n" +
+	"\x19GetFundPerformanceHistory\x12\x1f.fund.GetFundPerformanceRequest\x1a .fund.GetFundPerformanceResponseB9Z7github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/fundb\x06proto3"
 
 var (
 	file_fund_proto_rawDescOnce sync.Once
@@ -1924,7 +2100,7 @@ func file_fund_proto_rawDescGZIP() []byte {
 	return file_fund_proto_rawDescData
 }
 
-var file_fund_proto_msgTypes = make([]protoimpl.MessageInfo, 30)
+var file_fund_proto_msgTypes = make([]protoimpl.MessageInfo, 33)
 var file_fund_proto_goTypes = []any{
 	(*PingRequest)(nil),                     // 0: fund.PingRequest
 	(*PingResponse)(nil),                    // 1: fund.PingResponse
@@ -1954,8 +2130,11 @@ var file_fund_proto_goTypes = []any{
 	(*FundPortfolioPosition)(nil),           // 25: fund.FundPortfolioPosition
 	(*GetFundPortfolioRequest)(nil),         // 26: fund.GetFundPortfolioRequest
 	(*GetFundPortfolioResponse)(nil),        // 27: fund.GetFundPortfolioResponse
-	(*UpdateFundHoldingRequest)(nil),        // 28: fund.UpdateFundHoldingRequest
-	(*UpdateFundHoldingResponse)(nil),       // 29: fund.UpdateFundHoldingResponse
+	(*PerformanceRecord)(nil),               // 28: fund.PerformanceRecord
+	(*GetFundPerformanceRequest)(nil),       // 29: fund.GetFundPerformanceRequest
+	(*GetFundPerformanceResponse)(nil),      // 30: fund.GetFundPerformanceResponse
+	(*UpdateFundHoldingRequest)(nil),        // 31: fund.UpdateFundHoldingRequest
+	(*UpdateFundHoldingResponse)(nil),       // 32: fund.UpdateFundHoldingResponse
 }
 var file_fund_proto_depIdxs = []int32{
 	8,  // 0: fund.ListFundsResponse.funds:type_name -> fund.FundResponse
@@ -1963,41 +2142,44 @@ var file_fund_proto_depIdxs = []int32{
 	15, // 2: fund.GetBankPositionsResponse.positions:type_name -> fund.BankFundPosition
 	18, // 3: fund.GetMyPositionsResponse.positions:type_name -> fund.ClientFundPosition
 	25, // 4: fund.GetFundPortfolioResponse.positions:type_name -> fund.FundPortfolioPosition
-	0,  // 5: fund.FundService.Ping:input_type -> fund.PingRequest
-	2,  // 6: fund.FundService.CreateFund:input_type -> fund.CreateFundRequest
-	6,  // 7: fund.FundService.ListFunds:input_type -> fund.ListFundsRequest
-	7,  // 8: fund.FundService.GetFund:input_type -> fund.GetFundRequest
-	3,  // 9: fund.FundService.UpdateFund:input_type -> fund.UpdateFundRequest
-	4,  // 10: fund.FundService.DeleteFund:input_type -> fund.DeleteFundRequest
-	10, // 11: fund.FundService.InvestFund:input_type -> fund.InvestFundRequest
-	11, // 12: fund.FundService.WithdrawFund:input_type -> fund.WithdrawFundRequest
-	13, // 13: fund.FundService.CheckPendingWithdrawals:input_type -> fund.CheckPendingWithdrawalsRequest
-	16, // 14: fund.FundService.GetBankPositions:input_type -> fund.GetBankPositionsRequest
-	19, // 15: fund.FundService.GetMyPositions:input_type -> fund.GetMyPositionsRequest
-	21, // 16: fund.FundService.TransferFundsByManager:input_type -> fund.TransferFundsByManagerRequest
-	23, // 17: fund.FundService.ValidateFundAccount:input_type -> fund.ValidateFundAccountRequest
-	28, // 18: fund.FundService.UpdateFundHolding:input_type -> fund.UpdateFundHoldingRequest
-	26, // 19: fund.FundService.GetFundPortfolio:input_type -> fund.GetFundPortfolioRequest
-	1,  // 20: fund.FundService.Ping:output_type -> fund.PingResponse
-	8,  // 21: fund.FundService.CreateFund:output_type -> fund.FundResponse
-	9,  // 22: fund.FundService.ListFunds:output_type -> fund.ListFundsResponse
-	8,  // 23: fund.FundService.GetFund:output_type -> fund.FundResponse
-	8,  // 24: fund.FundService.UpdateFund:output_type -> fund.FundResponse
-	5,  // 25: fund.FundService.DeleteFund:output_type -> fund.DeleteFundResponse
-	8,  // 26: fund.FundService.InvestFund:output_type -> fund.FundResponse
-	12, // 27: fund.FundService.WithdrawFund:output_type -> fund.WithdrawFundResponse
-	14, // 28: fund.FundService.CheckPendingWithdrawals:output_type -> fund.CheckPendingWithdrawalsResponse
-	17, // 29: fund.FundService.GetBankPositions:output_type -> fund.GetBankPositionsResponse
-	20, // 30: fund.FundService.GetMyPositions:output_type -> fund.GetMyPositionsResponse
-	22, // 31: fund.FundService.TransferFundsByManager:output_type -> fund.TransferFundsByManagerResponse
-	24, // 32: fund.FundService.ValidateFundAccount:output_type -> fund.ValidateFundAccountResponse
-	29, // 33: fund.FundService.UpdateFundHolding:output_type -> fund.UpdateFundHoldingResponse
-	27, // 34: fund.FundService.GetFundPortfolio:output_type -> fund.GetFundPortfolioResponse
-	20, // [20:35] is the sub-list for method output_type
-	5,  // [5:20] is the sub-list for method input_type
-	5,  // [5:5] is the sub-list for extension type_name
-	5,  // [5:5] is the sub-list for extension extendee
-	0,  // [0:5] is the sub-list for field type_name
+	28, // 5: fund.GetFundPerformanceResponse.records:type_name -> fund.PerformanceRecord
+	0,  // 6: fund.FundService.Ping:input_type -> fund.PingRequest
+	2,  // 7: fund.FundService.CreateFund:input_type -> fund.CreateFundRequest
+	6,  // 8: fund.FundService.ListFunds:input_type -> fund.ListFundsRequest
+	7,  // 9: fund.FundService.GetFund:input_type -> fund.GetFundRequest
+	3,  // 10: fund.FundService.UpdateFund:input_type -> fund.UpdateFundRequest
+	4,  // 11: fund.FundService.DeleteFund:input_type -> fund.DeleteFundRequest
+	10, // 12: fund.FundService.InvestFund:input_type -> fund.InvestFundRequest
+	11, // 13: fund.FundService.WithdrawFund:input_type -> fund.WithdrawFundRequest
+	13, // 14: fund.FundService.CheckPendingWithdrawals:input_type -> fund.CheckPendingWithdrawalsRequest
+	16, // 15: fund.FundService.GetBankPositions:input_type -> fund.GetBankPositionsRequest
+	19, // 16: fund.FundService.GetMyPositions:input_type -> fund.GetMyPositionsRequest
+	21, // 17: fund.FundService.TransferFundsByManager:input_type -> fund.TransferFundsByManagerRequest
+	23, // 18: fund.FundService.ValidateFundAccount:input_type -> fund.ValidateFundAccountRequest
+	31, // 19: fund.FundService.UpdateFundHolding:input_type -> fund.UpdateFundHoldingRequest
+	26, // 20: fund.FundService.GetFundPortfolio:input_type -> fund.GetFundPortfolioRequest
+	29, // 21: fund.FundService.GetFundPerformanceHistory:input_type -> fund.GetFundPerformanceRequest
+	1,  // 22: fund.FundService.Ping:output_type -> fund.PingResponse
+	8,  // 23: fund.FundService.CreateFund:output_type -> fund.FundResponse
+	9,  // 24: fund.FundService.ListFunds:output_type -> fund.ListFundsResponse
+	8,  // 25: fund.FundService.GetFund:output_type -> fund.FundResponse
+	8,  // 26: fund.FundService.UpdateFund:output_type -> fund.FundResponse
+	5,  // 27: fund.FundService.DeleteFund:output_type -> fund.DeleteFundResponse
+	8,  // 28: fund.FundService.InvestFund:output_type -> fund.FundResponse
+	12, // 29: fund.FundService.WithdrawFund:output_type -> fund.WithdrawFundResponse
+	14, // 30: fund.FundService.CheckPendingWithdrawals:output_type -> fund.CheckPendingWithdrawalsResponse
+	17, // 31: fund.FundService.GetBankPositions:output_type -> fund.GetBankPositionsResponse
+	20, // 32: fund.FundService.GetMyPositions:output_type -> fund.GetMyPositionsResponse
+	22, // 33: fund.FundService.TransferFundsByManager:output_type -> fund.TransferFundsByManagerResponse
+	24, // 34: fund.FundService.ValidateFundAccount:output_type -> fund.ValidateFundAccountResponse
+	32, // 35: fund.FundService.UpdateFundHolding:output_type -> fund.UpdateFundHoldingResponse
+	27, // 36: fund.FundService.GetFundPortfolio:output_type -> fund.GetFundPortfolioResponse
+	30, // 37: fund.FundService.GetFundPerformanceHistory:output_type -> fund.GetFundPerformanceResponse
+	22, // [22:38] is the sub-list for method output_type
+	6,  // [6:22] is the sub-list for method input_type
+	6,  // [6:6] is the sub-list for extension type_name
+	6,  // [6:6] is the sub-list for extension extendee
+	0,  // [0:6] is the sub-list for field type_name
 }
 
 func init() { file_fund_proto_init() }
@@ -2011,7 +2193,7 @@ func file_fund_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_fund_proto_rawDesc), len(file_fund_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   30,
+			NumMessages:   33,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/shared/pb/fund/fund_grpc.pb.go
+++ b/shared/pb/fund/fund_grpc.pb.go
@@ -19,21 +19,22 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	FundService_Ping_FullMethodName                    = "/fund.FundService/Ping"
-	FundService_CreateFund_FullMethodName              = "/fund.FundService/CreateFund"
-	FundService_ListFunds_FullMethodName               = "/fund.FundService/ListFunds"
-	FundService_GetFund_FullMethodName                 = "/fund.FundService/GetFund"
-	FundService_UpdateFund_FullMethodName              = "/fund.FundService/UpdateFund"
-	FundService_DeleteFund_FullMethodName              = "/fund.FundService/DeleteFund"
-	FundService_InvestFund_FullMethodName              = "/fund.FundService/InvestFund"
-	FundService_WithdrawFund_FullMethodName            = "/fund.FundService/WithdrawFund"
-	FundService_CheckPendingWithdrawals_FullMethodName = "/fund.FundService/CheckPendingWithdrawals"
-	FundService_GetBankPositions_FullMethodName        = "/fund.FundService/GetBankPositions"
-	FundService_GetMyPositions_FullMethodName          = "/fund.FundService/GetMyPositions"
-	FundService_TransferFundsByManager_FullMethodName  = "/fund.FundService/TransferFundsByManager"
-	FundService_ValidateFundAccount_FullMethodName     = "/fund.FundService/ValidateFundAccount"
-	FundService_UpdateFundHolding_FullMethodName       = "/fund.FundService/UpdateFundHolding"
-	FundService_GetFundPortfolio_FullMethodName        = "/fund.FundService/GetFundPortfolio"
+	FundService_Ping_FullMethodName                      = "/fund.FundService/Ping"
+	FundService_CreateFund_FullMethodName                = "/fund.FundService/CreateFund"
+	FundService_ListFunds_FullMethodName                 = "/fund.FundService/ListFunds"
+	FundService_GetFund_FullMethodName                   = "/fund.FundService/GetFund"
+	FundService_UpdateFund_FullMethodName                = "/fund.FundService/UpdateFund"
+	FundService_DeleteFund_FullMethodName                = "/fund.FundService/DeleteFund"
+	FundService_InvestFund_FullMethodName                = "/fund.FundService/InvestFund"
+	FundService_WithdrawFund_FullMethodName              = "/fund.FundService/WithdrawFund"
+	FundService_CheckPendingWithdrawals_FullMethodName   = "/fund.FundService/CheckPendingWithdrawals"
+	FundService_GetBankPositions_FullMethodName          = "/fund.FundService/GetBankPositions"
+	FundService_GetMyPositions_FullMethodName            = "/fund.FundService/GetMyPositions"
+	FundService_TransferFundsByManager_FullMethodName    = "/fund.FundService/TransferFundsByManager"
+	FundService_ValidateFundAccount_FullMethodName       = "/fund.FundService/ValidateFundAccount"
+	FundService_UpdateFundHolding_FullMethodName         = "/fund.FundService/UpdateFundHolding"
+	FundService_GetFundPortfolio_FullMethodName          = "/fund.FundService/GetFundPortfolio"
+	FundService_GetFundPerformanceHistory_FullMethodName = "/fund.FundService/GetFundPerformanceHistory"
 )
 
 // FundServiceClient is the client API for FundService service.
@@ -55,6 +56,7 @@ type FundServiceClient interface {
 	ValidateFundAccount(ctx context.Context, in *ValidateFundAccountRequest, opts ...grpc.CallOption) (*ValidateFundAccountResponse, error)
 	UpdateFundHolding(ctx context.Context, in *UpdateFundHoldingRequest, opts ...grpc.CallOption) (*UpdateFundHoldingResponse, error)
 	GetFundPortfolio(ctx context.Context, in *GetFundPortfolioRequest, opts ...grpc.CallOption) (*GetFundPortfolioResponse, error)
+	GetFundPerformanceHistory(ctx context.Context, in *GetFundPerformanceRequest, opts ...grpc.CallOption) (*GetFundPerformanceResponse, error)
 }
 
 type fundServiceClient struct {
@@ -215,6 +217,16 @@ func (c *fundServiceClient) GetFundPortfolio(ctx context.Context, in *GetFundPor
 	return out, nil
 }
 
+func (c *fundServiceClient) GetFundPerformanceHistory(ctx context.Context, in *GetFundPerformanceRequest, opts ...grpc.CallOption) (*GetFundPerformanceResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetFundPerformanceResponse)
+	err := c.cc.Invoke(ctx, FundService_GetFundPerformanceHistory_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // FundServiceServer is the server API for FundService service.
 // All implementations must embed UnimplementedFundServiceServer
 // for forward compatibility.
@@ -234,6 +246,7 @@ type FundServiceServer interface {
 	ValidateFundAccount(context.Context, *ValidateFundAccountRequest) (*ValidateFundAccountResponse, error)
 	UpdateFundHolding(context.Context, *UpdateFundHoldingRequest) (*UpdateFundHoldingResponse, error)
 	GetFundPortfolio(context.Context, *GetFundPortfolioRequest) (*GetFundPortfolioResponse, error)
+	GetFundPerformanceHistory(context.Context, *GetFundPerformanceRequest) (*GetFundPerformanceResponse, error)
 	mustEmbedUnimplementedFundServiceServer()
 }
 
@@ -288,6 +301,9 @@ func (UnimplementedFundServiceServer) UpdateFundHolding(context.Context, *Update
 }
 func (UnimplementedFundServiceServer) GetFundPortfolio(context.Context, *GetFundPortfolioRequest) (*GetFundPortfolioResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetFundPortfolio not implemented")
+}
+func (UnimplementedFundServiceServer) GetFundPerformanceHistory(context.Context, *GetFundPerformanceRequest) (*GetFundPerformanceResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetFundPerformanceHistory not implemented")
 }
 func (UnimplementedFundServiceServer) mustEmbedUnimplementedFundServiceServer() {}
 func (UnimplementedFundServiceServer) testEmbeddedByValue()                     {}
@@ -580,6 +596,24 @@ func _FundService_GetFundPortfolio_Handler(srv interface{}, ctx context.Context,
 	return interceptor(ctx, in, info, handler)
 }
 
+func _FundService_GetFundPerformanceHistory_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetFundPerformanceRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(FundServiceServer).GetFundPerformanceHistory(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: FundService_GetFundPerformanceHistory_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(FundServiceServer).GetFundPerformanceHistory(ctx, req.(*GetFundPerformanceRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // FundService_ServiceDesc is the grpc.ServiceDesc for FundService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -646,6 +680,10 @@ var FundService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetFundPortfolio",
 			Handler:    _FundService_GetFundPortfolio_Handler,
+		},
+		{
+			MethodName: "GetFundPerformanceHistory",
+			Handler:    _FundService_GetFundPerformanceHistory_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/shared/proto/fund.proto
+++ b/shared/proto/fund.proto
@@ -18,6 +18,7 @@ service FundService {
   rpc ValidateFundAccount(ValidateFundAccountRequest) returns (ValidateFundAccountResponse);
   rpc UpdateFundHolding(UpdateFundHoldingRequest) returns (UpdateFundHoldingResponse);
   rpc GetFundPortfolio(GetFundPortfolioRequest) returns (GetFundPortfolioResponse);
+  rpc GetFundPerformanceHistory(GetFundPerformanceRequest) returns (GetFundPerformanceResponse);
 }
 
 message PingRequest {}
@@ -168,6 +169,22 @@ message FundPortfolioPosition {
 
 message GetFundPortfolioRequest  { int64 fund_id = 1; }
 message GetFundPortfolioResponse { repeated FundPortfolioPosition positions = 1; }
+
+// ── GetFundPerformanceHistory ─────────────────────────────────────────────────
+
+message PerformanceRecord {
+  string date       = 1;
+  double fund_value = 2;
+  double profit     = 3;
+}
+message GetFundPerformanceRequest {
+  int64  fund_id = 1;
+  string from    = 2; // "YYYY-MM-DD"
+  string to      = 3;
+}
+message GetFundPerformanceResponse {
+  repeated PerformanceRecord records = 1;
+}
 
 // ── UpdateFundHolding ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Adds `fund_performance_history` table (`fund_id`, `date`, `fund_value`, `profit`) with UPSERT-safe unique constraint on `(fund_id, date)`
- Adds `PerformanceScheduler` goroutine in fund-service that fires daily at 18:00 and snapshots each active fund's value and profit
- Adds `GetFundPerformanceHistory` gRPC RPC and `GET /investment/funds/:id/performance?from=&to=` HTTP endpoint (CLIENT/AGENT/SUPERVISOR auth) returning `[{date, fundValue, profit}]`

## Test plan
- [ ] `go test ./services/fund-service/...` — all handler tests pass (including 3 new performance history tests)
- [ ] `go test ./services/api-gateway/handlers/...` — all tests pass (including 3 new HTTP handler tests)
- [ ] `go build ./services/fund-service/... ./services/api-gateway/...` — clean build
- [ ] Verify `GET /investment/funds/1/performance?from=2025-01-01&to=2025-12-31` returns `[]` before any snapshots, and returns records after 18:00 daily run

🤖 Generated with [Claude Code](https://claude.com/claude-code)