### PR TITLE
feat(#218): add payment preview endpoint for cross-bank fee/rate

### DIFF
--- a/services/api-gateway/handlers/otc_interbank.go
+++ b/services/api-gateway/handlers/otc_interbank.go
@@ -41,25 +41,29 @@ type otcMoneyAmount struct {
 }
 
 type otcNegotiationBody struct {
-	Stock          struct{ Ticker string `json:"ticker"` } `json:"stock"`
-	SettlementDate string                                   `json:"settlementDate"`
-	PricePerUnit   otcMoneyAmount                           `json:"pricePerUnit"`
-	Premium        otcMoneyAmount                           `json:"premium"`
-	BuyerID        otcPartyID                               `json:"buyerId"`
-	SellerID       otcPartyID                               `json:"sellerId"`
-	Amount         int32                                    `json:"amount"`
-	SellerType     string                                   `json:"sellerType"`
+	Stock struct {
+		Ticker string `json:"ticker"`
+	} `json:"stock"`
+	SettlementDate string         `json:"settlementDate"`
+	PricePerUnit   otcMoneyAmount `json:"pricePerUnit"`
+	Premium        otcMoneyAmount `json:"premium"`
+	BuyerID        otcPartyID     `json:"buyerId"`
+	SellerID       otcPartyID     `json:"sellerId"`
+	Amount         int32          `json:"amount"`
+	SellerType     string         `json:"sellerType"`
 }
 
 type otcNegotiationResponse struct {
-	Stock          struct{ Ticker string `json:"ticker"` } `json:"stock"`
-	SettlementDate string                                   `json:"settlementDate"`
-	PricePerUnit   otcMoneyAmount                           `json:"pricePerUnit"`
-	Premium        otcMoneyAmount                           `json:"premium"`
-	BuyerID        otcPartyID                               `json:"buyerId"`
-	SellerID       otcPartyID                               `json:"sellerId"`
-	Amount         int32                                    `json:"amount"`
-	IsOngoing      bool                                     `json:"isOngoing"`
+	Stock struct {
+		Ticker string `json:"ticker"`
+	} `json:"stock"`
+	SettlementDate string         `json:"settlementDate"`
+	PricePerUnit   otcMoneyAmount `json:"pricePerUnit"`
+	Premium        otcMoneyAmount `json:"premium"`
+	BuyerID        otcPartyID     `json:"buyerId"`
+	SellerID       otcPartyID     `json:"sellerId"`
+	Amount         int32          `json:"amount"`
+	IsOngoing      bool           `json:"isOngoing"`
 }
 
 func interbankNegToJSON(n *pb.InterbankNegotiationResponse) otcNegotiationResponse {

--- a/services/api-gateway/handlers/payments.go
+++ b/services/api-gateway/handlers/payments.go
@@ -91,6 +91,56 @@ func CreatePayment(paymentClient pb.PaymentServiceClient) gin.HandlerFunc {
 	}
 }
 
+// PreviewPayment returns the estimated exchange rate and fee for a payment before confirmation.
+func PreviewPayment(paymentClient pb.PaymentServiceClient) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var req struct {
+			FromAccount      string  `json:"fromAccount"      binding:"required"`
+			RecipientAccount string  `json:"recipientAccount" binding:"required"`
+			Amount           float64 `json:"amount"           binding:"required,gt=0"`
+		}
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+
+		clientID, err := middleware.GetUserIDFromToken(c)
+		if err != nil {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "could not extract identity from token"})
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 15*time.Second)
+		defer cancel()
+
+		resp, err := paymentClient.PreviewPayment(ctx, &pb.PreviewPaymentRequest{
+			ClientId:         clientID,
+			FromAccount:      req.FromAccount,
+			RecipientAccount: req.RecipientAccount,
+			Amount:           req.Amount,
+		})
+		if err != nil {
+			switch status.Code(err) {
+			case codes.NotFound:
+				c.JSON(http.StatusNotFound, gin.H{"error": status.Convert(err).Message()})
+			case codes.PermissionDenied:
+				c.JSON(http.StatusForbidden, gin.H{"error": status.Convert(err).Message()})
+			default:
+				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			}
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{
+			"isCrossBank":  resp.IsCrossBank,
+			"exchangeRate": resp.ExchangeRate,
+			"fee":          resp.Fee,
+			"finalAmount":  resp.FinalAmount,
+			"fromCurrency": resp.FromCurrency,
+		})
+	}
+}
+
 type CreatePaymentRecipientRequest struct {
 	Name          string `json:"name"          binding:"required"`
 	AccountNumber string `json:"accountNumber" binding:"required"`

--- a/services/api-gateway/main.go
+++ b/services/api-gateway/main.go
@@ -158,6 +158,7 @@ func main() {
 	r.POST("/bank/profit/fund-positions/:fundId/invest", middleware.RequireRole("SUPERVISOR"), handlers.BankInvestFund(fundClient))
 	r.POST("/bank/profit/fund-positions/:fundId/redeem", middleware.RequireRole("SUPERVISOR"), handlers.BankRedeemFund(fundClient))
 	r.POST("/api/payments/create", handlers.CreatePayment(paymentClient))
+	r.POST("/api/payments/preview", handlers.PreviewPayment(paymentClient))
 	r.GET("/api/payments", handlers.GetPayments(paymentClient))
 	r.GET("/api/payments/:paymentId", handlers.GetPaymentById(paymentClient))
 	r.POST("/api/transfers", handlers.CreateTransfer(paymentClient))

--- a/services/payment-service/handlers/interbank_outgoing.go
+++ b/services/payment-service/handlers/interbank_outgoing.go
@@ -60,8 +60,11 @@ type ibEnvelope struct {
 }
 
 type ibVoteResponse struct {
-	Vote    string   `json:"vote"`
-	Reasons []string `json:"reasons"`
+	Vote         string   `json:"vote"`
+	Reasons      []string `json:"reasons"`
+	ExchangeRate float64  `json:"exchange_rate,omitempty"`
+	Fee          float64  `json:"fee,omitempty"`
+	FinalAmount  float64  `json:"final_amount,omitempty"`
 }
 
 // generateUUID returns a random UUID v4 string without external deps.

--- a/services/payment-service/handlers/preview.go
+++ b/services/payment-service/handlers/preview.go
@@ -1,0 +1,200 @@
+package handlers
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"math"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-4-Backend/services/payment-service/interbank"
+	pb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/payment"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func (s *PaymentServer) PreviewPayment(ctx context.Context, req *pb.PreviewPaymentRequest) (*pb.PreviewPaymentResponse, error) {
+	req.FromAccount = strings.ReplaceAll(req.FromAccount, "-", "")
+	req.RecipientAccount = strings.ReplaceAll(req.RecipientAccount, "-", "")
+
+	var ownerID, fromCurrencyID int64
+	if err := s.AccountDB.QueryRowContext(ctx,
+		`SELECT owner_id, currency_id FROM accounts WHERE account_number = $1`,
+		req.FromAccount,
+	).Scan(&ownerID, &fromCurrencyID); err == sql.ErrNoRows {
+		return nil, status.Errorf(codes.NotFound, "source account not found")
+	} else if err != nil {
+		return nil, status.Errorf(codes.Internal, "load source account: %v", err)
+	}
+	if ownerID != req.ClientId {
+		return nil, status.Errorf(codes.PermissionDenied, "account does not belong to this client")
+	}
+
+	var fromCurrencyCode string
+	if err := s.ExchangeDB.QueryRowContext(ctx,
+		`SELECT code FROM currencies WHERE id = $1`, fromCurrencyID,
+	).Scan(&fromCurrencyCode); err != nil {
+		return nil, status.Errorf(codes.Internal, "resolve source currency: %v", err)
+	}
+
+	routingNum := interbank.ExtractRoutingNumber(req.RecipientAccount)
+
+	if !interbank.IsOwnBank(routingNum) {
+		return s.previewCrossBank(ctx, req, fromCurrencyCode, routingNum)
+	}
+	return s.previewOwnBank(ctx, req, fromCurrencyID, fromCurrencyCode)
+}
+
+// previewCrossBank probes the partner bank with a NEW_TX and immediately rolls it back,
+// returning whatever rate/fee the partner quoted. Falls back gracefully on any error.
+func (s *PaymentServer) previewCrossBank(ctx context.Context, req *pb.PreviewPaymentRequest, fromCurrencyCode, routingNum string) (*pb.PreviewPaymentResponse, error) {
+	fallback := &pb.PreviewPaymentResponse{
+		IsCrossBank:  true,
+		ExchangeRate: 0,
+		Fee:          0,
+		FinalAmount:  req.Amount,
+		FromCurrency: fromCurrencyCode,
+	}
+
+	bank, err := interbank.ResolveBankByRoutingNumber(routingNum)
+	if err != nil || bank.BankURL == "" {
+		return fallback, nil
+	}
+	bankURL := bank.BankURL + "/interbank"
+
+	ownRouting := ownRoutingInt()
+	txID := ibTransactionID{RoutingNumber: ownRouting, ID: generateUUID()}
+	idemKey := ibIdempotenceKey{RoutingNumber: ownRouting, LocallyGeneratedKey: generateUUID()}
+
+	probeCtx, cancel := context.WithTimeout(ctx, interbankTimeout)
+	defer cancel()
+
+	probeResp, probeErr := sendInterbankRequest(probeCtx, bankURL, bank.APIKey, ibEnvelope{
+		IdempotenceKey: idemKey,
+		MessageType:    "NEW_TX",
+		Message: ibNewTxMessage{
+			TransactionID: txID,
+			Postings: []ibPosting{
+				{AccountType: "ACCOUNT", AccountNum: req.FromAccount, Amount: -req.Amount, AssetType: "MONAS", Currency: fromCurrencyCode},
+				{AccountType: "ACCOUNT", AccountNum: req.RecipientAccount, Amount: req.Amount, AssetType: "MONAS", Currency: fromCurrencyCode},
+			},
+		},
+	})
+
+	// Always roll back — we must not leave a dangling PENDING on the partner side
+	sendRollback(ctx, bankURL, bank.APIKey, txID)
+
+	if probeErr != nil || probeResp.StatusCode != http.StatusOK {
+		return fallback, nil
+	}
+	defer probeResp.Body.Close()
+
+	var vote ibVoteResponse
+	if err := json.NewDecoder(probeResp.Body).Decode(&vote); err != nil || vote.Vote != "YES" {
+		return fallback, nil
+	}
+
+	finalAmount := vote.FinalAmount
+	if finalAmount == 0 {
+		finalAmount = req.Amount - vote.Fee
+	}
+	if finalAmount <= 0 {
+		finalAmount = req.Amount
+	}
+	return &pb.PreviewPaymentResponse{
+		IsCrossBank:  true,
+		ExchangeRate: vote.ExchangeRate,
+		Fee:          vote.Fee,
+		FinalAmount:  finalAmount,
+		FromCurrency: fromCurrencyCode,
+	}, nil
+}
+
+// previewOwnBank calculates rate/fee for a same-bank payment (may still be cross-currency).
+func (s *PaymentServer) previewOwnBank(ctx context.Context, req *pb.PreviewPaymentRequest, fromCurrencyID int64, fromCurrencyCode string) (*pb.PreviewPaymentResponse, error) {
+	var toCurrencyID int64
+	err := s.AccountDB.QueryRowContext(ctx,
+		`SELECT currency_id FROM accounts WHERE account_number = $1`,
+		req.RecipientAccount,
+	).Scan(&toCurrencyID)
+	if err == sql.ErrNoRows || toCurrencyID == fromCurrencyID {
+		return &pb.PreviewPaymentResponse{
+			IsCrossBank:  false,
+			ExchangeRate: 1,
+			Fee:          0,
+			FinalAmount:  req.Amount,
+			FromCurrency: fromCurrencyCode,
+		}, nil
+	}
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "look up recipient: %v", err)
+	}
+
+	var toCurrencyCode string
+	if err := s.ExchangeDB.QueryRowContext(ctx,
+		`SELECT code FROM currencies WHERE id = $1`, toCurrencyID,
+	).Scan(&toCurrencyCode); err != nil {
+		return nil, status.Errorf(codes.Internal, "resolve destination currency: %v", err)
+	}
+
+	const commission = 0.005
+	today := time.Now().Format("2006-01-02")
+	getRate := func(code, rateType string) (float64, error) {
+		if code == "RSD" {
+			return 1.0, nil
+		}
+		var r float64
+		e := s.ExchangeDB.QueryRowContext(ctx,
+			`SELECT `+rateType+` FROM daily_exchange_rates WHERE currency_code = $1 AND date = $2`,
+			code, today,
+		).Scan(&r)
+		if e == sql.ErrNoRows {
+			e = s.ExchangeDB.QueryRowContext(ctx,
+				`SELECT rate FROM exchange_rates WHERE from_currency = $1 AND to_currency = 'RSD'`,
+				code,
+			).Scan(&r)
+		}
+		return r, e
+	}
+
+	var exchangeRate, finalAmount float64
+	finalAmount = req.Amount
+	switch {
+	case fromCurrencyCode == "RSD":
+		toSelling, err := getRate(toCurrencyCode, "selling_rate")
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "get rate for %s: %v", toCurrencyCode, err)
+		}
+		finalAmount = (req.Amount / toSelling) * (1 - commission)
+		exchangeRate = 1 / toSelling
+	case toCurrencyCode == "RSD":
+		fromBuying, err := getRate(fromCurrencyCode, "buying_rate")
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "get rate for %s: %v", fromCurrencyCode, err)
+		}
+		finalAmount = req.Amount * fromBuying * (1 - commission)
+		exchangeRate = fromBuying
+	default:
+		fromBuying, err := getRate(fromCurrencyCode, "buying_rate")
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "get rate for %s: %v", fromCurrencyCode, err)
+		}
+		toSelling, err := getRate(toCurrencyCode, "selling_rate")
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "get rate for %s: %v", toCurrencyCode, err)
+		}
+		rsdAmount := req.Amount * fromBuying * (1 - commission)
+		finalAmount = (rsdAmount / toSelling) * (1 - commission)
+		exchangeRate = fromBuying / toSelling
+	}
+
+	return &pb.PreviewPaymentResponse{
+		IsCrossBank:  false,
+		ExchangeRate: math.Round(exchangeRate*10000) / 10000,
+		Fee:          math.Round(req.Amount*commission*100) / 100,
+		FinalAmount:  math.Round(finalAmount*100) / 100,
+		FromCurrency: fromCurrencyCode,
+	}, nil
+}

--- a/shared/pb/payment/payment.pb.go
+++ b/shared/pb/payment/payment.pb.go
@@ -1993,6 +1993,150 @@ func (*CommitRollbackInterbankResponse) Descriptor() ([]byte, []int) {
 	return file_payment_proto_rawDescGZIP(), []int{30}
 }
 
+type PreviewPaymentRequest struct {
+	state            protoimpl.MessageState `protogen:"open.v1"`
+	FromAccount      string                 `protobuf:"bytes,1,opt,name=from_account,json=fromAccount,proto3" json:"from_account,omitempty"`
+	RecipientAccount string                 `protobuf:"bytes,2,opt,name=recipient_account,json=recipientAccount,proto3" json:"recipient_account,omitempty"`
+	Amount           float64                `protobuf:"fixed64,3,opt,name=amount,proto3" json:"amount,omitempty"`
+	ClientId         int64                  `protobuf:"varint,4,opt,name=client_id,json=clientId,proto3" json:"client_id,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *PreviewPaymentRequest) Reset() {
+	*x = PreviewPaymentRequest{}
+	mi := &file_payment_proto_msgTypes[31]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PreviewPaymentRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PreviewPaymentRequest) ProtoMessage() {}
+
+func (x *PreviewPaymentRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_payment_proto_msgTypes[31]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PreviewPaymentRequest.ProtoReflect.Descriptor instead.
+func (*PreviewPaymentRequest) Descriptor() ([]byte, []int) {
+	return file_payment_proto_rawDescGZIP(), []int{31}
+}
+
+func (x *PreviewPaymentRequest) GetFromAccount() string {
+	if x != nil {
+		return x.FromAccount
+	}
+	return ""
+}
+
+func (x *PreviewPaymentRequest) GetRecipientAccount() string {
+	if x != nil {
+		return x.RecipientAccount
+	}
+	return ""
+}
+
+func (x *PreviewPaymentRequest) GetAmount() float64 {
+	if x != nil {
+		return x.Amount
+	}
+	return 0
+}
+
+func (x *PreviewPaymentRequest) GetClientId() int64 {
+	if x != nil {
+		return x.ClientId
+	}
+	return 0
+}
+
+type PreviewPaymentResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	IsCrossBank   bool                   `protobuf:"varint,1,opt,name=is_cross_bank,json=isCrossBank,proto3" json:"is_cross_bank,omitempty"`
+	ExchangeRate  float64                `protobuf:"fixed64,2,opt,name=exchange_rate,json=exchangeRate,proto3" json:"exchange_rate,omitempty"`
+	Fee           float64                `protobuf:"fixed64,3,opt,name=fee,proto3" json:"fee,omitempty"`
+	FinalAmount   float64                `protobuf:"fixed64,4,opt,name=final_amount,json=finalAmount,proto3" json:"final_amount,omitempty"`
+	FromCurrency  string                 `protobuf:"bytes,5,opt,name=from_currency,json=fromCurrency,proto3" json:"from_currency,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PreviewPaymentResponse) Reset() {
+	*x = PreviewPaymentResponse{}
+	mi := &file_payment_proto_msgTypes[32]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PreviewPaymentResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PreviewPaymentResponse) ProtoMessage() {}
+
+func (x *PreviewPaymentResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_payment_proto_msgTypes[32]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PreviewPaymentResponse.ProtoReflect.Descriptor instead.
+func (*PreviewPaymentResponse) Descriptor() ([]byte, []int) {
+	return file_payment_proto_rawDescGZIP(), []int{32}
+}
+
+func (x *PreviewPaymentResponse) GetIsCrossBank() bool {
+	if x != nil {
+		return x.IsCrossBank
+	}
+	return false
+}
+
+func (x *PreviewPaymentResponse) GetExchangeRate() float64 {
+	if x != nil {
+		return x.ExchangeRate
+	}
+	return 0
+}
+
+func (x *PreviewPaymentResponse) GetFee() float64 {
+	if x != nil {
+		return x.Fee
+	}
+	return 0
+}
+
+func (x *PreviewPaymentResponse) GetFinalAmount() float64 {
+	if x != nil {
+		return x.FinalAmount
+	}
+	return 0
+}
+
+func (x *PreviewPaymentResponse) GetFromCurrency() string {
+	if x != nil {
+		return x.FromCurrency
+	}
+	return ""
+}
+
 var File_payment_proto protoreflect.FileDescriptor
 
 const file_payment_proto_rawDesc = "" +
@@ -2150,9 +2294,22 @@ const file_payment_proto_rawDesc = "" +
 	"\areasons\x18\x02 \x03(\v2\x18.payment.InterbankReasonR\areasons\"h\n" +
 	"\x1eCommitRollbackInterbankRequest\x12F\n" +
 	"\x0etransaction_id\x18\x01 \x01(\v2\x1f.payment.InterbankTransactionIdR\rtransactionId\"!\n" +
-	"\x1fCommitRollbackInterbankResponse2\xfe\t\n" +
+	"\x1fCommitRollbackInterbankResponse\"\x9c\x01\n" +
+	"\x15PreviewPaymentRequest\x12!\n" +
+	"\ffrom_account\x18\x01 \x01(\tR\vfromAccount\x12+\n" +
+	"\x11recipient_account\x18\x02 \x01(\tR\x10recipientAccount\x12\x16\n" +
+	"\x06amount\x18\x03 \x01(\x01R\x06amount\x12\x1b\n" +
+	"\tclient_id\x18\x04 \x01(\x03R\bclientId\"\xbb\x01\n" +
+	"\x16PreviewPaymentResponse\x12\"\n" +
+	"\ris_cross_bank\x18\x01 \x01(\bR\visCrossBank\x12#\n" +
+	"\rexchange_rate\x18\x02 \x01(\x01R\fexchangeRate\x12\x10\n" +
+	"\x03fee\x18\x03 \x01(\x01R\x03fee\x12!\n" +
+	"\ffinal_amount\x18\x04 \x01(\x01R\vfinalAmount\x12#\n" +
+	"\rfrom_currency\x18\x05 \x01(\tR\ffromCurrency2\xd1\n" +
+	"\n" +
 	"\x0ePaymentService\x12N\n" +
-	"\rCreatePayment\x12\x1d.payment.CreatePaymentRequest\x1a\x1e.payment.CreatePaymentResponse\x12H\n" +
+	"\rCreatePayment\x12\x1d.payment.CreatePaymentRequest\x1a\x1e.payment.CreatePaymentResponse\x12Q\n" +
+	"\x0ePreviewPayment\x12\x1e.payment.PreviewPaymentRequest\x1a\x1f.payment.PreviewPaymentResponse\x12H\n" +
 	"\vGetPayments\x12\x1b.payment.GetPaymentsRequest\x1a\x1c.payment.GetPaymentsResponse\x12Q\n" +
 	"\x0eGetPaymentById\x12\x1e.payment.GetPaymentByIdRequest\x1a\x1f.payment.GetPaymentByIdResponse\x12Q\n" +
 	"\x0eCreateTransfer\x12\x1e.payment.CreateTransferRequest\x1a\x1f.payment.CreateTransferResponse\x12i\n" +
@@ -2178,7 +2335,7 @@ func file_payment_proto_rawDescGZIP() []byte {
 	return file_payment_proto_rawDescData
 }
 
-var file_payment_proto_msgTypes = make([]protoimpl.MessageInfo, 31)
+var file_payment_proto_msgTypes = make([]protoimpl.MessageInfo, 33)
 var file_payment_proto_goTypes = []any{
 	(*CreatePaymentRequest)(nil),             // 0: payment.CreatePaymentRequest
 	(*CreatePaymentResponse)(nil),            // 1: payment.CreatePaymentResponse
@@ -2211,6 +2368,8 @@ var file_payment_proto_goTypes = []any{
 	(*PrepareInterbankPaymentResponse)(nil),  // 28: payment.PrepareInterbankPaymentResponse
 	(*CommitRollbackInterbankRequest)(nil),   // 29: payment.CommitRollbackInterbankRequest
 	(*CommitRollbackInterbankResponse)(nil),  // 30: payment.CommitRollbackInterbankResponse
+	(*PreviewPaymentRequest)(nil),            // 31: payment.PreviewPaymentRequest
+	(*PreviewPaymentResponse)(nil),           // 32: payment.PreviewPaymentResponse
 }
 var file_payment_proto_depIdxs = []int32{
 	2,  // 0: payment.CreatePaymentRecipientResponse.recipient:type_name -> payment.PaymentRecipient
@@ -2225,33 +2384,35 @@ var file_payment_proto_depIdxs = []int32{
 	26, // 9: payment.PrepareInterbankPaymentResponse.reasons:type_name -> payment.InterbankReason
 	23, // 10: payment.CommitRollbackInterbankRequest.transaction_id:type_name -> payment.InterbankTransactionId
 	0,  // 11: payment.PaymentService.CreatePayment:input_type -> payment.CreatePaymentRequest
-	16, // 12: payment.PaymentService.GetPayments:input_type -> payment.GetPaymentsRequest
-	14, // 13: payment.PaymentService.GetPaymentById:input_type -> payment.GetPaymentByIdRequest
-	18, // 14: payment.PaymentService.CreateTransfer:input_type -> payment.CreateTransferRequest
-	5,  // 15: payment.PaymentService.CreatePaymentRecipient:input_type -> payment.CreatePaymentRecipientRequest
-	7,  // 16: payment.PaymentService.GetPaymentRecipients:input_type -> payment.GetPaymentRecipientsRequest
-	11, // 17: payment.PaymentService.UpdatePaymentRecipient:input_type -> payment.UpdatePaymentRecipientRequest
-	9,  // 18: payment.PaymentService.DeletePaymentRecipient:input_type -> payment.DeletePaymentRecipientRequest
-	3,  // 19: payment.PaymentService.ReorderPaymentRecipients:input_type -> payment.ReorderPaymentRecipientsRequest
-	21, // 20: payment.PaymentService.GetTransfers:input_type -> payment.GetTransfersRequest
-	27, // 21: payment.PaymentService.PrepareInterbankPayment:input_type -> payment.PrepareInterbankPaymentRequest
-	29, // 22: payment.PaymentService.CommitInterbankPayment:input_type -> payment.CommitRollbackInterbankRequest
-	29, // 23: payment.PaymentService.RollbackInterbankPayment:input_type -> payment.CommitRollbackInterbankRequest
-	1,  // 24: payment.PaymentService.CreatePayment:output_type -> payment.CreatePaymentResponse
-	17, // 25: payment.PaymentService.GetPayments:output_type -> payment.GetPaymentsResponse
-	15, // 26: payment.PaymentService.GetPaymentById:output_type -> payment.GetPaymentByIdResponse
-	19, // 27: payment.PaymentService.CreateTransfer:output_type -> payment.CreateTransferResponse
-	6,  // 28: payment.PaymentService.CreatePaymentRecipient:output_type -> payment.CreatePaymentRecipientResponse
-	8,  // 29: payment.PaymentService.GetPaymentRecipients:output_type -> payment.GetPaymentRecipientsResponse
-	12, // 30: payment.PaymentService.UpdatePaymentRecipient:output_type -> payment.UpdatePaymentRecipientResponse
-	10, // 31: payment.PaymentService.DeletePaymentRecipient:output_type -> payment.DeletePaymentRecipientResponse
-	4,  // 32: payment.PaymentService.ReorderPaymentRecipients:output_type -> payment.ReorderPaymentRecipientsResponse
-	22, // 33: payment.PaymentService.GetTransfers:output_type -> payment.GetTransfersResponse
-	28, // 34: payment.PaymentService.PrepareInterbankPayment:output_type -> payment.PrepareInterbankPaymentResponse
-	30, // 35: payment.PaymentService.CommitInterbankPayment:output_type -> payment.CommitRollbackInterbankResponse
-	30, // 36: payment.PaymentService.RollbackInterbankPayment:output_type -> payment.CommitRollbackInterbankResponse
-	24, // [24:37] is the sub-list for method output_type
-	11, // [11:24] is the sub-list for method input_type
+	31, // 12: payment.PaymentService.PreviewPayment:input_type -> payment.PreviewPaymentRequest
+	16, // 13: payment.PaymentService.GetPayments:input_type -> payment.GetPaymentsRequest
+	14, // 14: payment.PaymentService.GetPaymentById:input_type -> payment.GetPaymentByIdRequest
+	18, // 15: payment.PaymentService.CreateTransfer:input_type -> payment.CreateTransferRequest
+	5,  // 16: payment.PaymentService.CreatePaymentRecipient:input_type -> payment.CreatePaymentRecipientRequest
+	7,  // 17: payment.PaymentService.GetPaymentRecipients:input_type -> payment.GetPaymentRecipientsRequest
+	11, // 18: payment.PaymentService.UpdatePaymentRecipient:input_type -> payment.UpdatePaymentRecipientRequest
+	9,  // 19: payment.PaymentService.DeletePaymentRecipient:input_type -> payment.DeletePaymentRecipientRequest
+	3,  // 20: payment.PaymentService.ReorderPaymentRecipients:input_type -> payment.ReorderPaymentRecipientsRequest
+	21, // 21: payment.PaymentService.GetTransfers:input_type -> payment.GetTransfersRequest
+	27, // 22: payment.PaymentService.PrepareInterbankPayment:input_type -> payment.PrepareInterbankPaymentRequest
+	29, // 23: payment.PaymentService.CommitInterbankPayment:input_type -> payment.CommitRollbackInterbankRequest
+	29, // 24: payment.PaymentService.RollbackInterbankPayment:input_type -> payment.CommitRollbackInterbankRequest
+	1,  // 25: payment.PaymentService.CreatePayment:output_type -> payment.CreatePaymentResponse
+	32, // 26: payment.PaymentService.PreviewPayment:output_type -> payment.PreviewPaymentResponse
+	17, // 27: payment.PaymentService.GetPayments:output_type -> payment.GetPaymentsResponse
+	15, // 28: payment.PaymentService.GetPaymentById:output_type -> payment.GetPaymentByIdResponse
+	19, // 29: payment.PaymentService.CreateTransfer:output_type -> payment.CreateTransferResponse
+	6,  // 30: payment.PaymentService.CreatePaymentRecipient:output_type -> payment.CreatePaymentRecipientResponse
+	8,  // 31: payment.PaymentService.GetPaymentRecipients:output_type -> payment.GetPaymentRecipientsResponse
+	12, // 32: payment.PaymentService.UpdatePaymentRecipient:output_type -> payment.UpdatePaymentRecipientResponse
+	10, // 33: payment.PaymentService.DeletePaymentRecipient:output_type -> payment.DeletePaymentRecipientResponse
+	4,  // 34: payment.PaymentService.ReorderPaymentRecipients:output_type -> payment.ReorderPaymentRecipientsResponse
+	22, // 35: payment.PaymentService.GetTransfers:output_type -> payment.GetTransfersResponse
+	28, // 36: payment.PaymentService.PrepareInterbankPayment:output_type -> payment.PrepareInterbankPaymentResponse
+	30, // 37: payment.PaymentService.CommitInterbankPayment:output_type -> payment.CommitRollbackInterbankResponse
+	30, // 38: payment.PaymentService.RollbackInterbankPayment:output_type -> payment.CommitRollbackInterbankResponse
+	25, // [25:39] is the sub-list for method output_type
+	11, // [11:25] is the sub-list for method input_type
 	11, // [11:11] is the sub-list for extension type_name
 	11, // [11:11] is the sub-list for extension extendee
 	0,  // [0:11] is the sub-list for field type_name
@@ -2268,7 +2429,7 @@ func file_payment_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_payment_proto_rawDesc), len(file_payment_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   31,
+			NumMessages:   33,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/shared/pb/payment/payment_grpc.pb.go
+++ b/shared/pb/payment/payment_grpc.pb.go
@@ -20,6 +20,7 @@ const _ = grpc.SupportPackageIsVersion9
 
 const (
 	PaymentService_CreatePayment_FullMethodName            = "/payment.PaymentService/CreatePayment"
+	PaymentService_PreviewPayment_FullMethodName           = "/payment.PaymentService/PreviewPayment"
 	PaymentService_GetPayments_FullMethodName              = "/payment.PaymentService/GetPayments"
 	PaymentService_GetPaymentById_FullMethodName           = "/payment.PaymentService/GetPaymentById"
 	PaymentService_CreateTransfer_FullMethodName           = "/payment.PaymentService/CreateTransfer"
@@ -39,6 +40,7 @@ const (
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type PaymentServiceClient interface {
 	CreatePayment(ctx context.Context, in *CreatePaymentRequest, opts ...grpc.CallOption) (*CreatePaymentResponse, error)
+	PreviewPayment(ctx context.Context, in *PreviewPaymentRequest, opts ...grpc.CallOption) (*PreviewPaymentResponse, error)
 	GetPayments(ctx context.Context, in *GetPaymentsRequest, opts ...grpc.CallOption) (*GetPaymentsResponse, error)
 	GetPaymentById(ctx context.Context, in *GetPaymentByIdRequest, opts ...grpc.CallOption) (*GetPaymentByIdResponse, error)
 	CreateTransfer(ctx context.Context, in *CreateTransferRequest, opts ...grpc.CallOption) (*CreateTransferResponse, error)
@@ -65,6 +67,16 @@ func (c *paymentServiceClient) CreatePayment(ctx context.Context, in *CreatePaym
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(CreatePaymentResponse)
 	err := c.cc.Invoke(ctx, PaymentService_CreatePayment_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *paymentServiceClient) PreviewPayment(ctx context.Context, in *PreviewPaymentRequest, opts ...grpc.CallOption) (*PreviewPaymentResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(PreviewPaymentResponse)
+	err := c.cc.Invoke(ctx, PaymentService_PreviewPayment_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -196,6 +208,7 @@ func (c *paymentServiceClient) RollbackInterbankPayment(ctx context.Context, in 
 // for forward compatibility.
 type PaymentServiceServer interface {
 	CreatePayment(context.Context, *CreatePaymentRequest) (*CreatePaymentResponse, error)
+	PreviewPayment(context.Context, *PreviewPaymentRequest) (*PreviewPaymentResponse, error)
 	GetPayments(context.Context, *GetPaymentsRequest) (*GetPaymentsResponse, error)
 	GetPaymentById(context.Context, *GetPaymentByIdRequest) (*GetPaymentByIdResponse, error)
 	CreateTransfer(context.Context, *CreateTransferRequest) (*CreateTransferResponse, error)
@@ -220,6 +233,9 @@ type UnimplementedPaymentServiceServer struct{}
 
 func (UnimplementedPaymentServiceServer) CreatePayment(context.Context, *CreatePaymentRequest) (*CreatePaymentResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method CreatePayment not implemented")
+}
+func (UnimplementedPaymentServiceServer) PreviewPayment(context.Context, *PreviewPaymentRequest) (*PreviewPaymentResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method PreviewPayment not implemented")
 }
 func (UnimplementedPaymentServiceServer) GetPayments(context.Context, *GetPaymentsRequest) (*GetPaymentsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetPayments not implemented")
@@ -292,6 +308,24 @@ func _PaymentService_CreatePayment_Handler(srv interface{}, ctx context.Context,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(PaymentServiceServer).CreatePayment(ctx, req.(*CreatePaymentRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _PaymentService_PreviewPayment_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(PreviewPaymentRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(PaymentServiceServer).PreviewPayment(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: PaymentService_PreviewPayment_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(PaymentServiceServer).PreviewPayment(ctx, req.(*PreviewPaymentRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -522,6 +556,10 @@ var PaymentService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "CreatePayment",
 			Handler:    _PaymentService_CreatePayment_Handler,
+		},
+		{
+			MethodName: "PreviewPayment",
+			Handler:    _PaymentService_PreviewPayment_Handler,
 		},
 		{
 			MethodName: "GetPayments",

--- a/shared/proto/payment.proto
+++ b/shared/proto/payment.proto
@@ -180,8 +180,24 @@ message CommitRollbackInterbankRequest {
 
 message CommitRollbackInterbankResponse {}
 
+message PreviewPaymentRequest {
+  string from_account      = 1;
+  string recipient_account = 2;
+  double amount            = 3;
+  int64  client_id         = 4;
+}
+
+message PreviewPaymentResponse {
+  bool   is_cross_bank  = 1;
+  double exchange_rate  = 2;
+  double fee            = 3;
+  double final_amount   = 4;
+  string from_currency  = 5;
+}
+
 service PaymentService {
   rpc CreatePayment(CreatePaymentRequest)                       returns (CreatePaymentResponse);
+  rpc PreviewPayment(PreviewPaymentRequest)                     returns (PreviewPaymentResponse);
   rpc GetPayments(GetPaymentsRequest)                           returns (GetPaymentsResponse);
   rpc GetPaymentById(GetPaymentByIdRequest)                     returns (GetPaymentByIdResponse);
   rpc CreateTransfer(CreateTransferRequest)                     returns (CreateTransferResponse);


### PR DESCRIPTION
Adds PreviewPayment gRPC method that probes the partner bank with a NEW_TX and immediately rolls back to retrieve quoted exchange rate, fee, and final amount without committing. Falls back gracefully if the partner bank is unreachable. Also extends ibVoteResponse to capture rate/fee fields from the partner's YES response.