### PR TITLE
feat: add Kubernetes deploy jobs to all service workflows

### DIFF
--- a/.github/workflows/account-docker.yml
+++ b/.github/workflows/account-docker.yml
@@ -39,3 +39,21 @@ jobs:
           file: services/account-service/Dockerfile
           push: ${{ github.event_name == 'push' }}
           tags: ghcr.io/raf-si-2025/exbanka-4-backend/account-service:${{ github.sha }}
+
+  deploy:
+    name: Deploy to Kubernetes
+    needs: docker
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    steps:
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG }}" | base64 -d > ~/.kube/config
+
+      - name: Deploy to Kubernetes
+        run: |
+          kubectl set image deployment/account-service account-service=ghcr.io/raf-si-2025/exbanka-4-backend/account-service:${{ github.sha }} -n exbanka

--- a/.github/workflows/api-gateway-docker.yml
+++ b/.github/workflows/api-gateway-docker.yml
@@ -39,3 +39,21 @@ jobs:
           file: services/api-gateway/Dockerfile
           push: ${{ github.event_name == 'push' }}
           tags: ghcr.io/raf-si-2025/exbanka-4-backend/api-gateway:${{ github.sha }}
+
+  deploy:
+    name: Deploy to Kubernetes
+    needs: docker
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    steps:
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG }}" | base64 -d > ~/.kube/config
+
+      - name: Deploy to Kubernetes
+        run: |
+          kubectl set image deployment/api-gateway api-gateway=ghcr.io/raf-si-2025/exbanka-4-backend/api-gateway:${{ github.sha }} -n exbanka

--- a/.github/workflows/auth-docker.yml
+++ b/.github/workflows/auth-docker.yml
@@ -39,3 +39,21 @@ jobs:
           file: services/auth-service/Dockerfile
           push: ${{ github.event_name == 'push' }}
           tags: ghcr.io/raf-si-2025/exbanka-4-backend/auth-service:${{ github.sha }}
+
+  deploy:
+    name: Deploy to Kubernetes
+    needs: docker
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    steps:
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG }}" | base64 -d > ~/.kube/config
+
+      - name: Deploy to Kubernetes
+        run: |
+          kubectl set image deployment/auth-service auth-service=ghcr.io/raf-si-2025/exbanka-4-backend/auth-service:${{ github.sha }} -n exbanka

--- a/.github/workflows/card-docker.yml
+++ b/.github/workflows/card-docker.yml
@@ -39,3 +39,21 @@ jobs:
           file: services/card-service/Dockerfile
           push: ${{ github.event_name == 'push' }}
           tags: ghcr.io/raf-si-2025/exbanka-4-backend/card-service:${{ github.sha }}
+
+  deploy:
+    name: Deploy to Kubernetes
+    needs: docker
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    steps:
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG }}" | base64 -d > ~/.kube/config
+
+      - name: Deploy to Kubernetes
+        run: |
+          kubectl set image deployment/card-service card-service=ghcr.io/raf-si-2025/exbanka-4-backend/card-service:${{ github.sha }} -n exbanka

--- a/.github/workflows/client-docker.yml
+++ b/.github/workflows/client-docker.yml
@@ -39,3 +39,21 @@ jobs:
           file: services/client-service/Dockerfile
           push: ${{ github.event_name == 'push' }}
           tags: ghcr.io/raf-si-2025/exbanka-4-backend/client-service:${{ github.sha }}
+
+  deploy:
+    name: Deploy to Kubernetes
+    needs: docker
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    steps:
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG }}" | base64 -d > ~/.kube/config
+
+      - name: Deploy to Kubernetes
+        run: |
+          kubectl set image deployment/client-service client-service=ghcr.io/raf-si-2025/exbanka-4-backend/client-service:${{ github.sha }} -n exbanka

--- a/.github/workflows/email-docker.yml
+++ b/.github/workflows/email-docker.yml
@@ -39,3 +39,21 @@ jobs:
           file: services/email-service/Dockerfile
           push: ${{ github.event_name == 'push' }}
           tags: ghcr.io/raf-si-2025/exbanka-4-backend/email-service:${{ github.sha }}
+
+  deploy:
+    name: Deploy to Kubernetes
+    needs: docker
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    steps:
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG }}" | base64 -d > ~/.kube/config
+
+      - name: Deploy to Kubernetes
+        run: |
+          kubectl set image deployment/email-service email-service=ghcr.io/raf-si-2025/exbanka-4-backend/email-service:${{ github.sha }} -n exbanka

--- a/.github/workflows/employee-docker.yml
+++ b/.github/workflows/employee-docker.yml
@@ -39,3 +39,20 @@ jobs:
           file: services/employee-service/Dockerfile
           push: ${{ github.event_name == 'push' }}
           tags: ghcr.io/raf-si-2025/exbanka-4-backend/employee-service:${{ github.sha }}
+  deploy:
+    name: Deploy to Kubernetes
+    needs: docker
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    steps:
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG }}" | base64 -d > ~/.kube/config
+
+      - name: Deploy to Kubernetes
+        run: |
+          kubectl set image deployment/employee-service employee-service=ghcr.io/raf-si-2025/exbanka-4-backend/employee-service:${{ github.sha }} -n exbanka

--- a/.github/workflows/exchange-docker.yml
+++ b/.github/workflows/exchange-docker.yml
@@ -39,3 +39,21 @@ jobs:
           file: services/exchange-service/Dockerfile
           push: ${{ github.event_name == 'push' }}
           tags: ghcr.io/raf-si-2025/exbanka-4-backend/exchange-service:${{ github.sha }}
+
+  deploy:
+    name: Deploy to Kubernetes
+    needs: docker
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    steps:
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG }}" | base64 -d > ~/.kube/config
+
+      - name: Deploy to Kubernetes
+        run: |
+          kubectl set image deployment/exchange-service exchange-service=ghcr.io/raf-si-2025/exbanka-4-backend/exchange-service:${{ github.sha }} -n exbanka

--- a/.github/workflows/fund-docker.yml
+++ b/.github/workflows/fund-docker.yml
@@ -39,3 +39,21 @@ jobs:
           file: services/fund-service/Dockerfile
           push: ${{ github.event_name == 'push' }}
           tags: ghcr.io/raf-si-2025/exbanka-4-backend/fund-service:${{ github.sha }}
+
+  deploy:
+    name: Deploy to Kubernetes
+    needs: docker
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    steps:
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG }}" | base64 -d > ~/.kube/config
+
+      - name: Deploy to Kubernetes
+        run: |
+          kubectl set image deployment/fund-service fund-service=ghcr.io/raf-si-2025/exbanka-4-backend/fund-service:${{ github.sha }} -n exbanka

--- a/.github/workflows/loan-docker.yml
+++ b/.github/workflows/loan-docker.yml
@@ -39,3 +39,21 @@ jobs:
           file: services/loan-service/Dockerfile
           push: ${{ github.event_name == 'push' }}
           tags: ghcr.io/raf-si-2025/exbanka-4-backend/loan-service:${{ github.sha }}
+
+  deploy:
+    name: Deploy to Kubernetes
+    needs: docker
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    steps:
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG }}" | base64 -d > ~/.kube/config
+
+      - name: Deploy to Kubernetes
+        run: |
+          kubectl set image deployment/loan-service loan-service=ghcr.io/raf-si-2025/exbanka-4-backend/loan-service:${{ github.sha }} -n exbanka

--- a/.github/workflows/order-docker.yml
+++ b/.github/workflows/order-docker.yml
@@ -39,3 +39,21 @@ jobs:
           file: services/order-service/Dockerfile
           push: ${{ github.event_name == 'push' }}
           tags: ghcr.io/raf-si-2025/exbanka-4-backend/order-service:${{ github.sha }}
+
+  deploy:
+    name: Deploy to Kubernetes
+    needs: docker
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    steps:
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG }}" | base64 -d > ~/.kube/config
+
+      - name: Deploy to Kubernetes
+        run: |
+          kubectl set image deployment/order-service order-service=ghcr.io/raf-si-2025/exbanka-4-backend/order-service:${{ github.sha }} -n exbanka

--- a/.github/workflows/otc-docker.yml
+++ b/.github/workflows/otc-docker.yml
@@ -39,3 +39,21 @@ jobs:
           file: services/otc-service/Dockerfile
           push: ${{ github.event_name == 'push' }}
           tags: ghcr.io/raf-si-2025/exbanka-4-backend/otc-service:${{ github.sha }}
+
+  deploy:
+    name: Deploy to Kubernetes
+    needs: docker
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    steps:
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG }}" | base64 -d > ~/.kube/config
+
+      - name: Deploy to Kubernetes
+        run: |
+          kubectl set image deployment/otc-service otc-service=ghcr.io/raf-si-2025/exbanka-4-backend/otc-service:${{ github.sha }} -n exbanka

--- a/.github/workflows/payment-docker.yml
+++ b/.github/workflows/payment-docker.yml
@@ -39,3 +39,21 @@ jobs:
           file: services/payment-service/Dockerfile
           push: ${{ github.event_name == 'push' }}
           tags: ghcr.io/raf-si-2025/exbanka-4-backend/payment-service:${{ github.sha }}
+
+  deploy:
+    name: Deploy to Kubernetes
+    needs: docker
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    steps:
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG }}" | base64 -d > ~/.kube/config
+
+      - name: Deploy to Kubernetes
+        run: |
+          kubectl set image deployment/payment-service payment-service=ghcr.io/raf-si-2025/exbanka-4-backend/payment-service:${{ github.sha }} -n exbanka

--- a/.github/workflows/portfolio-docker.yml
+++ b/.github/workflows/portfolio-docker.yml
@@ -39,3 +39,21 @@ jobs:
           file: services/portfolio-service/Dockerfile
           push: ${{ github.event_name == 'push' }}
           tags: ghcr.io/raf-si-2025/exbanka-4-backend/portfolio-service:${{ github.sha }}
+
+  deploy:
+    name: Deploy to Kubernetes
+    needs: docker
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    steps:
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG }}" | base64 -d > ~/.kube/config
+
+      - name: Deploy to Kubernetes
+        run: |
+          kubectl set image deployment/portfolio-service portfolio-service=ghcr.io/raf-si-2025/exbanka-4-backend/portfolio-service:${{ github.sha }} -n exbanka

--- a/.github/workflows/securities-docker.yml
+++ b/.github/workflows/securities-docker.yml
@@ -39,3 +39,21 @@ jobs:
           file: services/securities-service/Dockerfile
           push: ${{ github.event_name == 'push' }}
           tags: ghcr.io/raf-si-2025/exbanka-4-backend/securities-service:${{ github.sha }}
+
+  deploy:
+    name: Deploy to Kubernetes
+    needs: docker
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    steps:
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG }}" | base64 -d > ~/.kube/config
+
+      - name: Deploy to Kubernetes
+        run: |
+          kubectl set image deployment/securities-service securities-service=ghcr.io/raf-si-2025/exbanka-4-backend/securities-service:${{ github.sha }} -n exbanka


### PR DESCRIPTION
## Summary

- Adds a `deploy` job to all 15 service docker workflows (`account`, `api-gateway`, `auth`, `card`, `client`, `email`, `employee`, `exchange`, `fund`, `loan`, `order`, `otc`, `payment`, `portfolio`, `securities`)
- Each deploy job runs after a successful image push and calls `kubectl set image` with the exact git SHA, updating the deployment in the `exbanka` namespace
- Requires `KUBECONFIG` secret (base64-encoded kubeconfig) to be set in repo settings — deploy job will fail gracefully until then

## Test plan

- [ ] Add `KUBECONFIG` secret to repo settings once cluster is available
- [ ] Push any code change to Sprint-9 and verify the deploy job runs after the docker job
- [ ] Confirm pod is updated: `kubectl get pods -n exbanka | grep <service>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)