### PR TITLE
fix: use valid 18-digit account numbers in seed data and seed daily e…

### DIFF
--- a/services/account-service/db/schema.sql
+++ b/services/account-service/db/schema.sql
@@ -76,11 +76,11 @@ ON CONFLICT (account_number) DO NOTHING;
 
 -- Test account for Tara Dunjic (client id=1) — used for OTC testing
 INSERT INTO accounts (account_number, account_name, owner_id, employee_id, currency_id, account_type, account_subtype, balance, available_balance, expiration_date)
-SELECT '265-0001-01', 'Tara Personal USD', 1, 1, 4, 'personal', 'checking', 500000, 500000, CURRENT_DATE + INTERVAL '5 years'
-WHERE NOT EXISTS (SELECT 1 FROM accounts WHERE account_number = '265-0001-01');
+SELECT '265000100000000101', 'Tara Personal USD', 1, 1, 4, 'personal', 'checking', 500000, 500000, CURRENT_DATE + INTERVAL '5 years'
+WHERE NOT EXISTS (SELECT 1 FROM accounts WHERE account_number = '265000100000000101');
 
 -- Test account for Marko Markovic (client id=2) — used for OTC testing
 -- currency_id=4 is USD; owner_id matches the insertion order of client seed data
 INSERT INTO accounts (account_number, account_name, owner_id, employee_id, currency_id, account_type, account_subtype, balance, available_balance, expiration_date)
-SELECT '265-0002-01', 'Marko Personal USD', 2, 1, 4, 'personal', 'checking', 500000, 500000, CURRENT_DATE + INTERVAL '5 years'
-WHERE NOT EXISTS (SELECT 1 FROM accounts WHERE account_number = '265-0002-01');
+SELECT '265000200000000201', 'Marko Personal USD', 2, 1, 4, 'personal', 'checking', 500000, 500000, CURRENT_DATE + INTERVAL '5 years'
+WHERE NOT EXISTS (SELECT 1 FROM accounts WHERE account_number = '265000200000000201');

--- a/services/exchange-service/db/schema.sql
+++ b/services/exchange-service/db/schema.sql
@@ -53,6 +53,19 @@ CREATE TABLE daily_exchange_rates (
     UNIQUE (currency_code, date)
 );
 
+-- Seed approximate rates for today so the order-service limit check works on a fresh DB.
+-- The exchange-service overwrites these with real API rates when it starts up.
+INSERT INTO daily_exchange_rates (currency_code, buying_rate, selling_rate, middle_rate, date)
+VALUES
+  ('EUR', 116.00, 117.00, 116.50, CURRENT_DATE),
+  ('CHF', 115.00, 116.00, 115.50, CURRENT_DATE),
+  ('USD', 107.50, 108.50, 108.00, CURRENT_DATE),
+  ('GBP', 135.00, 136.00, 135.50, CURRENT_DATE),
+  ('JPY',   0.72,   0.73,   0.725, CURRENT_DATE),
+  ('CAD',  79.00,  80.00,  79.50, CURRENT_DATE),
+  ('AUD',  69.00,  70.00,  69.50, CURRENT_DATE)
+ON CONFLICT (currency_code, date) DO NOTHING;
+
 -- Exchange transaction history (issue #76)
 CREATE TABLE exchange_transactions (
     id            BIGSERIAL PRIMARY KEY,

--- a/services/exchange-service/go.mod
+++ b/services/exchange-service/go.mod
@@ -5,18 +5,18 @@ go 1.26.1
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/RAF-SI-2025/EXBanka-4-Backend/shared v0.0.0-00010101000000-000000000000
+	github.com/alicebob/miniredis/v2 v2.37.0
 	github.com/lib/pq v1.11.2
+	github.com/redis/go-redis/v9 v9.19.0
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/grpc v1.79.3
 )
 
 require (
-	github.com/alicebob/miniredis/v2 v2.37.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/redis/go-redis/v9 v9.19.0 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.uber.org/atomic v1.11.0 // indirect

--- a/services/exchange-service/go.sum
+++ b/services/exchange-service/go.sum
@@ -2,6 +2,10 @@ github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7Oputl
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/alicebob/miniredis/v2 v2.37.0 h1:RheObYW32G1aiJIj81XVt78ZHJpHonHLHW7OLIshq68=
 github.com/alicebob/miniredis/v2 v2.37.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
+github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
+github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
+github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
+github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -18,6 +22,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
+github.com/klauspost/cpuid/v2 v2.2.10 h1:tBs3QSyvjDyFTq3uoc/9xFpCuOsJQFNPiAhYdw2skhE=
+github.com/klauspost/cpuid/v2 v2.2.10/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
@@ -39,6 +45,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
 github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
+github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=
+github.com/zeebo/xxh3 v1.1.0/go.mod h1:IisAie1LELR4xhVinxWS5+zf1lA4p0MW4T+w+W07F5s=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/otel v1.39.0 h1:8yPrr/S0ND9QEfTfdP9V+SiwT4E0G7Y5MO7p85nis48=

--- a/services/exchange-service/handlers/coverage_gaps_test.go
+++ b/services/exchange-service/handlers/coverage_gaps_test.go
@@ -6,9 +6,9 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/alicebob/miniredis/v2"
 	"github.com/DATA-DOG/go-sqlmock"
 	pb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/exchange"
+	"github.com/alicebob/miniredis/v2"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -39,7 +39,7 @@ func seedRateCache(t *testing.T, mr *miniredis.Miniredis) {
 	}
 	data, err := json.Marshal(rates)
 	require.NoError(t, err)
-	mr.Set(ratesCacheKey(), string(data))
+	require.NoError(t, mr.Set(ratesCacheKey(), string(data)))
 }
 
 // ── ConvertAmount: source currency code error (line 267-269) ─────────────────

--- a/services/exchange-service/handlers/redis_test.go
+++ b/services/exchange-service/handlers/redis_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/alicebob/miniredis/v2"
 	pb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/exchange"
+	"github.com/alicebob/miniredis/v2"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -46,7 +46,7 @@ func TestLoadCachedRates_KeyMissing_ReturnsNil(t *testing.T) {
 
 func TestLoadCachedRates_InvalidJSON_ReturnsNil(t *testing.T) {
 	mr, rdb := newRedisServer(t)
-	mr.Set(ratesCacheKey(), "not-json")
+	require.NoError(t, mr.Set(ratesCacheKey(), "not-json"))
 
 	s := &ExchangeServer{Redis: rdb}
 	assert.Nil(t, s.loadCachedRates(context.Background()))
@@ -61,7 +61,7 @@ func TestLoadCachedRates_ValidCache_ReturnsParsedRates(t *testing.T) {
 	}
 	data, err := json.Marshal(payload)
 	require.NoError(t, err)
-	mr.Set(ratesCacheKey(), string(data))
+	require.NoError(t, mr.Set(ratesCacheKey(), string(data)))
 
 	s := &ExchangeServer{Redis: rdb}
 	result := s.loadCachedRates(context.Background())


### PR DESCRIPTION
…xchange rates

- account-service: replace old dash-formatted OTC test account numbers (265-0001-01, 265-0002-01) with proper 18-digit format so the celina2 Scenario 7 regex assertion passes
- exchange-service: seed approximate USD/RSD daily exchange rates on DB init so the order-service actuary limit check works on a fresh DB without requiring external API keys (fixes celina3 agent_workday flow)  (agent_workday tests still fail tho)