### PR TITLE
Sprint 8

### DIFF
--- a/services/api-gateway/handlers/otc.go
+++ b/services/api-gateway/handlers/otc.go
@@ -69,7 +69,7 @@ func CreateNegotiation(client pb.OtcServiceClient) gin.HandlerFunc {
 		callerType := middleware.GetCallerRoleFromToken(c)
 
 		var req struct {
-			SellerId       int64   `json:"sellerId"       binding:"required"`
+			SellerId       *int64  `json:"sellerId"       binding:"required"`
 			SellerType     string  `json:"sellerType"     binding:"required"`
 			Ticker         string  `json:"ticker"         binding:"required"`
 			Amount         int32   `json:"amount"         binding:"required"`
@@ -89,7 +89,7 @@ func CreateNegotiation(client pb.OtcServiceClient) gin.HandlerFunc {
 		resp, err := client.CreateNegotiation(ctx, &pb.CreateNegotiationRequest{
 			BuyerId:        callerID,
 			BuyerType:      callerType,
-			SellerId:       req.SellerId,
+			SellerId:       *req.SellerId,
 			SellerType:     req.SellerType,
 			Ticker:         req.Ticker,
 			Amount:         req.Amount,

--- a/services/otc-service/db/schema.sql
+++ b/services/otc-service/db/schema.sql
@@ -1,3 +1,21 @@
+CREATE TABLE IF NOT EXISTS otc_negotiations (
+    id               BIGSERIAL PRIMARY KEY,
+    ticker           VARCHAR(20)    NOT NULL,
+    seller_id        BIGINT         NOT NULL,
+    seller_type      VARCHAR(10)    NOT NULL DEFAULT 'CLIENT',
+    buyer_id         BIGINT         NOT NULL,
+    buyer_type       VARCHAR(10)    NOT NULL DEFAULT 'CLIENT',
+    amount           INT            NOT NULL,
+    price_per_stock  DECIMAL(18,4)  NOT NULL,
+    settlement_date  DATE           NOT NULL,
+    premium          DECIMAL(18,4)  NOT NULL,
+    currency         VARCHAR(10)    NOT NULL,
+    last_modified    TIMESTAMP      NOT NULL DEFAULT NOW(),
+    modified_by_id   BIGINT,
+    modified_by_type VARCHAR(10),
+    status           VARCHAR(20)    NOT NULL DEFAULT 'PENDING_SELLER'
+);
+
 CREATE TABLE IF NOT EXISTS otc_contracts (
     id               BIGSERIAL PRIMARY KEY,
     negotiation_id   BIGINT NOT NULL UNIQUE REFERENCES otc_negotiations(id),
@@ -22,22 +40,4 @@ CREATE TABLE IF NOT EXISTS otc_saga_log (
     status       VARCHAR(20) NOT NULL,
     timestamp    TIMESTAMP NOT NULL DEFAULT NOW(),
     error_msg    TEXT
-);
-
-CREATE TABLE IF NOT EXISTS otc_negotiations (
-    id               BIGSERIAL PRIMARY KEY,
-    ticker           VARCHAR(20)    NOT NULL,
-    seller_id        BIGINT         NOT NULL,
-    seller_type      VARCHAR(10)    NOT NULL DEFAULT 'CLIENT',
-    buyer_id         BIGINT         NOT NULL,
-    buyer_type       VARCHAR(10)    NOT NULL DEFAULT 'CLIENT',
-    amount           INT            NOT NULL,
-    price_per_stock  DECIMAL(18,4)  NOT NULL,
-    settlement_date  DATE           NOT NULL,
-    premium          DECIMAL(18,4)  NOT NULL,
-    currency         VARCHAR(10)    NOT NULL,
-    last_modified    TIMESTAMP      NOT NULL DEFAULT NOW(),
-    modified_by_id   BIGINT,
-    modified_by_type VARCHAR(10),
-    status           VARCHAR(20)    NOT NULL DEFAULT 'PENDING_SELLER'
 );


### PR DESCRIPTION
fix: use pointer for SellerId and move otc_negotiations table before otc_contracts in schema