### PR TITLE
feat(#251): expose GET /public-stock for inter-bank OTC discovery

### DIFF
--- a/services/api-gateway/handlers/fund_coverage_test.go
+++ b/services/api-gateway/handlers/fund_coverage_test.go
@@ -230,21 +230,21 @@ func TestGetFundSecurities_SkipsFailedSecLookup(t *testing.T) {
 // ---- BuyFundSecurities edge cases ----
 
 func TestBuyFundSecurities_NoToken(t *testing.T) {
-	w := serveHandler(BuyFundSecurities(&stubFundClient{}, &stubSecuritiesClient{}, &stubOrderClient{}), "POST", "/investment/funds/:id/securities/buy", "/investment/funds/1/securities/buy", buyBody)
+	w := serveHandler(BuyFundSecurities(&stubFundClient{}, &stubSecuritiesClient{}, &stubOrderClient{}, &stubExchangeClient{}), "POST", "/investment/funds/:id/securities/buy", "/investment/funds/1/securities/buy", buyBody)
 	if w.Code != http.StatusUnauthorized {
 		t.Fatalf("expected 401 got %d", w.Code)
 	}
 }
 
 func TestBuyFundSecurities_BadID(t *testing.T) {
-	w := serveHandlerFull(BuyFundSecurities(&stubFundClient{}, &stubSecuritiesClient{}, &stubOrderClient{}), "POST", "/investment/funds/:id/securities/buy", "/investment/funds/abc/securities/buy", buyBody, makeSupervisorToken())
+	w := serveHandlerFull(BuyFundSecurities(&stubFundClient{}, &stubSecuritiesClient{}, &stubOrderClient{}, &stubExchangeClient{}), "POST", "/investment/funds/:id/securities/buy", "/investment/funds/abc/securities/buy", buyBody, makeSupervisorToken())
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 got %d", w.Code)
 	}
 }
 
 func TestBuyFundSecurities_BadBody(t *testing.T) {
-	w := serveHandlerFull(BuyFundSecurities(&stubFundClient{}, &stubSecuritiesClient{}, &stubOrderClient{}), "POST", "/investment/funds/:id/securities/buy", "/investment/funds/1/securities/buy", `{}`, makeSupervisorToken())
+	w := serveHandlerFull(BuyFundSecurities(&stubFundClient{}, &stubSecuritiesClient{}, &stubOrderClient{}, &stubExchangeClient{}), "POST", "/investment/funds/:id/securities/buy", "/investment/funds/1/securities/buy", `{}`, makeSupervisorToken())
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 got %d", w.Code)
 	}
@@ -266,7 +266,7 @@ func TestBuyFundSecurities_OrderError(t *testing.T) {
 			return nil, status.Error(codes.Internal, "order service error")
 		},
 	}
-	w := serveHandlerFull(BuyFundSecurities(fund, sec, order), "POST", "/investment/funds/:id/securities/buy", "/investment/funds/1/securities/buy", buyBody, makeSupervisorToken())
+	w := serveHandlerFull(BuyFundSecurities(fund, sec, order, &stubExchangeClient{}), "POST", "/investment/funds/:id/securities/buy", "/investment/funds/1/securities/buy", buyBody, makeSupervisorToken())
 	if w.Code != http.StatusInternalServerError {
 		t.Fatalf("expected 500 got %d", w.Code)
 	}
@@ -291,7 +291,7 @@ func TestBuyFundSecurities_AdminPath(t *testing.T) {
 			return &pb_order.CreateOrderResponse{OrderId: 77, OrderType: "MARKET", Status: "APPROVED"}, nil
 		},
 	}
-	w := serveHandlerFull(BuyFundSecurities(fund, sec, order), "POST", "/investment/funds/:id/securities/buy", "/investment/funds/1/securities/buy", buyBody, makeAdminToken())
+	w := serveHandlerFull(BuyFundSecurities(fund, sec, order, &stubExchangeClient{}), "POST", "/investment/funds/:id/securities/buy", "/investment/funds/1/securities/buy", buyBody, makeAdminToken())
 	if w.Code != http.StatusCreated {
 		t.Fatalf("expected 201 got %d: %s", w.Code, w.Body.String())
 	}
@@ -310,7 +310,7 @@ func TestBuyFundSecurities_AdminPath_InsufficientLiquidity(t *testing.T) {
 			return f, nil
 		},
 	}
-	w := serveHandlerFull(BuyFundSecurities(fund, sec, &stubOrderClient{}), "POST", "/investment/funds/:id/securities/buy", "/investment/funds/1/securities/buy", buyBody, makeAdminToken())
+	w := serveHandlerFull(BuyFundSecurities(fund, sec, &stubOrderClient{}, &stubExchangeClient{}), "POST", "/investment/funds/:id/securities/buy", "/investment/funds/1/securities/buy", buyBody, makeAdminToken())
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 got %d", w.Code)
 	}
@@ -516,7 +516,7 @@ func TestBuyFundSecurities_FundNotFound(t *testing.T) {
 			return nil, status.Error(codes.NotFound, "fund not found")
 		},
 	}
-	w := serveHandlerFull(BuyFundSecurities(fund, sec, &stubOrderClient{}), "POST", "/investment/funds/:id/securities/buy", "/investment/funds/1/securities/buy", buyBody, makeSupervisorToken())
+	w := serveHandlerFull(BuyFundSecurities(fund, sec, &stubOrderClient{}, &stubExchangeClient{}), "POST", "/investment/funds/:id/securities/buy", "/investment/funds/1/securities/buy", buyBody, makeSupervisorToken())
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("expected 404 got %d", w.Code)
 	}
@@ -582,7 +582,7 @@ func TestBuyFundSecurities_ValidateInternalError(t *testing.T) {
 			return nil, status.Error(codes.Internal, "db error")
 		},
 	}
-	w := serveHandlerFull(BuyFundSecurities(fund, sec, &stubOrderClient{}), "POST", "/investment/funds/:id/securities/buy", "/investment/funds/1/securities/buy", buyBody, makeSupervisorToken())
+	w := serveHandlerFull(BuyFundSecurities(fund, sec, &stubOrderClient{}, &stubExchangeClient{}), "POST", "/investment/funds/:id/securities/buy", "/investment/funds/1/securities/buy", buyBody, makeSupervisorToken())
 	if w.Code != http.StatusInternalServerError {
 		t.Fatalf("expected 500 got %d", w.Code)
 	}
@@ -601,7 +601,7 @@ func TestBuyFundSecurities_AdminPath_GetFundError(t *testing.T) {
 			return nil, status.Error(codes.NotFound, "fund not found")
 		},
 	}
-	w := serveHandlerFull(BuyFundSecurities(fund, sec, &stubOrderClient{}), "POST", "/investment/funds/:id/securities/buy", "/investment/funds/1/securities/buy", buyBody, makeAdminToken())
+	w := serveHandlerFull(BuyFundSecurities(fund, sec, &stubOrderClient{}, &stubExchangeClient{}), "POST", "/investment/funds/:id/securities/buy", "/investment/funds/1/securities/buy", buyBody, makeAdminToken())
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("expected 404 got %d", w.Code)
 	}

--- a/services/api-gateway/handlers/fund_test.go
+++ b/services/api-gateway/handlers/fund_test.go
@@ -573,7 +573,7 @@ func TestBuyFundSecurities_TickerNotFound(t *testing.T) {
 			return &pb_sec.GetListingsResponse{Listings: []*pb_sec.ListingSummary{}}, nil
 		},
 	}
-	w := serveHandlerFull(BuyFundSecurities(&stubFundClient{}, sec, &stubOrderClient{}), "POST", "/investment/funds/:id/securities/buy", "/investment/funds/1/securities/buy", buyBody, makeSupervisorToken())
+	w := serveHandlerFull(BuyFundSecurities(&stubFundClient{}, sec, &stubOrderClient{}, &stubExchangeClient{}), "POST", "/investment/funds/:id/securities/buy", "/investment/funds/1/securities/buy", buyBody, makeSupervisorToken())
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("expected 404 got %d: %s", w.Code, w.Body.String())
 	}
@@ -590,7 +590,7 @@ func TestBuyFundSecurities_InsufficientLiquidity(t *testing.T) {
 			return &pb.ValidateFundAccountResponse{AccountId: 100, IsLiquid: false, LiquidAssets: 100.0}, nil
 		},
 	}
-	w := serveHandlerFull(BuyFundSecurities(fund, sec, &stubOrderClient{}), "POST", "/investment/funds/:id/securities/buy", "/investment/funds/1/securities/buy", buyBody, makeSupervisorToken())
+	w := serveHandlerFull(BuyFundSecurities(fund, sec, &stubOrderClient{}, &stubExchangeClient{}), "POST", "/investment/funds/:id/securities/buy", "/investment/funds/1/securities/buy", buyBody, makeSupervisorToken())
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 got %d: %s", w.Code, w.Body.String())
 	}
@@ -607,7 +607,7 @@ func TestBuyFundSecurities_NotManager(t *testing.T) {
 			return nil, status.Error(codes.PermissionDenied, "not the fund manager")
 		},
 	}
-	w := serveHandlerFull(BuyFundSecurities(fund, sec, &stubOrderClient{}), "POST", "/investment/funds/:id/securities/buy", "/investment/funds/1/securities/buy", buyBody, makeSupervisorToken())
+	w := serveHandlerFull(BuyFundSecurities(fund, sec, &stubOrderClient{}, &stubExchangeClient{}), "POST", "/investment/funds/:id/securities/buy", "/investment/funds/1/securities/buy", buyBody, makeSupervisorToken())
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("expected 403 got %d: %s", w.Code, w.Body.String())
 	}
@@ -629,7 +629,7 @@ func TestBuyFundSecurities_Success(t *testing.T) {
 			return &pb_order.CreateOrderResponse{OrderId: 42, OrderType: "MARKET", Status: "APPROVED"}, nil
 		},
 	}
-	w := serveHandlerFull(BuyFundSecurities(fund, sec, order), "POST", "/investment/funds/:id/securities/buy", "/investment/funds/1/securities/buy", buyBody, makeSupervisorToken())
+	w := serveHandlerFull(BuyFundSecurities(fund, sec, order, &stubExchangeClient{}), "POST", "/investment/funds/:id/securities/buy", "/investment/funds/1/securities/buy", buyBody, makeSupervisorToken())
 	if w.Code != http.StatusCreated {
 		t.Fatalf("expected 201 got %d: %s", w.Code, w.Body.String())
 	}

--- a/services/api-gateway/handlers/otc.go
+++ b/services/api-gateway/handlers/otc.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"net/http"
+	"os"
 	"strconv"
 	"time"
 
@@ -487,5 +488,67 @@ func SetPublicMode(portfolioClient pb_portfolio.PortfolioServiceClient) gin.Hand
 			"ticker":   resp.Ticker,
 			"isPublic": resp.IsPublic,
 		})
+	}
+}
+
+func GetPublicStock(client pb.OtcServiceClient) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		apiKey := os.Getenv("OWN_INTERBANK_API_KEY")
+		if apiKey == "" || c.GetHeader("X-Api-Key") != apiKey {
+			c.Status(http.StatusUnauthorized)
+			return
+		}
+
+		routingNumber, _ := strconv.Atoi(os.Getenv("OWN_ROUTING_NUMBER"))
+
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 10*time.Second)
+		defer cancel()
+
+		resp, err := client.GetMarket(ctx, &pb.GetMarketRequest{
+			CallerId:   0,
+			CallerType: "CLIENT",
+		})
+		if err != nil {
+			mapOtcError(c, err)
+			return
+		}
+
+		type seller struct {
+			RoutingNumber int    `json:"routingNumber"`
+			ID            string `json:"id"`
+		}
+		type sellerEntry struct {
+			Seller seller `json:"seller"`
+			Amount int32  `json:"amount"`
+		}
+		type stock struct {
+			Ticker string `json:"ticker"`
+		}
+		type stockEntry struct {
+			Stock   stock         `json:"stock"`
+			Sellers []sellerEntry `json:"sellers"`
+		}
+
+		byTicker := make(map[string]*stockEntry)
+		for _, item := range resp.Items {
+			entry, ok := byTicker[item.Ticker]
+			if !ok {
+				entry = &stockEntry{Stock: stock{Ticker: item.Ticker}}
+				byTicker[item.Ticker] = entry
+			}
+			entry.Sellers = append(entry.Sellers, sellerEntry{
+				Seller: seller{
+					RoutingNumber: routingNumber,
+					ID:            strconv.FormatInt(item.OwnerId, 10),
+				},
+				Amount: item.Amount,
+			})
+		}
+
+		result := make([]*stockEntry, 0, len(byTicker))
+		for _, v := range byTicker {
+			result = append(result, v)
+		}
+		c.JSON(http.StatusOK, result)
 	}
 }

--- a/services/api-gateway/handlers/otc_test.go
+++ b/services/api-gateway/handlers/otc_test.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
 	pb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/otc"
+	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v5"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -587,5 +589,122 @@ func TestGetMarket_Empty(t *testing.T) {
 	_ = json.Unmarshal(w.Body.Bytes(), &resp)
 	if len(resp) != 0 {
 		t.Fatalf("expected empty array got %d", len(resp))
+	}
+}
+
+// ---- GetPublicStock tests ----
+
+func serveHandlerWithAPIKey(handler gin.HandlerFunc, method, path, urlPath, apiKey string) *httptest.ResponseRecorder {
+	router := gin.New()
+	router.Handle(method, path, handler)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(method, urlPath, nil)
+	if apiKey != "" {
+		req.Header.Set("X-Api-Key", apiKey)
+	}
+	router.ServeHTTP(w, req)
+	return w
+}
+
+func TestGetPublicStock_NoAPIKey(t *testing.T) {
+	t.Setenv("OWN_INTERBANK_API_KEY", "secret")
+	w := serveHandlerWithAPIKey(GetPublicStock(&stubOtcClient{}), "GET", "/public-stock", "/public-stock", "")
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 got %d", w.Code)
+	}
+}
+
+func TestGetPublicStock_WrongAPIKey(t *testing.T) {
+	t.Setenv("OWN_INTERBANK_API_KEY", "secret")
+	w := serveHandlerWithAPIKey(GetPublicStock(&stubOtcClient{}), "GET", "/public-stock", "/public-stock", "wrong")
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 got %d", w.Code)
+	}
+}
+
+func TestGetPublicStock_Empty(t *testing.T) {
+	t.Setenv("OWN_INTERBANK_API_KEY", "secret")
+	t.Setenv("OWN_ROUTING_NUMBER", "123")
+	svc := &stubOtcClient{
+		getMarketFn: func(_ context.Context, _ *pb.GetMarketRequest, _ ...grpc.CallOption) (*pb.GetMarketResponse, error) {
+			return &pb.GetMarketResponse{Items: []*pb.MarketItem{}}, nil
+		},
+	}
+	w := serveHandlerWithAPIKey(GetPublicStock(svc), "GET", "/public-stock", "/public-stock", "secret")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d", w.Code)
+	}
+	var resp []interface{}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if len(resp) != 0 {
+		t.Fatalf("expected empty array got %d items", len(resp))
+	}
+}
+
+func TestGetPublicStock_GroupsByTicker(t *testing.T) {
+	t.Setenv("OWN_INTERBANK_API_KEY", "secret")
+	t.Setenv("OWN_ROUTING_NUMBER", "123")
+	svc := &stubOtcClient{
+		getMarketFn: func(_ context.Context, req *pb.GetMarketRequest, _ ...grpc.CallOption) (*pb.GetMarketResponse, error) {
+			// Verify caller identity passed to GetMarket
+			if req.CallerId != 0 || req.CallerType != "CLIENT" {
+				return nil, status.Error(codes.InvalidArgument, "unexpected caller")
+			}
+			return &pb.GetMarketResponse{Items: []*pb.MarketItem{
+				{Ticker: "AAPL", OwnerId: 1, Amount: 50},
+				{Ticker: "AAPL", OwnerId: 2, Amount: 30},
+				{Ticker: "MSFT", OwnerId: 3, Amount: 10},
+			}}, nil
+		},
+	}
+	w := serveHandlerWithAPIKey(GetPublicStock(svc), "GET", "/public-stock", "/public-stock", "secret")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp []map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if len(resp) != 2 {
+		t.Fatalf("expected 2 ticker groups got %d", len(resp))
+	}
+
+	// Build a map for order-independent checks
+	byTicker := map[string][]interface{}{}
+	for _, entry := range resp {
+		stock := entry["stock"].(map[string]interface{})
+		ticker := stock["ticker"].(string)
+		byTicker[ticker] = entry["sellers"].([]interface{})
+	}
+
+	if len(byTicker["AAPL"]) != 2 {
+		t.Fatalf("expected 2 AAPL sellers got %d", len(byTicker["AAPL"]))
+	}
+	if len(byTicker["MSFT"]) != 1 {
+		t.Fatalf("expected 1 MSFT seller got %d", len(byTicker["MSFT"]))
+	}
+
+	// Check routing number is set correctly on a seller
+	msftSeller := byTicker["MSFT"][0].(map[string]interface{})
+	sellerInfo := msftSeller["seller"].(map[string]interface{})
+	if int(sellerInfo["routingNumber"].(float64)) != 123 {
+		t.Fatalf("expected routingNumber 123 got %v", sellerInfo["routingNumber"])
+	}
+	if sellerInfo["id"].(string) != "3" {
+		t.Fatalf("expected id '3' got %v", sellerInfo["id"])
+	}
+}
+
+func TestGetPublicStock_ServiceError(t *testing.T) {
+	t.Setenv("OWN_INTERBANK_API_KEY", "secret")
+	svc := &stubOtcClient{
+		getMarketFn: func(_ context.Context, _ *pb.GetMarketRequest, _ ...grpc.CallOption) (*pb.GetMarketResponse, error) {
+			return nil, status.Error(codes.Internal, "db error")
+		},
+	}
+	w := serveHandlerWithAPIKey(GetPublicStock(svc), "GET", "/public-stock", "/public-stock", "secret")
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 got %d", w.Code)
 	}
 }

--- a/services/api-gateway/handlers/payments_test.go
+++ b/services/api-gateway/handlers/payments_test.go
@@ -87,6 +87,15 @@ func (s *stubPaymentClient) GetTransfers(ctx context.Context, in *pb.GetTransfer
 	}
 	return nil, fmt.Errorf("not implemented")
 }
+func (s *stubPaymentClient) PrepareInterbankPayment(ctx context.Context, in *pb.PrepareInterbankPaymentRequest, opts ...grpc.CallOption) (*pb.PrepareInterbankPaymentResponse, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+func (s *stubPaymentClient) CommitInterbankPayment(ctx context.Context, in *pb.CommitRollbackInterbankRequest, opts ...grpc.CallOption) (*pb.CommitRollbackInterbankResponse, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+func (s *stubPaymentClient) RollbackInterbankPayment(ctx context.Context, in *pb.CommitRollbackInterbankRequest, opts ...grpc.CallOption) (*pb.CommitRollbackInterbankResponse, error) {
+	return nil, fmt.Errorf("not implemented")
+}
 
 // ---- CreatePayment ----
 

--- a/services/api-gateway/main.go
+++ b/services/api-gateway/main.go
@@ -123,6 +123,8 @@ func main() {
 
 	// Inter-bank 2PC endpoint — authenticated by X-Api-Key, no JWT
 	r.POST("/interbank", handlers.InterbankHandler(paymentClient))
+	// Public stock listing for partner banks — authenticated by X-Api-Key, no JWT
+	r.GET("/public-stock", handlers.GetPublicStock(otcClient))
 
 	r.Use(cors.New(cors.Config{
 		AllowOrigins:     []string{"http://localhost:5173", "http://localhost:3000"},

--- a/services/api-gateway/middleware/ratelimit_test.go
+++ b/services/api-gateway/middleware/ratelimit_test.go
@@ -1,7 +1,6 @@
 package middleware
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -234,6 +233,6 @@ func TestRateLimit_KeyFormat(t *testing.T) {
 
 	keys := mr.Keys()
 	require.Len(t, keys, 1)
-	expected := fmt.Sprintf("ratelimit:uid:7:/exchange/rates")
+	expected := "ratelimit:uid:7:/exchange/rates"
 	assert.Equal(t, expected, keys[0])
 }


### PR DESCRIPTION
## Summary
- Adds `GET /public-stock` endpoint authenticated via `X-Api-Key` (uses `OWN_INTERBANK_API_KEY` env var) for partner banks to discover our publicly listed OTC stocks before initiating a cross-bank negotiation
- Delegates to the existing `GetMarket` gRPC RPC with `CallerId=0, CallerType=CLIENT` so all public CLIENT stocks are returned with free amounts (pending negotiations and active contracts already subtracted by the service)
- Response groups items by ticker with a `sellers` array containing our routing number and owner ID

Also fixes pre-existing test compilation failures unrelated to this feature:
- `BuyFundSecurities` calls in `fund_test.go` / `fund_coverage_test.go` were missing the `exchangeClient` 4th argument
- `stubPaymentClient` in `payments_test.go` was missing three new interbank 2PC interface methods (`PrepareInterbankPayment`, `CommitInterbankPayment`, `RollbackInterbankPayment`)

## Test plan
- [ ] `go test ./services/api-gateway/handlers/...` passes (all handler tests green)
- [ ] `curl -H "X-Api-Key: <key>" http://localhost:8083/public-stock` → 200 with grouped ticker JSON
- [ ] `curl http://localhost:8083/public-stock` (no key) → 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)