### PR TITLE
feat(#250, #252): outgoing 2PC payment flow and incoming OTC interban…

### DIFF
--- a/services/api-gateway/handlers/otc_interbank.go
+++ b/services/api-gateway/handlers/otc_interbank.go
@@ -1,0 +1,327 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	gwinterbank "github.com/RAF-SI-2025/EXBanka-4-Backend/services/api-gateway/interbank"
+	pb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/otc"
+	"github.com/gin-gonic/gin"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func gatewayOwnRoutingInt() int32 {
+	var n int32
+	fmt.Sscanf(os.Getenv("OWN_ROUTING_NUMBER"), "%d", &n)
+	return n
+}
+
+// validateOtcInterbankKey rejects requests whose X-Api-Key does not match OWN_INTERBANK_API_KEY.
+func validateOtcInterbankKey(c *gin.Context) bool {
+	key := os.Getenv("OWN_INTERBANK_API_KEY")
+	return key != "" && c.GetHeader("X-Api-Key") == key
+}
+
+// ── JSON shapes expected/returned by the /otc/interbank/* endpoints ──────────
+
+type otcPartyID struct {
+	RoutingNumber int32  `json:"routingNumber"`
+	ID            string `json:"id"`
+}
+
+type otcMoneyAmount struct {
+	Currency string  `json:"currency"`
+	Amount   float64 `json:"amount"`
+}
+
+type otcNegotiationBody struct {
+	Stock          struct{ Ticker string `json:"ticker"` } `json:"stock"`
+	SettlementDate string                                   `json:"settlementDate"`
+	PricePerUnit   otcMoneyAmount                           `json:"pricePerUnit"`
+	Premium        otcMoneyAmount                           `json:"premium"`
+	BuyerID        otcPartyID                               `json:"buyerId"`
+	SellerID       otcPartyID                               `json:"sellerId"`
+	Amount         int32                                    `json:"amount"`
+	SellerType     string                                   `json:"sellerType"`
+}
+
+type otcNegotiationResponse struct {
+	Stock          struct{ Ticker string `json:"ticker"` } `json:"stock"`
+	SettlementDate string                                   `json:"settlementDate"`
+	PricePerUnit   otcMoneyAmount                           `json:"pricePerUnit"`
+	Premium        otcMoneyAmount                           `json:"premium"`
+	BuyerID        otcPartyID                               `json:"buyerId"`
+	SellerID       otcPartyID                               `json:"sellerId"`
+	Amount         int32                                    `json:"amount"`
+	IsOngoing      bool                                     `json:"isOngoing"`
+}
+
+func interbankNegToJSON(n *pb.InterbankNegotiationResponse) otcNegotiationResponse {
+	resp := otcNegotiationResponse{
+		SettlementDate: n.SettlementDate,
+		Amount:         n.Amount,
+		IsOngoing:      n.IsOngoing,
+		PricePerUnit:   otcMoneyAmount{Currency: n.PriceCurrency, Amount: n.PricePerUnit},
+		Premium:        otcMoneyAmount{Currency: n.PriceCurrency, Amount: n.Premium},
+		BuyerID:        otcPartyID{RoutingNumber: n.BuyerRoutingNumber, ID: n.BuyerExternalId},
+		SellerID:       otcPartyID{RoutingNumber: n.SellerRoutingNumber, ID: n.SellerExternalId},
+	}
+	resp.Stock.Ticker = n.Ticker
+	return resp
+}
+
+func mapOtcInterbankError(c *gin.Context, err error) {
+	switch status.Code(err) {
+	case codes.NotFound:
+		c.JSON(http.StatusNotFound, gin.H{"error": status.Convert(err).Message()})
+	case codes.FailedPrecondition, codes.AlreadyExists:
+		c.JSON(http.StatusConflict, gin.H{"error": status.Convert(err).Message()})
+	case codes.InvalidArgument:
+		c.JSON(http.StatusBadRequest, gin.H{"error": status.Convert(err).Message()})
+	default:
+		c.JSON(http.StatusInternalServerError, gin.H{"error": status.Convert(err).Message()})
+	}
+}
+
+// IncomingCreateNegotiation handles POST /otc/interbank/negotiations from a partner bank.
+// The partner (buyer) creates a new negotiation for one of our listed stocks (our user = seller).
+func IncomingCreateNegotiation(otcClient pb.OtcServiceClient) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if !validateOtcInterbankKey(c) {
+			c.Status(http.StatusUnauthorized)
+			return
+		}
+
+		var body otcNegotiationBody
+		if err := c.ShouldBindJSON(&body); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body: " + err.Error()})
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 10*time.Second)
+		defer cancel()
+
+		resp, err := otcClient.CreateInterbankNegotiation(ctx, &pb.CreateInterbankNegotiationRequest{
+			Ticker:               body.Stock.Ticker,
+			SettlementDate:       body.SettlementDate,
+			PricePerUnit:         body.PricePerUnit.Amount,
+			PriceCurrency:        body.PricePerUnit.Currency,
+			Premium:              body.Premium.Amount,
+			BuyerRoutingNumber:   body.BuyerID.RoutingNumber,
+			BuyerExternalId:      body.BuyerID.ID,
+			SellerRoutingNumber:  body.SellerID.RoutingNumber,
+			SellerExternalId:     body.SellerID.ID,
+			CreatorRoutingNumber: body.BuyerID.RoutingNumber,
+			CreatorExternalId:    body.BuyerID.ID,
+			Amount:               body.Amount,
+			SellerType:           body.SellerType,
+		})
+		if err != nil {
+			mapOtcInterbankError(c, err)
+			return
+		}
+
+		// Return the globally-unique negotiation ID (our routing + our local id)
+		ownRouting := gatewayOwnRoutingInt()
+		c.JSON(http.StatusCreated, gin.H{
+			"routingNumber": ownRouting,
+			"id":            fmt.Sprintf("%d", resp.LocalId),
+		})
+	}
+}
+
+// IncomingCounterOffer handles PUT /otc/interbank/negotiations/:routingNumber/:id from a partner bank.
+func IncomingCounterOffer(otcClient pb.OtcServiceClient) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if !validateOtcInterbankKey(c) {
+			c.Status(http.StatusUnauthorized)
+			return
+		}
+
+		routingNumber, extID, ok := parseInterbankNegPath(c)
+		if !ok {
+			return
+		}
+
+		var body struct {
+			PricePerUnit   otcMoneyAmount `json:"pricePerUnit"`
+			Premium        otcMoneyAmount `json:"premium"`
+			Amount         int32          `json:"amount"`
+			SettlementDate string         `json:"settlementDate"`
+		}
+		if err := c.ShouldBindJSON(&body); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body: " + err.Error()})
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 10*time.Second)
+		defer cancel()
+
+		resp, err := otcClient.InterbankCounterOffer(ctx, &pb.InterbankCounterOfferRequest{
+			RoutingNumber:  routingNumber,
+			ExternalId:     extID,
+			PricePerUnit:   body.PricePerUnit.Amount,
+			Premium:        body.Premium.Amount,
+			Amount:         body.Amount,
+			SettlementDate: body.SettlementDate,
+		})
+		if err != nil {
+			mapOtcInterbankError(c, err)
+			return
+		}
+		c.JSON(http.StatusOK, interbankNegToJSON(resp))
+	}
+}
+
+// IncomingGetNegotiation handles GET /otc/interbank/negotiations/:routingNumber/:id from a partner bank.
+func IncomingGetNegotiation(otcClient pb.OtcServiceClient) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if !validateOtcInterbankKey(c) {
+			c.Status(http.StatusUnauthorized)
+			return
+		}
+
+		routingNumber, extID, ok := parseInterbankNegPath(c)
+		if !ok {
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 10*time.Second)
+		defer cancel()
+
+		resp, err := otcClient.InterbankGetNegotiation(ctx, &pb.InterbankNegotiationIdRequest{
+			RoutingNumber: routingNumber,
+			ExternalId:    extID,
+		})
+		if err != nil {
+			mapOtcInterbankError(c, err)
+			return
+		}
+		c.JSON(http.StatusOK, interbankNegToJSON(resp))
+	}
+}
+
+// IncomingDeleteNegotiation handles DELETE /otc/interbank/negotiations/:routingNumber/:id from a partner bank.
+func IncomingDeleteNegotiation(otcClient pb.OtcServiceClient) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if !validateOtcInterbankKey(c) {
+			c.Status(http.StatusUnauthorized)
+			return
+		}
+
+		routingNumber, extID, ok := parseInterbankNegPath(c)
+		if !ok {
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 10*time.Second)
+		defer cancel()
+
+		_, err := otcClient.InterbankDeleteNegotiation(ctx, &pb.InterbankNegotiationIdRequest{
+			RoutingNumber: routingNumber,
+			ExternalId:    extID,
+		})
+		if err != nil {
+			mapOtcInterbankError(c, err)
+			return
+		}
+		c.Status(http.StatusNoContent)
+	}
+}
+
+// IncomingAcceptNegotiation handles GET /otc/interbank/negotiations/:routingNumber/:id/accept from a partner bank.
+func IncomingAcceptNegotiation(otcClient pb.OtcServiceClient) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if !validateOtcInterbankKey(c) {
+			c.Status(http.StatusUnauthorized)
+			return
+		}
+
+		routingNumber, extID, ok := parseInterbankNegPath(c)
+		if !ok {
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 10*time.Second)
+		defer cancel()
+
+		_, err := otcClient.InterbankAcceptNegotiation(ctx, &pb.InterbankNegotiationIdRequest{
+			RoutingNumber: routingNumber,
+			ExternalId:    extID,
+		})
+		if err != nil {
+			mapOtcInterbankError(c, err)
+			return
+		}
+		c.Status(http.StatusNoContent)
+	}
+}
+
+// parseInterbankNegPath extracts (routingNumber, externalId) from path params.
+func parseInterbankNegPath(c *gin.Context) (int32, string, bool) {
+	var routing int32
+	if _, err := fmt.Sscanf(c.Param("routingNumber"), "%d", &routing); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid routingNumber"})
+		return 0, "", false
+	}
+	extID := c.Param("id")
+	if extID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "id is required"})
+		return 0, "", false
+	}
+	return routing, extID, true
+}
+
+// ── Outgoing HTTP calls to partner bank (helper used by existing OTC handlers) ─
+
+const otcInterbankTimeout = 10 * time.Second
+
+// sendOtcRequest POSTs or PUTs body to the partner bank's OTC endpoint.
+func sendOtcRequest(method, url, apiKey string, body any) (*http.Response, error) {
+	data, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal: %w", err)
+	}
+	req, err := http.NewRequest(method, url, bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("new request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Api-Key", apiKey)
+	client := &http.Client{Timeout: otcInterbankTimeout}
+	return client.Do(req)
+}
+
+// ForwardNegotiationToPartner calls POST <PARTNER_BANK_URL>/otc/interbank/negotiations.
+// Returns the partner's (routingNumber, id) tuple, or an error.
+func ForwardNegotiationToPartner(body otcNegotiationBody, partnerRoutingNumber string) (int32, string, error) {
+	bank, err := gwinterbank.ResolveBankByRoutingNumber(partnerRoutingNumber)
+	if err != nil || bank.BankURL == "" {
+		return 0, "", fmt.Errorf("cannot resolve partner bank: %w", err)
+	}
+
+	resp, err := sendOtcRequest(http.MethodPost, bank.BankURL+"/otc/interbank/negotiations", bank.APIKey, body)
+	if err != nil {
+		return 0, "", fmt.Errorf("partner request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		return 0, "", fmt.Errorf("partner returned status %d", resp.StatusCode)
+	}
+
+	var result struct {
+		RoutingNumber int32  `json:"routingNumber"`
+		ID            string `json:"id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return 0, "", fmt.Errorf("decode partner response: %w", err)
+	}
+	return result.RoutingNumber, result.ID, nil
+}

--- a/services/api-gateway/interbank/routing.go
+++ b/services/api-gateway/interbank/routing.go
@@ -1,0 +1,43 @@
+package interbank
+
+import (
+	"fmt"
+	"os"
+)
+
+type BankInfo struct {
+	RoutingNumber string
+	BankName      string
+	BankURL       string
+	APIKey        string
+}
+
+func ExtractRoutingNumber(accountNumber string) string {
+	if len(accountNumber) < 3 {
+		return ""
+	}
+	return accountNumber[:3]
+}
+
+func IsOwnBank(routingNumber string) bool {
+	return routingNumber == os.Getenv("OWN_ROUTING_NUMBER")
+}
+
+func ResolveBankByRoutingNumber(routingNumber string) (BankInfo, error) {
+	own := os.Getenv("OWN_ROUTING_NUMBER")
+	partner := os.Getenv("PARTNER_ROUTING_NUMBER")
+
+	switch routingNumber {
+	case own:
+		return BankInfo{RoutingNumber: own}, nil
+	case partner:
+		return BankInfo{
+			RoutingNumber: routingNumber,
+			BankName:      os.Getenv("PARTNER_BANK_NAME"),
+			BankURL:       os.Getenv("PARTNER_BANK_URL"),
+			APIKey:        os.Getenv("PARTNER_API_KEY"),
+		}, nil
+	default:
+		return BankInfo{}, fmt.Errorf("unknown routing number: %s", routingNumber)
+	}
+}

--- a/services/api-gateway/main.go
+++ b/services/api-gateway/main.go
@@ -126,6 +126,13 @@ func main() {
 	// Public stock listing for partner banks — authenticated by X-Api-Key, no JWT
 	r.GET("/public-stock", handlers.GetPublicStock(otcClient))
 
+	// OTC interbank endpoints (partner bank calls, no JWT)
+	r.POST("/otc/interbank/negotiations", handlers.IncomingCreateNegotiation(otcClient))
+	r.PUT("/otc/interbank/negotiations/:routingNumber/:id", handlers.IncomingCounterOffer(otcClient))
+	r.GET("/otc/interbank/negotiations/:routingNumber/:id", handlers.IncomingGetNegotiation(otcClient))
+	r.DELETE("/otc/interbank/negotiations/:routingNumber/:id", handlers.IncomingDeleteNegotiation(otcClient))
+	r.GET("/otc/interbank/negotiations/:routingNumber/:id/accept", handlers.IncomingAcceptNegotiation(otcClient))
+
 	r.Use(cors.New(cors.Config{
 		AllowOrigins:     []string{"http://localhost:5173", "http://localhost:3000"},
 		AllowMethods:     []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},

--- a/services/otc-service/db/schema.sql
+++ b/services/otc-service/db/schema.sql
@@ -13,8 +13,24 @@ CREATE TABLE IF NOT EXISTS otc_negotiations (
     last_modified    TIMESTAMP      NOT NULL DEFAULT NOW(),
     modified_by_id   BIGINT,
     modified_by_type VARCHAR(10),
-    status           VARCHAR(20)    NOT NULL DEFAULT 'PENDING_SELLER'
+    status           VARCHAR(20)    NOT NULL DEFAULT 'PENDING_SELLER',
+    -- cross-bank negotiation fields (NULL for intra-bank negotiations)
+    buyer_routing_number   INTEGER,
+    buyer_external_id      VARCHAR(100),
+    seller_routing_number  INTEGER,
+    seller_external_id     VARCHAR(100),
+    creator_routing_number INTEGER,
+    creator_external_id    VARCHAR(100),
+    UNIQUE (creator_routing_number, creator_external_id)
 );
+
+-- Migration: add cross-bank columns if upgrading an existing deployment
+ALTER TABLE otc_negotiations ADD COLUMN IF NOT EXISTS buyer_routing_number   INTEGER;
+ALTER TABLE otc_negotiations ADD COLUMN IF NOT EXISTS buyer_external_id      VARCHAR(100);
+ALTER TABLE otc_negotiations ADD COLUMN IF NOT EXISTS seller_routing_number  INTEGER;
+ALTER TABLE otc_negotiations ADD COLUMN IF NOT EXISTS seller_external_id     VARCHAR(100);
+ALTER TABLE otc_negotiations ADD COLUMN IF NOT EXISTS creator_routing_number INTEGER;
+ALTER TABLE otc_negotiations ADD COLUMN IF NOT EXISTS creator_external_id    VARCHAR(100);
 
 CREATE TABLE IF NOT EXISTS otc_contracts (
     id               BIGSERIAL PRIMARY KEY,

--- a/services/otc-service/handlers/grpc_server.go
+++ b/services/otc-service/handlers/grpc_server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strconv"
 	"time"
 
 	pb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/otc"
@@ -888,6 +889,256 @@ func (s *OtcServer) GetMarket(ctx context.Context, req *pb.GetMarketRequest) (*p
 	}
 
 	return &pb.GetMarketResponse{Items: items}, nil
+}
+
+// ── Cross-bank (interbank) negotiation handlers ──────────────────────────────
+
+// fetchInterbankNegotiationByID reads a negotiation row and returns the cross-bank response shape.
+func (s *OtcServer) fetchInterbankNegotiationByID(ctx context.Context, id int64) (*pb.InterbankNegotiationResponse, error) {
+	var r pb.InterbankNegotiationResponse
+	var ticker, currency, settlementDate, currentStatus string
+	var amount int32
+	var pricePerStock, premium float64
+	var buyerRouting, sellerRouting, creatorRouting sql.NullInt32
+	var buyerExtID, sellerExtID, creatorExtID sql.NullString
+
+	err := s.DB.QueryRowContext(ctx, `
+		SELECT id, ticker, amount, price_per_stock, settlement_date::text, premium, currency, status,
+		       buyer_routing_number, buyer_external_id,
+		       seller_routing_number, seller_external_id,
+		       creator_routing_number, creator_external_id
+		FROM otc_negotiations WHERE id = $1`, id,
+	).Scan(
+		&r.LocalId, &ticker, &amount, &pricePerStock, &settlementDate, &premium, &currency, &currentStatus,
+		&buyerRouting, &buyerExtID,
+		&sellerRouting, &sellerExtID,
+		&creatorRouting, &creatorExtID,
+	)
+	if err == sql.ErrNoRows {
+		return nil, status.Error(codes.NotFound, "negotiation not found")
+	} else if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to fetch negotiation: %v", err)
+	}
+
+	r.Ticker = ticker
+	r.Amount = amount
+	r.PricePerUnit = pricePerStock
+	r.PriceCurrency = currency
+	r.SettlementDate = settlementDate
+	r.Premium = premium
+	r.IsOngoing = currentStatus == "PENDING_SELLER" || currentStatus == "PENDING_BUYER"
+	if buyerRouting.Valid {
+		r.BuyerRoutingNumber = buyerRouting.Int32
+	}
+	if buyerExtID.Valid {
+		r.BuyerExternalId = buyerExtID.String
+	}
+	if sellerRouting.Valid {
+		r.SellerRoutingNumber = sellerRouting.Int32
+	}
+	if sellerExtID.Valid {
+		r.SellerExternalId = sellerExtID.String
+	}
+	if creatorRouting.Valid {
+		r.CreatorRoutingNumber = creatorRouting.Int32
+	}
+	if creatorExtID.Valid {
+		r.CreatorExternalId = creatorExtID.String
+	}
+	return &r, nil
+}
+
+// lookupInterbankNegotiation returns the local id of a cross-bank negotiation by its creator key.
+func (s *OtcServer) lookupInterbankNegotiation(ctx context.Context, routingNumber int32, externalID string) (int64, string, error) {
+	var localID int64
+	var currentStatus string
+	err := s.DB.QueryRowContext(ctx, `
+		SELECT id, status FROM otc_negotiations
+		WHERE creator_routing_number = $1 AND creator_external_id = $2`,
+		routingNumber, externalID,
+	).Scan(&localID, &currentStatus)
+	if err == sql.ErrNoRows {
+		return 0, "", status.Error(codes.NotFound, "negotiation not found")
+	} else if err != nil {
+		return 0, "", status.Errorf(codes.Internal, "failed to look up negotiation: %v", err)
+	}
+	return localID, currentStatus, nil
+}
+
+func (s *OtcServer) CreateInterbankNegotiation(ctx context.Context, req *pb.CreateInterbankNegotiationRequest) (*pb.InterbankNegotiationResponse, error) {
+	if req.Ticker == "" {
+		return nil, status.Error(codes.InvalidArgument, "ticker is required")
+	}
+	if req.Amount <= 0 {
+		return nil, status.Error(codes.InvalidArgument, "amount must be positive")
+	}
+	if req.SettlementDate == "" {
+		return nil, status.Error(codes.InvalidArgument, "settlement_date is required")
+	}
+
+	sellerType := req.SellerType
+	if sellerType == "" {
+		sellerType = "CLIENT"
+	}
+
+	// seller_external_id is our local user's numeric ID as a string
+	sellerID, parseErr := strconv.ParseInt(req.SellerExternalId, 10, 64)
+	if parseErr != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "seller_external_id must be a numeric local user ID")
+	}
+
+	// Idempotency: return existing row if this creator key already exists
+	if existingID, _, err := s.lookupInterbankNegotiation(ctx, req.CreatorRoutingNumber, req.CreatorExternalId); err == nil {
+		return s.fetchInterbankNegotiationByID(ctx, existingID)
+	}
+
+	now := time.Now()
+	var id int64
+	err := s.DB.QueryRowContext(ctx, `
+		INSERT INTO otc_negotiations
+			(ticker, seller_id, seller_type, buyer_id, buyer_type,
+			 amount, price_per_stock, settlement_date, premium, currency,
+			 last_modified, modified_by_id, modified_by_type, status,
+			 buyer_routing_number, buyer_external_id,
+			 seller_routing_number, seller_external_id,
+			 creator_routing_number, creator_external_id)
+		VALUES ($1, $2, $3, 0, 'INTERBANK', $4, $5, $6, $7, $8, $9, 0, 'INTERBANK', 'PENDING_SELLER',
+		        $10, $11, $12, $13, $14, $15)
+		RETURNING id`,
+		req.Ticker, sellerID, sellerType,
+		req.Amount, req.PricePerUnit, req.SettlementDate, req.Premium, req.PriceCurrency,
+		now,
+		req.BuyerRoutingNumber, req.BuyerExternalId,
+		req.SellerRoutingNumber, req.SellerExternalId,
+		req.CreatorRoutingNumber, req.CreatorExternalId,
+	).Scan(&id)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to create interbank negotiation: %v", err)
+	}
+	return s.fetchInterbankNegotiationByID(ctx, id)
+}
+
+func (s *OtcServer) InterbankCounterOffer(ctx context.Context, req *pb.InterbankCounterOfferRequest) (*pb.InterbankNegotiationResponse, error) {
+	localID, currentStatus, err := s.lookupInterbankNegotiation(ctx, req.RoutingNumber, req.ExternalId)
+	if err != nil {
+		return nil, err
+	}
+	if currentStatus != "PENDING_BUYER" && currentStatus != "PENDING_SELLER" {
+		return nil, status.Errorf(codes.FailedPrecondition, "negotiation is in terminal state: %s", currentStatus)
+	}
+	// The partner bank is always the buyer for incoming negotiations.
+	// Counter-offer is only allowed when it is the buyer's turn.
+	if currentStatus != "PENDING_BUYER" {
+		return nil, status.Error(codes.FailedPrecondition, "not your turn")
+	}
+
+	now := time.Now()
+	if _, err = s.DB.ExecContext(ctx, `
+		UPDATE otc_negotiations
+		SET amount = $1, price_per_stock = $2, settlement_date = $3, premium = $4,
+		    last_modified = $5, modified_by_id = 0, modified_by_type = 'INTERBANK', status = 'PENDING_SELLER'
+		WHERE id = $6`,
+		req.Amount, req.PricePerUnit, req.SettlementDate, req.Premium,
+		now, localID,
+	); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to update negotiation: %v", err)
+	}
+	return s.fetchInterbankNegotiationByID(ctx, localID)
+}
+
+func (s *OtcServer) InterbankGetNegotiation(ctx context.Context, req *pb.InterbankNegotiationIdRequest) (*pb.InterbankNegotiationResponse, error) {
+	localID, _, err := s.lookupInterbankNegotiation(ctx, req.RoutingNumber, req.ExternalId)
+	if err != nil {
+		return nil, err
+	}
+	return s.fetchInterbankNegotiationByID(ctx, localID)
+}
+
+func (s *OtcServer) InterbankDeleteNegotiation(ctx context.Context, req *pb.InterbankNegotiationIdRequest) (*pb.OtcEmptyResponse, error) {
+	localID, currentStatus, err := s.lookupInterbankNegotiation(ctx, req.RoutingNumber, req.ExternalId)
+	if err != nil {
+		return nil, err
+	}
+	if currentStatus == "ACCEPTED" {
+		return nil, status.Error(codes.FailedPrecondition, "cannot cancel an already accepted negotiation")
+	}
+	if currentStatus == "REJECTED" {
+		return &pb.OtcEmptyResponse{}, nil // idempotent
+	}
+
+	if _, err = s.DB.ExecContext(ctx, `
+		UPDATE otc_negotiations SET status = 'REJECTED', last_modified = NOW()
+		WHERE id = $1`, localID,
+	); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to cancel negotiation: %v", err)
+	}
+	return &pb.OtcEmptyResponse{}, nil
+}
+
+func (s *OtcServer) InterbankAcceptNegotiation(ctx context.Context, req *pb.InterbankNegotiationIdRequest) (*pb.OtcEmptyResponse, error) {
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to begin tx: %v", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var localID int64
+	var currentStatus, ticker, currency, settlementDate string
+	var amount int32
+	var premium, strikePrice float64
+	var sellerID int64
+	var sellerType string
+	err = tx.QueryRowContext(ctx, `
+		SELECT id, status, ticker, currency, settlement_date::text, amount, premium, price_per_stock,
+		       seller_id, seller_type
+		FROM otc_negotiations
+		WHERE creator_routing_number = $1 AND creator_external_id = $2 FOR UPDATE`,
+		req.RoutingNumber, req.ExternalId,
+	).Scan(&localID, &currentStatus, &ticker, &currency, &settlementDate, &amount, &premium, &strikePrice,
+		&sellerID, &sellerType)
+	if err == sql.ErrNoRows {
+		return nil, status.Error(codes.NotFound, "negotiation not found")
+	} else if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to load negotiation: %v", err)
+	}
+
+	if currentStatus == "ACCEPTED" {
+		if err = tx.Commit(); err == nil {
+			return &pb.OtcEmptyResponse{}, nil // idempotent
+		}
+	}
+	// The partner bank is the buyer; they can accept only when it is their turn.
+	if currentStatus != "PENDING_BUYER" {
+		return nil, status.Error(codes.FailedPrecondition, "not your turn to accept")
+	}
+
+	// Create the OTC contract.
+	now := time.Now()
+	var contractID int64
+	if err = tx.QueryRowContext(ctx, `
+		INSERT INTO otc_contracts
+			(negotiation_id, seller_id, seller_type, buyer_id, buyer_type,
+			 ticker, amount, strike_price, premium, currency, settlement_date)
+		VALUES ($1, $2, $3, 0, 'INTERBANK', $4, $5, $6, $7, $8, $9)
+		RETURNING id`,
+		localID, sellerID, sellerType,
+		ticker, amount, strikePrice, premium, currency, settlementDate,
+	).Scan(&contractID); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to create contract: %v", err)
+	}
+
+	if _, err = tx.ExecContext(ctx, `
+		UPDATE otc_negotiations
+		SET status = 'ACCEPTED', last_modified = $1, modified_by_id = 0, modified_by_type = 'INTERBANK'
+		WHERE id = $2`, now, localID,
+	); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to accept negotiation: %v", err)
+	}
+
+	if err = tx.Commit(); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to commit: %v", err)
+	}
+	return &pb.OtcEmptyResponse{}, nil
 }
 
 func (s *OtcServer) fetchNegotiationByID(ctx context.Context, id int64) (*pb.NegotiationResponse, error) {

--- a/services/payment-service/handlers/grpc_server.go
+++ b/services/payment-service/handlers/grpc_server.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/RAF-SI-2025/EXBanka-4-Backend/services/payment-service/interbank"
 	pb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/payment"
 	"github.com/lib/pq"
 	"google.golang.org/grpc/codes"
@@ -27,6 +28,14 @@ func (s *PaymentServer) CreatePayment(ctx context.Context, req *pb.CreatePayment
 	// Normalize account numbers — strip formatting dashes
 	req.FromAccount = strings.ReplaceAll(req.FromAccount, "-", "")
 	req.RecipientAccount = strings.ReplaceAll(req.RecipientAccount, "-", "")
+
+	// Route to the outgoing 2PC protocol when the recipient is at a known partner bank.
+	// Unknown or own-bank routing numbers fall through to the standard payment flow.
+	if routingNum := interbank.ExtractRoutingNumber(req.RecipientAccount); !interbank.IsOwnBank(routingNum) {
+		if bank, err := interbank.ResolveBankByRoutingNumber(routingNum); err == nil && bank.BankURL != "" {
+			return executeOutgoing2PC(ctx, s, req, routingNum)
+		}
+	}
 
 	// 1. Load fromAccount metadata (currency, owner) – no balance read yet
 	var fromID int64

--- a/services/payment-service/handlers/interbank_outgoing.go
+++ b/services/payment-service/handlers/interbank_outgoing.go
@@ -1,0 +1,317 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-4-Backend/services/payment-service/interbank"
+	pb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/payment"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	interbankTimeout    = 10 * time.Second
+	interbankMaxRetries = 3
+)
+
+// --- JSON types for the /interbank envelope ---
+
+type ibTransactionID struct {
+	RoutingNumber int    `json:"routingNumber"`
+	ID            string `json:"id"`
+}
+
+type ibIdempotenceKey struct {
+	RoutingNumber       int    `json:"routingNumber"`
+	LocallyGeneratedKey string `json:"locallyGeneratedKey"`
+}
+
+type ibPosting struct {
+	AccountType string  `json:"accountType"`
+	AccountNum  string  `json:"accountNum"`
+	Amount      float64 `json:"amount"`
+	AssetType   string  `json:"assetType"`
+	Currency    string  `json:"currency"`
+}
+
+type ibNewTxMessage struct {
+	TransactionID  ibTransactionID `json:"transactionId"`
+	Postings       []ibPosting     `json:"postings"`
+	PaymentCode    string          `json:"paymentCode"`
+	PaymentPurpose string          `json:"paymentPurpose"`
+}
+
+type ibCommitRollbackMessage struct {
+	TransactionID ibTransactionID `json:"transactionId"`
+}
+
+type ibEnvelope struct {
+	IdempotenceKey ibIdempotenceKey `json:"idempotenceKey"`
+	MessageType    string           `json:"messageType"`
+	Message        any              `json:"message"`
+}
+
+type ibVoteResponse struct {
+	Vote    string   `json:"vote"`
+	Reasons []string `json:"reasons"`
+}
+
+// generateUUID returns a random UUID v4 string without external deps.
+func generateUUID() string {
+	b := make([]byte, 16)
+	_, _ = rand.Read(b)
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+		b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+}
+
+// ownRoutingInt returns OWN_ROUTING_NUMBER as int.
+func ownRoutingInt() int {
+	var n int
+	fmt.Sscanf(os.Getenv("OWN_ROUTING_NUMBER"), "%d", &n)
+	return n
+}
+
+// sendInterbankRequest POSTs body to url with X-Api-Key auth.
+// Retries up to interbankMaxRetries times if the partner responds 202.
+func sendInterbankRequest(ctx context.Context, url, apiKey string, body any) (*http.Response, error) {
+	data, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal body: %w", err)
+	}
+
+	client := &http.Client{Timeout: interbankTimeout}
+	var lastErr error
+	for attempt := 0; attempt < interbankMaxRetries; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(data))
+		if err != nil {
+			return nil, fmt.Errorf("create request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-Api-Key", apiKey)
+
+		resp, err := client.Do(req)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+
+		if resp.StatusCode == http.StatusAccepted {
+			_ = resp.Body.Close()
+			continue
+		}
+
+		return resp, nil
+	}
+	if lastErr != nil {
+		return nil, fmt.Errorf("request failed after %d attempts: %w", interbankMaxRetries, lastErr)
+	}
+	return nil, fmt.Errorf("partner bank returned 202 for all %d attempts", interbankMaxRetries)
+}
+
+func sendRollback(ctx context.Context, bankURL, apiKey string, txID ibTransactionID) {
+	ownRouting := ownRoutingInt()
+	envelope := ibEnvelope{
+		IdempotenceKey: ibIdempotenceKey{RoutingNumber: ownRouting, LocallyGeneratedKey: generateUUID()},
+		MessageType:    "ROLLBACK_TX",
+		Message:        ibCommitRollbackMessage{TransactionID: txID},
+	}
+	resp, err := sendInterbankRequest(ctx, bankURL, apiKey, envelope)
+	if err == nil {
+		_ = resp.Body.Close()
+	}
+}
+
+// executeOutgoing2PC runs the full outgoing Two-Phase Commit when the
+// recipient account belongs to a partner bank.
+func executeOutgoing2PC(ctx context.Context, s *PaymentServer, req *pb.CreatePaymentRequest, routingNum string) (*pb.CreatePaymentResponse, error) {
+	bank, err := interbank.ResolveBankByRoutingNumber(routingNum)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "unknown bank routing number %s", routingNum)
+	}
+	bankURL := bank.BankURL + "/interbank"
+
+	// Load sender metadata.
+	var fromID, ownerID, fromCurrencyID int64
+	if err := s.AccountDB.QueryRowContext(ctx,
+		`SELECT id, owner_id, currency_id FROM accounts WHERE account_number = $1`,
+		req.FromAccount,
+	).Scan(&fromID, &ownerID, &fromCurrencyID); err == sql.ErrNoRows {
+		return nil, status.Errorf(codes.NotFound, "source account %s not found", req.FromAccount)
+	} else if err != nil {
+		return nil, status.Errorf(codes.Internal, "load source account: %v", err)
+	}
+	if ownerID != req.ClientId {
+		return nil, status.Errorf(codes.PermissionDenied, "account does not belong to this client")
+	}
+
+	var currencyCode string
+	if err := s.ExchangeDB.QueryRowContext(ctx,
+		`SELECT code FROM currencies WHERE id = $1`, fromCurrencyID,
+	).Scan(&currencyCode); err != nil {
+		return nil, status.Errorf(codes.Internal, "resolve currency: %v", err)
+	}
+
+	// DB tx #1: validate limits and reserve funds.
+	resvTx, err := s.AccountDB.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "begin reservation tx: %v", err)
+	}
+
+	var availBal float64
+	var dailyLimit, monthlyLimit sql.NullFloat64
+	var dailySpent, monthlySpent float64
+	if err = resvTx.QueryRowContext(ctx, `
+		SELECT available_balance, daily_limit, monthly_limit, daily_spent, monthly_spent
+		FROM accounts WHERE id = $1 FOR UPDATE`, fromID,
+	).Scan(&availBal, &dailyLimit, &monthlyLimit, &dailySpent, &monthlySpent); err != nil {
+		_ = resvTx.Rollback()
+		return nil, status.Errorf(codes.Internal, "lock source account: %v", err)
+	}
+	if availBal < req.Amount {
+		_ = resvTx.Rollback()
+		return nil, status.Errorf(codes.FailedPrecondition, "insufficient funds")
+	}
+	if dailyLimit.Valid && dailySpent+req.Amount > dailyLimit.Float64 {
+		_ = resvTx.Rollback()
+		return nil, status.Errorf(codes.FailedPrecondition, "daily limit exceeded")
+	}
+	if monthlyLimit.Valid && monthlySpent+req.Amount > monthlyLimit.Float64 {
+		_ = resvTx.Rollback()
+		return nil, status.Errorf(codes.FailedPrecondition, "monthly limit exceeded")
+	}
+
+	if _, err = resvTx.ExecContext(ctx, `
+		UPDATE accounts SET
+			available_balance = available_balance - $1,
+			daily_spent       = daily_spent + $1,
+			monthly_spent     = monthly_spent + $1
+		WHERE id = $2`, req.Amount, fromID); err != nil {
+		_ = resvTx.Rollback()
+		return nil, status.Errorf(codes.Internal, "reserve funds: %v", err)
+	}
+	if err = resvTx.Commit(); err != nil {
+		return nil, status.Errorf(codes.Internal, "commit reservation: %v", err)
+	}
+
+	releaseReservation := func() {
+		_, _ = s.AccountDB.ExecContext(ctx, `
+			UPDATE accounts SET
+				available_balance = available_balance + $1,
+				daily_spent       = daily_spent - $1,
+				monthly_spent     = monthly_spent - $1
+			WHERE id = $2`, req.Amount, fromID)
+	}
+
+	// Generate stable identifiers for this transaction.
+	ownRouting := ownRoutingInt()
+	txID := ibTransactionID{RoutingNumber: ownRouting, ID: generateUUID()}
+	idemKey := ibIdempotenceKey{RoutingNumber: ownRouting, LocallyGeneratedKey: generateUUID()}
+
+	// Phase 1: NEW_TX — ask partner bank to prepare.
+	newTxResp, err := sendInterbankRequest(ctx, bankURL, bank.APIKey, ibEnvelope{
+		IdempotenceKey: idemKey,
+		MessageType:    "NEW_TX",
+		Message: ibNewTxMessage{
+			TransactionID: txID,
+			Postings: []ibPosting{
+				{AccountType: "ACCOUNT", AccountNum: req.FromAccount, Amount: -req.Amount, AssetType: "MONAS", Currency: currencyCode},
+				{AccountType: "ACCOUNT", AccountNum: req.RecipientAccount, Amount: req.Amount, AssetType: "MONAS", Currency: currencyCode},
+			},
+			PaymentCode:    req.PaymentCode,
+			PaymentPurpose: req.Purpose,
+		},
+	})
+	if err != nil {
+		releaseReservation()
+		return nil, status.Errorf(codes.Unavailable, "NEW_TX request failed: %v", err)
+	}
+	defer newTxResp.Body.Close()
+
+	if newTxResp.StatusCode != http.StatusOK {
+		releaseReservation()
+		return nil, status.Errorf(codes.Unavailable, "partner bank NEW_TX returned status %d", newTxResp.StatusCode)
+	}
+
+	var vote ibVoteResponse
+	if err := json.NewDecoder(newTxResp.Body).Decode(&vote); err != nil {
+		sendRollback(ctx, bankURL, bank.APIKey, txID)
+		releaseReservation()
+		return nil, status.Errorf(codes.Internal, "decode vote response: %v", err)
+	}
+
+	if vote.Vote != "YES" {
+		releaseReservation()
+		if len(vote.Reasons) > 0 {
+			return nil, status.Errorf(codes.FailedPrecondition, "partner bank voted NO: %v", vote.Reasons)
+		}
+		return nil, status.Errorf(codes.FailedPrecondition, "partner bank voted NO")
+	}
+
+	// Phase 2: COMMIT_TX.
+	commitResp, err := sendInterbankRequest(ctx, bankURL, bank.APIKey, ibEnvelope{
+		IdempotenceKey: ibIdempotenceKey{RoutingNumber: ownRouting, LocallyGeneratedKey: generateUUID()},
+		MessageType:    "COMMIT_TX",
+		Message:        ibCommitRollbackMessage{TransactionID: txID},
+	})
+	if err != nil {
+		sendRollback(ctx, bankURL, bank.APIKey, txID)
+		releaseReservation()
+		return nil, status.Errorf(codes.Unavailable, "COMMIT_TX request failed: %v", err)
+	}
+	defer commitResp.Body.Close()
+
+	if commitResp.StatusCode != http.StatusNoContent {
+		sendRollback(ctx, bankURL, bank.APIKey, txID)
+		releaseReservation()
+		return nil, status.Errorf(codes.Unavailable, "partner bank COMMIT_TX returned status %d", commitResp.StatusCode)
+	}
+
+	// DB tx #2: apply debit now that partner committed.
+	// Decreases balance and restores available_balance (cancels reservation).
+	_, _ = s.AccountDB.ExecContext(ctx, `
+		UPDATE accounts SET
+			balance           = balance - $1,
+			available_balance = available_balance + $1
+		WHERE id = $2`, req.Amount, fromID)
+
+	// Persist payment record.
+	orderNumber := fmt.Sprintf("ORD-%d-%s", time.Now().UnixMilli(), generateUUID()[:8])
+	now := time.Now()
+
+	var paymentID int64
+	err = s.DB.QueryRowContext(ctx, `
+		INSERT INTO payments
+			(order_number, from_account, to_account, initial_amount, final_amount,
+			 fee, recipient_id, payment_code, reference_number, purpose, timestamp, status)
+		VALUES ($1, $2, $3, $4, $5, 0,
+			(SELECT id FROM payment_recipients WHERE client_id = $6 AND account_number = $7 LIMIT 1),
+			$8, $9, $10, $11, 'COMPLETED')
+		RETURNING id`,
+		orderNumber, req.FromAccount, req.RecipientAccount,
+		req.Amount, req.Amount,
+		req.ClientId, req.RecipientAccount,
+		req.PaymentCode, req.ReferenceNumber, req.Purpose, now,
+	).Scan(&paymentID)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "persist payment: %v", err)
+	}
+
+	return &pb.CreatePaymentResponse{
+		Id:            paymentID,
+		OrderNumber:   orderNumber,
+		FromAccount:   req.FromAccount,
+		ToAccount:     req.RecipientAccount,
+		InitialAmount: req.Amount,
+		FinalAmount:   req.Amount,
+		Status:        "COMPLETED",
+		Timestamp:     now.Format(time.RFC3339),
+	}, nil
+}

--- a/shared/pb/otc/otc.pb.go
+++ b/shared/pb/otc/otc.pb.go
@@ -1365,6 +1365,466 @@ func (x *GetMarketResponse) GetItems() []*MarketItem {
 	return nil
 }
 
+type OtcEmptyResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *OtcEmptyResponse) Reset() {
+	*x = OtcEmptyResponse{}
+	mi := &file_otc_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *OtcEmptyResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OtcEmptyResponse) ProtoMessage() {}
+
+func (x *OtcEmptyResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_otc_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use OtcEmptyResponse.ProtoReflect.Descriptor instead.
+func (*OtcEmptyResponse) Descriptor() ([]byte, []int) {
+	return file_otc_proto_rawDescGZIP(), []int{18}
+}
+
+type CreateInterbankNegotiationRequest struct {
+	state                protoimpl.MessageState `protogen:"open.v1"`
+	Ticker               string                 `protobuf:"bytes,1,opt,name=ticker,proto3" json:"ticker,omitempty"`
+	SettlementDate       string                 `protobuf:"bytes,2,opt,name=settlement_date,json=settlementDate,proto3" json:"settlement_date,omitempty"`
+	PricePerUnit         float64                `protobuf:"fixed64,3,opt,name=price_per_unit,json=pricePerUnit,proto3" json:"price_per_unit,omitempty"`
+	PriceCurrency        string                 `protobuf:"bytes,4,opt,name=price_currency,json=priceCurrency,proto3" json:"price_currency,omitempty"`
+	Premium              float64                `protobuf:"fixed64,5,opt,name=premium,proto3" json:"premium,omitempty"`
+	BuyerRoutingNumber   int32                  `protobuf:"varint,6,opt,name=buyer_routing_number,json=buyerRoutingNumber,proto3" json:"buyer_routing_number,omitempty"`
+	BuyerExternalId      string                 `protobuf:"bytes,7,opt,name=buyer_external_id,json=buyerExternalId,proto3" json:"buyer_external_id,omitempty"`
+	SellerRoutingNumber  int32                  `protobuf:"varint,8,opt,name=seller_routing_number,json=sellerRoutingNumber,proto3" json:"seller_routing_number,omitempty"`
+	SellerExternalId     string                 `protobuf:"bytes,9,opt,name=seller_external_id,json=sellerExternalId,proto3" json:"seller_external_id,omitempty"`
+	CreatorRoutingNumber int32                  `protobuf:"varint,10,opt,name=creator_routing_number,json=creatorRoutingNumber,proto3" json:"creator_routing_number,omitempty"`
+	CreatorExternalId    string                 `protobuf:"bytes,11,opt,name=creator_external_id,json=creatorExternalId,proto3" json:"creator_external_id,omitempty"`
+	Amount               int32                  `protobuf:"varint,12,opt,name=amount,proto3" json:"amount,omitempty"`
+	SellerType           string                 `protobuf:"bytes,13,opt,name=seller_type,json=sellerType,proto3" json:"seller_type,omitempty"` // CLIENT or EMPLOYEE; defaults to CLIENT if empty
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
+}
+
+func (x *CreateInterbankNegotiationRequest) Reset() {
+	*x = CreateInterbankNegotiationRequest{}
+	mi := &file_otc_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateInterbankNegotiationRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateInterbankNegotiationRequest) ProtoMessage() {}
+
+func (x *CreateInterbankNegotiationRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_otc_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateInterbankNegotiationRequest.ProtoReflect.Descriptor instead.
+func (*CreateInterbankNegotiationRequest) Descriptor() ([]byte, []int) {
+	return file_otc_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *CreateInterbankNegotiationRequest) GetTicker() string {
+	if x != nil {
+		return x.Ticker
+	}
+	return ""
+}
+
+func (x *CreateInterbankNegotiationRequest) GetSettlementDate() string {
+	if x != nil {
+		return x.SettlementDate
+	}
+	return ""
+}
+
+func (x *CreateInterbankNegotiationRequest) GetPricePerUnit() float64 {
+	if x != nil {
+		return x.PricePerUnit
+	}
+	return 0
+}
+
+func (x *CreateInterbankNegotiationRequest) GetPriceCurrency() string {
+	if x != nil {
+		return x.PriceCurrency
+	}
+	return ""
+}
+
+func (x *CreateInterbankNegotiationRequest) GetPremium() float64 {
+	if x != nil {
+		return x.Premium
+	}
+	return 0
+}
+
+func (x *CreateInterbankNegotiationRequest) GetBuyerRoutingNumber() int32 {
+	if x != nil {
+		return x.BuyerRoutingNumber
+	}
+	return 0
+}
+
+func (x *CreateInterbankNegotiationRequest) GetBuyerExternalId() string {
+	if x != nil {
+		return x.BuyerExternalId
+	}
+	return ""
+}
+
+func (x *CreateInterbankNegotiationRequest) GetSellerRoutingNumber() int32 {
+	if x != nil {
+		return x.SellerRoutingNumber
+	}
+	return 0
+}
+
+func (x *CreateInterbankNegotiationRequest) GetSellerExternalId() string {
+	if x != nil {
+		return x.SellerExternalId
+	}
+	return ""
+}
+
+func (x *CreateInterbankNegotiationRequest) GetCreatorRoutingNumber() int32 {
+	if x != nil {
+		return x.CreatorRoutingNumber
+	}
+	return 0
+}
+
+func (x *CreateInterbankNegotiationRequest) GetCreatorExternalId() string {
+	if x != nil {
+		return x.CreatorExternalId
+	}
+	return ""
+}
+
+func (x *CreateInterbankNegotiationRequest) GetAmount() int32 {
+	if x != nil {
+		return x.Amount
+	}
+	return 0
+}
+
+func (x *CreateInterbankNegotiationRequest) GetSellerType() string {
+	if x != nil {
+		return x.SellerType
+	}
+	return ""
+}
+
+type InterbankNegotiationResponse struct {
+	state                protoimpl.MessageState `protogen:"open.v1"`
+	LocalId              int64                  `protobuf:"varint,1,opt,name=local_id,json=localId,proto3" json:"local_id,omitempty"`
+	CreatorRoutingNumber int32                  `protobuf:"varint,2,opt,name=creator_routing_number,json=creatorRoutingNumber,proto3" json:"creator_routing_number,omitempty"`
+	CreatorExternalId    string                 `protobuf:"bytes,3,opt,name=creator_external_id,json=creatorExternalId,proto3" json:"creator_external_id,omitempty"`
+	Ticker               string                 `protobuf:"bytes,4,opt,name=ticker,proto3" json:"ticker,omitempty"`
+	SettlementDate       string                 `protobuf:"bytes,5,opt,name=settlement_date,json=settlementDate,proto3" json:"settlement_date,omitempty"`
+	PricePerUnit         float64                `protobuf:"fixed64,6,opt,name=price_per_unit,json=pricePerUnit,proto3" json:"price_per_unit,omitempty"`
+	PriceCurrency        string                 `protobuf:"bytes,7,opt,name=price_currency,json=priceCurrency,proto3" json:"price_currency,omitempty"`
+	Premium              float64                `protobuf:"fixed64,8,opt,name=premium,proto3" json:"premium,omitempty"`
+	Amount               int32                  `protobuf:"varint,9,opt,name=amount,proto3" json:"amount,omitempty"`
+	IsOngoing            bool                   `protobuf:"varint,10,opt,name=is_ongoing,json=isOngoing,proto3" json:"is_ongoing,omitempty"`
+	BuyerRoutingNumber   int32                  `protobuf:"varint,11,opt,name=buyer_routing_number,json=buyerRoutingNumber,proto3" json:"buyer_routing_number,omitempty"`
+	BuyerExternalId      string                 `protobuf:"bytes,12,opt,name=buyer_external_id,json=buyerExternalId,proto3" json:"buyer_external_id,omitempty"`
+	SellerRoutingNumber  int32                  `protobuf:"varint,13,opt,name=seller_routing_number,json=sellerRoutingNumber,proto3" json:"seller_routing_number,omitempty"`
+	SellerExternalId     string                 `protobuf:"bytes,14,opt,name=seller_external_id,json=sellerExternalId,proto3" json:"seller_external_id,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
+}
+
+func (x *InterbankNegotiationResponse) Reset() {
+	*x = InterbankNegotiationResponse{}
+	mi := &file_otc_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InterbankNegotiationResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InterbankNegotiationResponse) ProtoMessage() {}
+
+func (x *InterbankNegotiationResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_otc_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InterbankNegotiationResponse.ProtoReflect.Descriptor instead.
+func (*InterbankNegotiationResponse) Descriptor() ([]byte, []int) {
+	return file_otc_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *InterbankNegotiationResponse) GetLocalId() int64 {
+	if x != nil {
+		return x.LocalId
+	}
+	return 0
+}
+
+func (x *InterbankNegotiationResponse) GetCreatorRoutingNumber() int32 {
+	if x != nil {
+		return x.CreatorRoutingNumber
+	}
+	return 0
+}
+
+func (x *InterbankNegotiationResponse) GetCreatorExternalId() string {
+	if x != nil {
+		return x.CreatorExternalId
+	}
+	return ""
+}
+
+func (x *InterbankNegotiationResponse) GetTicker() string {
+	if x != nil {
+		return x.Ticker
+	}
+	return ""
+}
+
+func (x *InterbankNegotiationResponse) GetSettlementDate() string {
+	if x != nil {
+		return x.SettlementDate
+	}
+	return ""
+}
+
+func (x *InterbankNegotiationResponse) GetPricePerUnit() float64 {
+	if x != nil {
+		return x.PricePerUnit
+	}
+	return 0
+}
+
+func (x *InterbankNegotiationResponse) GetPriceCurrency() string {
+	if x != nil {
+		return x.PriceCurrency
+	}
+	return ""
+}
+
+func (x *InterbankNegotiationResponse) GetPremium() float64 {
+	if x != nil {
+		return x.Premium
+	}
+	return 0
+}
+
+func (x *InterbankNegotiationResponse) GetAmount() int32 {
+	if x != nil {
+		return x.Amount
+	}
+	return 0
+}
+
+func (x *InterbankNegotiationResponse) GetIsOngoing() bool {
+	if x != nil {
+		return x.IsOngoing
+	}
+	return false
+}
+
+func (x *InterbankNegotiationResponse) GetBuyerRoutingNumber() int32 {
+	if x != nil {
+		return x.BuyerRoutingNumber
+	}
+	return 0
+}
+
+func (x *InterbankNegotiationResponse) GetBuyerExternalId() string {
+	if x != nil {
+		return x.BuyerExternalId
+	}
+	return ""
+}
+
+func (x *InterbankNegotiationResponse) GetSellerRoutingNumber() int32 {
+	if x != nil {
+		return x.SellerRoutingNumber
+	}
+	return 0
+}
+
+func (x *InterbankNegotiationResponse) GetSellerExternalId() string {
+	if x != nil {
+		return x.SellerExternalId
+	}
+	return ""
+}
+
+type InterbankNegotiationIdRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	RoutingNumber int32                  `protobuf:"varint,1,opt,name=routing_number,json=routingNumber,proto3" json:"routing_number,omitempty"`
+	ExternalId    string                 `protobuf:"bytes,2,opt,name=external_id,json=externalId,proto3" json:"external_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *InterbankNegotiationIdRequest) Reset() {
+	*x = InterbankNegotiationIdRequest{}
+	mi := &file_otc_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InterbankNegotiationIdRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InterbankNegotiationIdRequest) ProtoMessage() {}
+
+func (x *InterbankNegotiationIdRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_otc_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InterbankNegotiationIdRequest.ProtoReflect.Descriptor instead.
+func (*InterbankNegotiationIdRequest) Descriptor() ([]byte, []int) {
+	return file_otc_proto_rawDescGZIP(), []int{21}
+}
+
+func (x *InterbankNegotiationIdRequest) GetRoutingNumber() int32 {
+	if x != nil {
+		return x.RoutingNumber
+	}
+	return 0
+}
+
+func (x *InterbankNegotiationIdRequest) GetExternalId() string {
+	if x != nil {
+		return x.ExternalId
+	}
+	return ""
+}
+
+type InterbankCounterOfferRequest struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	RoutingNumber  int32                  `protobuf:"varint,1,opt,name=routing_number,json=routingNumber,proto3" json:"routing_number,omitempty"`
+	ExternalId     string                 `protobuf:"bytes,2,opt,name=external_id,json=externalId,proto3" json:"external_id,omitempty"`
+	PricePerUnit   float64                `protobuf:"fixed64,3,opt,name=price_per_unit,json=pricePerUnit,proto3" json:"price_per_unit,omitempty"`
+	Premium        float64                `protobuf:"fixed64,4,opt,name=premium,proto3" json:"premium,omitempty"`
+	Amount         int32                  `protobuf:"varint,5,opt,name=amount,proto3" json:"amount,omitempty"`
+	SettlementDate string                 `protobuf:"bytes,6,opt,name=settlement_date,json=settlementDate,proto3" json:"settlement_date,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *InterbankCounterOfferRequest) Reset() {
+	*x = InterbankCounterOfferRequest{}
+	mi := &file_otc_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InterbankCounterOfferRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InterbankCounterOfferRequest) ProtoMessage() {}
+
+func (x *InterbankCounterOfferRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_otc_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InterbankCounterOfferRequest.ProtoReflect.Descriptor instead.
+func (*InterbankCounterOfferRequest) Descriptor() ([]byte, []int) {
+	return file_otc_proto_rawDescGZIP(), []int{22}
+}
+
+func (x *InterbankCounterOfferRequest) GetRoutingNumber() int32 {
+	if x != nil {
+		return x.RoutingNumber
+	}
+	return 0
+}
+
+func (x *InterbankCounterOfferRequest) GetExternalId() string {
+	if x != nil {
+		return x.ExternalId
+	}
+	return ""
+}
+
+func (x *InterbankCounterOfferRequest) GetPricePerUnit() float64 {
+	if x != nil {
+		return x.PricePerUnit
+	}
+	return 0
+}
+
+func (x *InterbankCounterOfferRequest) GetPremium() float64 {
+	if x != nil {
+		return x.Premium
+	}
+	return 0
+}
+
+func (x *InterbankCounterOfferRequest) GetAmount() int32 {
+	if x != nil {
+		return x.Amount
+	}
+	return 0
+}
+
+func (x *InterbankCounterOfferRequest) GetSettlementDate() string {
+	if x != nil {
+		return x.SettlementDate
+	}
+	return ""
+}
+
 var File_otc_proto protoreflect.FileDescriptor
 
 const file_otc_proto_rawDesc = "" +
@@ -1502,7 +1962,53 @@ const file_otc_proto_rawDesc = "" +
 	"owner_type\x18\n" +
 	" \x01(\tR\townerType\":\n" +
 	"\x11GetMarketResponse\x12%\n" +
-	"\x05items\x18\x01 \x03(\v2\x0f.otc.MarketItemR\x05items2\xd5\x05\n" +
+	"\x05items\x18\x01 \x03(\v2\x0f.otc.MarketItemR\x05items\"\x12\n" +
+	"\x10OtcEmptyResponse\"\xaa\x04\n" +
+	"!CreateInterbankNegotiationRequest\x12\x16\n" +
+	"\x06ticker\x18\x01 \x01(\tR\x06ticker\x12'\n" +
+	"\x0fsettlement_date\x18\x02 \x01(\tR\x0esettlementDate\x12$\n" +
+	"\x0eprice_per_unit\x18\x03 \x01(\x01R\fpricePerUnit\x12%\n" +
+	"\x0eprice_currency\x18\x04 \x01(\tR\rpriceCurrency\x12\x18\n" +
+	"\apremium\x18\x05 \x01(\x01R\apremium\x120\n" +
+	"\x14buyer_routing_number\x18\x06 \x01(\x05R\x12buyerRoutingNumber\x12*\n" +
+	"\x11buyer_external_id\x18\a \x01(\tR\x0fbuyerExternalId\x122\n" +
+	"\x15seller_routing_number\x18\b \x01(\x05R\x13sellerRoutingNumber\x12,\n" +
+	"\x12seller_external_id\x18\t \x01(\tR\x10sellerExternalId\x124\n" +
+	"\x16creator_routing_number\x18\n" +
+	" \x01(\x05R\x14creatorRoutingNumber\x12.\n" +
+	"\x13creator_external_id\x18\v \x01(\tR\x11creatorExternalId\x12\x16\n" +
+	"\x06amount\x18\f \x01(\x05R\x06amount\x12\x1f\n" +
+	"\vseller_type\x18\r \x01(\tR\n" +
+	"sellerType\"\xbe\x04\n" +
+	"\x1cInterbankNegotiationResponse\x12\x19\n" +
+	"\blocal_id\x18\x01 \x01(\x03R\alocalId\x124\n" +
+	"\x16creator_routing_number\x18\x02 \x01(\x05R\x14creatorRoutingNumber\x12.\n" +
+	"\x13creator_external_id\x18\x03 \x01(\tR\x11creatorExternalId\x12\x16\n" +
+	"\x06ticker\x18\x04 \x01(\tR\x06ticker\x12'\n" +
+	"\x0fsettlement_date\x18\x05 \x01(\tR\x0esettlementDate\x12$\n" +
+	"\x0eprice_per_unit\x18\x06 \x01(\x01R\fpricePerUnit\x12%\n" +
+	"\x0eprice_currency\x18\a \x01(\tR\rpriceCurrency\x12\x18\n" +
+	"\apremium\x18\b \x01(\x01R\apremium\x12\x16\n" +
+	"\x06amount\x18\t \x01(\x05R\x06amount\x12\x1d\n" +
+	"\n" +
+	"is_ongoing\x18\n" +
+	" \x01(\bR\tisOngoing\x120\n" +
+	"\x14buyer_routing_number\x18\v \x01(\x05R\x12buyerRoutingNumber\x12*\n" +
+	"\x11buyer_external_id\x18\f \x01(\tR\x0fbuyerExternalId\x122\n" +
+	"\x15seller_routing_number\x18\r \x01(\x05R\x13sellerRoutingNumber\x12,\n" +
+	"\x12seller_external_id\x18\x0e \x01(\tR\x10sellerExternalId\"g\n" +
+	"\x1dInterbankNegotiationIdRequest\x12%\n" +
+	"\x0erouting_number\x18\x01 \x01(\x05R\rroutingNumber\x12\x1f\n" +
+	"\vexternal_id\x18\x02 \x01(\tR\n" +
+	"externalId\"\xe7\x01\n" +
+	"\x1cInterbankCounterOfferRequest\x12%\n" +
+	"\x0erouting_number\x18\x01 \x01(\x05R\rroutingNumber\x12\x1f\n" +
+	"\vexternal_id\x18\x02 \x01(\tR\n" +
+	"externalId\x12$\n" +
+	"\x0eprice_per_unit\x18\x03 \x01(\x01R\fpricePerUnit\x12\x18\n" +
+	"\apremium\x18\x04 \x01(\x01R\apremium\x12\x16\n" +
+	"\x06amount\x18\x05 \x01(\x05R\x06amount\x12'\n" +
+	"\x0fsettlement_date\x18\x06 \x01(\tR\x0esettlementDate2\xb1\t\n" +
 	"\n" +
 	"OtcService\x12+\n" +
 	"\x04Ping\x12\x10.otc.PingRequest\x1a\x11.otc.PingResponse\x12L\n" +
@@ -1514,7 +2020,12 @@ const file_otc_proto_rawDesc = "" +
 	"\x11RejectNegotiation\x12\x1d.otc.RejectNegotiationRequest\x1a\x18.otc.NegotiationResponse\x12F\n" +
 	"\rListContracts\x12\x19.otc.ListContractsRequest\x1a\x1a.otc.ListContractsResponse\x12O\n" +
 	"\x10ExerciseContract\x12\x1c.otc.ExerciseContractRequest\x1a\x1d.otc.ExerciseContractResponse\x12:\n" +
-	"\tGetMarket\x12\x15.otc.GetMarketRequest\x1a\x16.otc.GetMarketResponseB8Z6github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/otcb\x06proto3"
+	"\tGetMarket\x12\x15.otc.GetMarketRequest\x1a\x16.otc.GetMarketResponse\x12g\n" +
+	"\x1aCreateInterbankNegotiation\x12&.otc.CreateInterbankNegotiationRequest\x1a!.otc.InterbankNegotiationResponse\x12]\n" +
+	"\x15InterbankCounterOffer\x12!.otc.InterbankCounterOfferRequest\x1a!.otc.InterbankNegotiationResponse\x12`\n" +
+	"\x17InterbankGetNegotiation\x12\".otc.InterbankNegotiationIdRequest\x1a!.otc.InterbankNegotiationResponse\x12W\n" +
+	"\x1aInterbankDeleteNegotiation\x12\".otc.InterbankNegotiationIdRequest\x1a\x15.otc.OtcEmptyResponse\x12W\n" +
+	"\x1aInterbankAcceptNegotiation\x12\".otc.InterbankNegotiationIdRequest\x1a\x15.otc.OtcEmptyResponseB8Z6github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/otcb\x06proto3"
 
 var (
 	file_otc_proto_rawDescOnce sync.Once
@@ -1528,26 +2039,31 @@ func file_otc_proto_rawDescGZIP() []byte {
 	return file_otc_proto_rawDescData
 }
 
-var file_otc_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
+var file_otc_proto_msgTypes = make([]protoimpl.MessageInfo, 23)
 var file_otc_proto_goTypes = []any{
-	(*PingRequest)(nil),              // 0: otc.PingRequest
-	(*PingResponse)(nil),             // 1: otc.PingResponse
-	(*CreateNegotiationRequest)(nil), // 2: otc.CreateNegotiationRequest
-	(*CounterOfferRequest)(nil),      // 3: otc.CounterOfferRequest
-	(*AcceptNegotiationRequest)(nil), // 4: otc.AcceptNegotiationRequest
-	(*RejectNegotiationRequest)(nil), // 5: otc.RejectNegotiationRequest
-	(*ListNegotiationsRequest)(nil),  // 6: otc.ListNegotiationsRequest
-	(*GetNegotiationRequest)(nil),    // 7: otc.GetNegotiationRequest
-	(*NegotiationResponse)(nil),      // 8: otc.NegotiationResponse
-	(*ListNegotiationsResponse)(nil), // 9: otc.ListNegotiationsResponse
-	(*ContractResponse)(nil),         // 10: otc.ContractResponse
-	(*ListContractsRequest)(nil),     // 11: otc.ListContractsRequest
-	(*ListContractsResponse)(nil),    // 12: otc.ListContractsResponse
-	(*ExerciseContractRequest)(nil),  // 13: otc.ExerciseContractRequest
-	(*ExerciseContractResponse)(nil), // 14: otc.ExerciseContractResponse
-	(*GetMarketRequest)(nil),         // 15: otc.GetMarketRequest
-	(*MarketItem)(nil),               // 16: otc.MarketItem
-	(*GetMarketResponse)(nil),        // 17: otc.GetMarketResponse
+	(*PingRequest)(nil),                       // 0: otc.PingRequest
+	(*PingResponse)(nil),                      // 1: otc.PingResponse
+	(*CreateNegotiationRequest)(nil),          // 2: otc.CreateNegotiationRequest
+	(*CounterOfferRequest)(nil),               // 3: otc.CounterOfferRequest
+	(*AcceptNegotiationRequest)(nil),          // 4: otc.AcceptNegotiationRequest
+	(*RejectNegotiationRequest)(nil),          // 5: otc.RejectNegotiationRequest
+	(*ListNegotiationsRequest)(nil),           // 6: otc.ListNegotiationsRequest
+	(*GetNegotiationRequest)(nil),             // 7: otc.GetNegotiationRequest
+	(*NegotiationResponse)(nil),               // 8: otc.NegotiationResponse
+	(*ListNegotiationsResponse)(nil),          // 9: otc.ListNegotiationsResponse
+	(*ContractResponse)(nil),                  // 10: otc.ContractResponse
+	(*ListContractsRequest)(nil),              // 11: otc.ListContractsRequest
+	(*ListContractsResponse)(nil),             // 12: otc.ListContractsResponse
+	(*ExerciseContractRequest)(nil),           // 13: otc.ExerciseContractRequest
+	(*ExerciseContractResponse)(nil),          // 14: otc.ExerciseContractResponse
+	(*GetMarketRequest)(nil),                  // 15: otc.GetMarketRequest
+	(*MarketItem)(nil),                        // 16: otc.MarketItem
+	(*GetMarketResponse)(nil),                 // 17: otc.GetMarketResponse
+	(*OtcEmptyResponse)(nil),                  // 18: otc.OtcEmptyResponse
+	(*CreateInterbankNegotiationRequest)(nil), // 19: otc.CreateInterbankNegotiationRequest
+	(*InterbankNegotiationResponse)(nil),      // 20: otc.InterbankNegotiationResponse
+	(*InterbankNegotiationIdRequest)(nil),     // 21: otc.InterbankNegotiationIdRequest
+	(*InterbankCounterOfferRequest)(nil),      // 22: otc.InterbankCounterOfferRequest
 }
 var file_otc_proto_depIdxs = []int32{
 	8,  // 0: otc.ListNegotiationsResponse.negotiations:type_name -> otc.NegotiationResponse
@@ -1563,18 +2079,28 @@ var file_otc_proto_depIdxs = []int32{
 	11, // 10: otc.OtcService.ListContracts:input_type -> otc.ListContractsRequest
 	13, // 11: otc.OtcService.ExerciseContract:input_type -> otc.ExerciseContractRequest
 	15, // 12: otc.OtcService.GetMarket:input_type -> otc.GetMarketRequest
-	1,  // 13: otc.OtcService.Ping:output_type -> otc.PingResponse
-	8,  // 14: otc.OtcService.CreateNegotiation:output_type -> otc.NegotiationResponse
-	9,  // 15: otc.OtcService.ListNegotiations:output_type -> otc.ListNegotiationsResponse
-	8,  // 16: otc.OtcService.GetNegotiation:output_type -> otc.NegotiationResponse
-	8,  // 17: otc.OtcService.CounterOffer:output_type -> otc.NegotiationResponse
-	8,  // 18: otc.OtcService.AcceptNegotiation:output_type -> otc.NegotiationResponse
-	8,  // 19: otc.OtcService.RejectNegotiation:output_type -> otc.NegotiationResponse
-	12, // 20: otc.OtcService.ListContracts:output_type -> otc.ListContractsResponse
-	14, // 21: otc.OtcService.ExerciseContract:output_type -> otc.ExerciseContractResponse
-	17, // 22: otc.OtcService.GetMarket:output_type -> otc.GetMarketResponse
-	13, // [13:23] is the sub-list for method output_type
-	3,  // [3:13] is the sub-list for method input_type
+	19, // 13: otc.OtcService.CreateInterbankNegotiation:input_type -> otc.CreateInterbankNegotiationRequest
+	22, // 14: otc.OtcService.InterbankCounterOffer:input_type -> otc.InterbankCounterOfferRequest
+	21, // 15: otc.OtcService.InterbankGetNegotiation:input_type -> otc.InterbankNegotiationIdRequest
+	21, // 16: otc.OtcService.InterbankDeleteNegotiation:input_type -> otc.InterbankNegotiationIdRequest
+	21, // 17: otc.OtcService.InterbankAcceptNegotiation:input_type -> otc.InterbankNegotiationIdRequest
+	1,  // 18: otc.OtcService.Ping:output_type -> otc.PingResponse
+	8,  // 19: otc.OtcService.CreateNegotiation:output_type -> otc.NegotiationResponse
+	9,  // 20: otc.OtcService.ListNegotiations:output_type -> otc.ListNegotiationsResponse
+	8,  // 21: otc.OtcService.GetNegotiation:output_type -> otc.NegotiationResponse
+	8,  // 22: otc.OtcService.CounterOffer:output_type -> otc.NegotiationResponse
+	8,  // 23: otc.OtcService.AcceptNegotiation:output_type -> otc.NegotiationResponse
+	8,  // 24: otc.OtcService.RejectNegotiation:output_type -> otc.NegotiationResponse
+	12, // 25: otc.OtcService.ListContracts:output_type -> otc.ListContractsResponse
+	14, // 26: otc.OtcService.ExerciseContract:output_type -> otc.ExerciseContractResponse
+	17, // 27: otc.OtcService.GetMarket:output_type -> otc.GetMarketResponse
+	20, // 28: otc.OtcService.CreateInterbankNegotiation:output_type -> otc.InterbankNegotiationResponse
+	20, // 29: otc.OtcService.InterbankCounterOffer:output_type -> otc.InterbankNegotiationResponse
+	20, // 30: otc.OtcService.InterbankGetNegotiation:output_type -> otc.InterbankNegotiationResponse
+	18, // 31: otc.OtcService.InterbankDeleteNegotiation:output_type -> otc.OtcEmptyResponse
+	18, // 32: otc.OtcService.InterbankAcceptNegotiation:output_type -> otc.OtcEmptyResponse
+	18, // [18:33] is the sub-list for method output_type
+	3,  // [3:18] is the sub-list for method input_type
 	3,  // [3:3] is the sub-list for extension type_name
 	3,  // [3:3] is the sub-list for extension extendee
 	0,  // [0:3] is the sub-list for field type_name
@@ -1591,7 +2117,7 @@ func file_otc_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_otc_proto_rawDesc), len(file_otc_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   18,
+			NumMessages:   23,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/shared/pb/otc/otc_grpc.pb.go
+++ b/shared/pb/otc/otc_grpc.pb.go
@@ -19,16 +19,21 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	OtcService_Ping_FullMethodName              = "/otc.OtcService/Ping"
-	OtcService_CreateNegotiation_FullMethodName = "/otc.OtcService/CreateNegotiation"
-	OtcService_ListNegotiations_FullMethodName  = "/otc.OtcService/ListNegotiations"
-	OtcService_GetNegotiation_FullMethodName    = "/otc.OtcService/GetNegotiation"
-	OtcService_CounterOffer_FullMethodName      = "/otc.OtcService/CounterOffer"
-	OtcService_AcceptNegotiation_FullMethodName = "/otc.OtcService/AcceptNegotiation"
-	OtcService_RejectNegotiation_FullMethodName = "/otc.OtcService/RejectNegotiation"
-	OtcService_ListContracts_FullMethodName     = "/otc.OtcService/ListContracts"
-	OtcService_ExerciseContract_FullMethodName  = "/otc.OtcService/ExerciseContract"
-	OtcService_GetMarket_FullMethodName         = "/otc.OtcService/GetMarket"
+	OtcService_Ping_FullMethodName                       = "/otc.OtcService/Ping"
+	OtcService_CreateNegotiation_FullMethodName          = "/otc.OtcService/CreateNegotiation"
+	OtcService_ListNegotiations_FullMethodName           = "/otc.OtcService/ListNegotiations"
+	OtcService_GetNegotiation_FullMethodName             = "/otc.OtcService/GetNegotiation"
+	OtcService_CounterOffer_FullMethodName               = "/otc.OtcService/CounterOffer"
+	OtcService_AcceptNegotiation_FullMethodName          = "/otc.OtcService/AcceptNegotiation"
+	OtcService_RejectNegotiation_FullMethodName          = "/otc.OtcService/RejectNegotiation"
+	OtcService_ListContracts_FullMethodName              = "/otc.OtcService/ListContracts"
+	OtcService_ExerciseContract_FullMethodName           = "/otc.OtcService/ExerciseContract"
+	OtcService_GetMarket_FullMethodName                  = "/otc.OtcService/GetMarket"
+	OtcService_CreateInterbankNegotiation_FullMethodName = "/otc.OtcService/CreateInterbankNegotiation"
+	OtcService_InterbankCounterOffer_FullMethodName      = "/otc.OtcService/InterbankCounterOffer"
+	OtcService_InterbankGetNegotiation_FullMethodName    = "/otc.OtcService/InterbankGetNegotiation"
+	OtcService_InterbankDeleteNegotiation_FullMethodName = "/otc.OtcService/InterbankDeleteNegotiation"
+	OtcService_InterbankAcceptNegotiation_FullMethodName = "/otc.OtcService/InterbankAcceptNegotiation"
 )
 
 // OtcServiceClient is the client API for OtcService service.
@@ -45,6 +50,12 @@ type OtcServiceClient interface {
 	ListContracts(ctx context.Context, in *ListContractsRequest, opts ...grpc.CallOption) (*ListContractsResponse, error)
 	ExerciseContract(ctx context.Context, in *ExerciseContractRequest, opts ...grpc.CallOption) (*ExerciseContractResponse, error)
 	GetMarket(ctx context.Context, in *GetMarketRequest, opts ...grpc.CallOption) (*GetMarketResponse, error)
+	// Cross-bank (interbank) negotiation RPCs
+	CreateInterbankNegotiation(ctx context.Context, in *CreateInterbankNegotiationRequest, opts ...grpc.CallOption) (*InterbankNegotiationResponse, error)
+	InterbankCounterOffer(ctx context.Context, in *InterbankCounterOfferRequest, opts ...grpc.CallOption) (*InterbankNegotiationResponse, error)
+	InterbankGetNegotiation(ctx context.Context, in *InterbankNegotiationIdRequest, opts ...grpc.CallOption) (*InterbankNegotiationResponse, error)
+	InterbankDeleteNegotiation(ctx context.Context, in *InterbankNegotiationIdRequest, opts ...grpc.CallOption) (*OtcEmptyResponse, error)
+	InterbankAcceptNegotiation(ctx context.Context, in *InterbankNegotiationIdRequest, opts ...grpc.CallOption) (*OtcEmptyResponse, error)
 }
 
 type otcServiceClient struct {
@@ -155,6 +166,56 @@ func (c *otcServiceClient) GetMarket(ctx context.Context, in *GetMarketRequest, 
 	return out, nil
 }
 
+func (c *otcServiceClient) CreateInterbankNegotiation(ctx context.Context, in *CreateInterbankNegotiationRequest, opts ...grpc.CallOption) (*InterbankNegotiationResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(InterbankNegotiationResponse)
+	err := c.cc.Invoke(ctx, OtcService_CreateInterbankNegotiation_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *otcServiceClient) InterbankCounterOffer(ctx context.Context, in *InterbankCounterOfferRequest, opts ...grpc.CallOption) (*InterbankNegotiationResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(InterbankNegotiationResponse)
+	err := c.cc.Invoke(ctx, OtcService_InterbankCounterOffer_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *otcServiceClient) InterbankGetNegotiation(ctx context.Context, in *InterbankNegotiationIdRequest, opts ...grpc.CallOption) (*InterbankNegotiationResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(InterbankNegotiationResponse)
+	err := c.cc.Invoke(ctx, OtcService_InterbankGetNegotiation_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *otcServiceClient) InterbankDeleteNegotiation(ctx context.Context, in *InterbankNegotiationIdRequest, opts ...grpc.CallOption) (*OtcEmptyResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(OtcEmptyResponse)
+	err := c.cc.Invoke(ctx, OtcService_InterbankDeleteNegotiation_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *otcServiceClient) InterbankAcceptNegotiation(ctx context.Context, in *InterbankNegotiationIdRequest, opts ...grpc.CallOption) (*OtcEmptyResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(OtcEmptyResponse)
+	err := c.cc.Invoke(ctx, OtcService_InterbankAcceptNegotiation_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // OtcServiceServer is the server API for OtcService service.
 // All implementations must embed UnimplementedOtcServiceServer
 // for forward compatibility.
@@ -169,6 +230,12 @@ type OtcServiceServer interface {
 	ListContracts(context.Context, *ListContractsRequest) (*ListContractsResponse, error)
 	ExerciseContract(context.Context, *ExerciseContractRequest) (*ExerciseContractResponse, error)
 	GetMarket(context.Context, *GetMarketRequest) (*GetMarketResponse, error)
+	// Cross-bank (interbank) negotiation RPCs
+	CreateInterbankNegotiation(context.Context, *CreateInterbankNegotiationRequest) (*InterbankNegotiationResponse, error)
+	InterbankCounterOffer(context.Context, *InterbankCounterOfferRequest) (*InterbankNegotiationResponse, error)
+	InterbankGetNegotiation(context.Context, *InterbankNegotiationIdRequest) (*InterbankNegotiationResponse, error)
+	InterbankDeleteNegotiation(context.Context, *InterbankNegotiationIdRequest) (*OtcEmptyResponse, error)
+	InterbankAcceptNegotiation(context.Context, *InterbankNegotiationIdRequest) (*OtcEmptyResponse, error)
 	mustEmbedUnimplementedOtcServiceServer()
 }
 
@@ -208,6 +275,21 @@ func (UnimplementedOtcServiceServer) ExerciseContract(context.Context, *Exercise
 }
 func (UnimplementedOtcServiceServer) GetMarket(context.Context, *GetMarketRequest) (*GetMarketResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetMarket not implemented")
+}
+func (UnimplementedOtcServiceServer) CreateInterbankNegotiation(context.Context, *CreateInterbankNegotiationRequest) (*InterbankNegotiationResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method CreateInterbankNegotiation not implemented")
+}
+func (UnimplementedOtcServiceServer) InterbankCounterOffer(context.Context, *InterbankCounterOfferRequest) (*InterbankNegotiationResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method InterbankCounterOffer not implemented")
+}
+func (UnimplementedOtcServiceServer) InterbankGetNegotiation(context.Context, *InterbankNegotiationIdRequest) (*InterbankNegotiationResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method InterbankGetNegotiation not implemented")
+}
+func (UnimplementedOtcServiceServer) InterbankDeleteNegotiation(context.Context, *InterbankNegotiationIdRequest) (*OtcEmptyResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method InterbankDeleteNegotiation not implemented")
+}
+func (UnimplementedOtcServiceServer) InterbankAcceptNegotiation(context.Context, *InterbankNegotiationIdRequest) (*OtcEmptyResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method InterbankAcceptNegotiation not implemented")
 }
 func (UnimplementedOtcServiceServer) mustEmbedUnimplementedOtcServiceServer() {}
 func (UnimplementedOtcServiceServer) testEmbeddedByValue()                    {}
@@ -410,6 +492,96 @@ func _OtcService_GetMarket_Handler(srv interface{}, ctx context.Context, dec fun
 	return interceptor(ctx, in, info, handler)
 }
 
+func _OtcService_CreateInterbankNegotiation_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CreateInterbankNegotiationRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(OtcServiceServer).CreateInterbankNegotiation(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: OtcService_CreateInterbankNegotiation_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(OtcServiceServer).CreateInterbankNegotiation(ctx, req.(*CreateInterbankNegotiationRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _OtcService_InterbankCounterOffer_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(InterbankCounterOfferRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(OtcServiceServer).InterbankCounterOffer(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: OtcService_InterbankCounterOffer_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(OtcServiceServer).InterbankCounterOffer(ctx, req.(*InterbankCounterOfferRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _OtcService_InterbankGetNegotiation_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(InterbankNegotiationIdRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(OtcServiceServer).InterbankGetNegotiation(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: OtcService_InterbankGetNegotiation_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(OtcServiceServer).InterbankGetNegotiation(ctx, req.(*InterbankNegotiationIdRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _OtcService_InterbankDeleteNegotiation_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(InterbankNegotiationIdRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(OtcServiceServer).InterbankDeleteNegotiation(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: OtcService_InterbankDeleteNegotiation_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(OtcServiceServer).InterbankDeleteNegotiation(ctx, req.(*InterbankNegotiationIdRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _OtcService_InterbankAcceptNegotiation_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(InterbankNegotiationIdRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(OtcServiceServer).InterbankAcceptNegotiation(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: OtcService_InterbankAcceptNegotiation_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(OtcServiceServer).InterbankAcceptNegotiation(ctx, req.(*InterbankNegotiationIdRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // OtcService_ServiceDesc is the grpc.ServiceDesc for OtcService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -456,6 +628,26 @@ var OtcService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetMarket",
 			Handler:    _OtcService_GetMarket_Handler,
+		},
+		{
+			MethodName: "CreateInterbankNegotiation",
+			Handler:    _OtcService_CreateInterbankNegotiation_Handler,
+		},
+		{
+			MethodName: "InterbankCounterOffer",
+			Handler:    _OtcService_InterbankCounterOffer_Handler,
+		},
+		{
+			MethodName: "InterbankGetNegotiation",
+			Handler:    _OtcService_InterbankGetNegotiation_Handler,
+		},
+		{
+			MethodName: "InterbankDeleteNegotiation",
+			Handler:    _OtcService_InterbankDeleteNegotiation_Handler,
+		},
+		{
+			MethodName: "InterbankAcceptNegotiation",
+			Handler:    _OtcService_InterbankAcceptNegotiation_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/shared/proto/otc.proto
+++ b/shared/proto/otc.proto
@@ -13,6 +13,12 @@ service OtcService {
   rpc ListContracts(ListContractsRequest) returns (ListContractsResponse);
   rpc ExerciseContract(ExerciseContractRequest) returns (ExerciseContractResponse);
   rpc GetMarket(GetMarketRequest) returns (GetMarketResponse);
+  // Cross-bank (interbank) negotiation RPCs
+  rpc CreateInterbankNegotiation(CreateInterbankNegotiationRequest) returns (InterbankNegotiationResponse);
+  rpc InterbankCounterOffer(InterbankCounterOfferRequest)           returns (InterbankNegotiationResponse);
+  rpc InterbankGetNegotiation(InterbankNegotiationIdRequest)        returns (InterbankNegotiationResponse);
+  rpc InterbankDeleteNegotiation(InterbankNegotiationIdRequest)     returns (OtcEmptyResponse);
+  rpc InterbankAcceptNegotiation(InterbankNegotiationIdRequest)     returns (OtcEmptyResponse);
 }
 
 message PingRequest {}
@@ -146,4 +152,55 @@ message MarketItem {
 }
 message GetMarketResponse {
   repeated MarketItem items = 1;
+}
+
+// ── Cross-bank (interbank) negotiation messages ──────────────────────────────
+
+message OtcEmptyResponse {}
+
+message CreateInterbankNegotiationRequest {
+  string ticker                 = 1;
+  string settlement_date        = 2;
+  double price_per_unit         = 3;
+  string price_currency         = 4;
+  double premium                = 5;
+  int32  buyer_routing_number   = 6;
+  string buyer_external_id      = 7;
+  int32  seller_routing_number  = 8;
+  string seller_external_id     = 9;
+  int32  creator_routing_number = 10;
+  string creator_external_id    = 11;
+  int32  amount                 = 12;
+  string seller_type            = 13; // CLIENT or EMPLOYEE; defaults to CLIENT if empty
+}
+
+message InterbankNegotiationResponse {
+  int64  local_id               = 1;
+  int32  creator_routing_number = 2;
+  string creator_external_id    = 3;
+  string ticker                 = 4;
+  string settlement_date        = 5;
+  double price_per_unit         = 6;
+  string price_currency         = 7;
+  double premium                = 8;
+  int32  amount                 = 9;
+  bool   is_ongoing             = 10;
+  int32  buyer_routing_number   = 11;
+  string buyer_external_id      = 12;
+  int32  seller_routing_number  = 13;
+  string seller_external_id     = 14;
+}
+
+message InterbankNegotiationIdRequest {
+  int32  routing_number = 1;
+  string external_id    = 2;
+}
+
+message InterbankCounterOfferRequest {
+  int32  routing_number   = 1;
+  string external_id      = 2;
+  double price_per_unit   = 3;
+  double premium          = 4;
+  int32  amount           = 5;
+  string settlement_date  = 6;
 }


### PR DESCRIPTION
…k endpoints

- payment-service: execute full Two-Phase Commit when recipient is at a partner bank (NEW_TX → vote → COMMIT_TX / ROLLBACK_TX); fund reservation on prepare, debit on commit
- otc-service: add cross-bank columns to schema, 5 new gRPC methods (CreateInterbank, CounterOffer, Get, Delete, Accept), idempotency via (creator_routing_number, creator_external_id)
- api-gateway: new interbank routing package, otc_interbank.go handlers for all 5 incoming partner endpoints (X-Api-Key auth, no JWT), routes registered before JWT middleware
- proto: add interbank negotiation messages and RPCs; regenerate pb files