### PR TITLE
fix: OTC bank-seller visibility, double-credit guard, external stock …

### DIFF
--- a/services/api-gateway/handlers/otc.go
+++ b/services/api-gateway/handlers/otc.go
@@ -526,7 +526,10 @@ func GetPublicStock(client pb.OtcServiceClient) gin.HandlerFunc {
 			Amount int32  `json:"amount"`
 		}
 		type stock struct {
-			Ticker string `json:"ticker"`
+			Ticker   string  `json:"ticker"`
+			Name     string  `json:"name"`
+			Price    float64 `json:"price"`
+			Currency string  `json:"currency"`
 		}
 		type stockEntry struct {
 			Stock   stock         `json:"stock"`
@@ -537,7 +540,12 @@ func GetPublicStock(client pb.OtcServiceClient) gin.HandlerFunc {
 		for _, item := range resp.Items {
 			entry, ok := byTicker[item.Ticker]
 			if !ok {
-				entry = &stockEntry{Stock: stock{Ticker: item.Ticker}}
+				entry = &stockEntry{Stock: stock{
+					Ticker:   item.Ticker,
+					Name:     item.Name,
+					Price:    item.PricePerStock,
+					Currency: item.Currency,
+				}}
 				byTicker[item.Ticker] = entry
 			}
 			entry.Sellers = append(entry.Sellers, sellerEntry{

--- a/services/api-gateway/handlers/otc_interbank.go
+++ b/services/api-gateway/handlers/otc_interbank.go
@@ -267,6 +267,41 @@ func IncomingAcceptNegotiation(otcClient pb.OtcServiceClient) gin.HandlerFunc {
 	}
 }
 
+// GetExternalStocks proxies GET /public-stock from the configured partner bank.
+// Returns { items, bankName } or an empty list if the partner is unreachable.
+func GetExternalStocks() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		partnerRouting := os.Getenv("PARTNER_ROUTING_NUMBER")
+		bank, err := gwinterbank.ResolveBankByRoutingNumber(partnerRouting)
+		if err != nil || bank.BankURL == "" {
+			c.JSON(http.StatusOK, gin.H{"items": []any{}, "bankName": ""})
+			return
+		}
+
+		req, err := http.NewRequestWithContext(c.Request.Context(), http.MethodGet, bank.BankURL+"/public-stock", nil)
+		if err != nil {
+			c.JSON(http.StatusOK, gin.H{"items": []any{}, "bankName": bank.BankName})
+			return
+		}
+		req.Header.Set("X-Api-Key", bank.APIKey)
+
+		httpClient := &http.Client{Timeout: otcInterbankTimeout}
+		resp, err := httpClient.Do(req)
+		if err != nil || resp.StatusCode != http.StatusOK {
+			c.JSON(http.StatusOK, gin.H{"items": []any{}, "bankName": bank.BankName})
+			return
+		}
+		defer resp.Body.Close()
+
+		var items []any
+		if err := json.NewDecoder(resp.Body).Decode(&items); err != nil {
+			c.JSON(http.StatusOK, gin.H{"items": []any{}, "bankName": bank.BankName})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"items": items, "bankName": bank.BankName})
+	}
+}
+
 // parseInterbankNegPath extracts (routingNumber, externalId) from path params.
 func parseInterbankNegPath(c *gin.Context) (int32, string, bool) {
 	var routing int32

--- a/services/api-gateway/main.go
+++ b/services/api-gateway/main.go
@@ -270,6 +270,7 @@ func main() {
 	r.GET("/otc/contracts", middleware.RequireRole("CLIENT", "AGENT", "SUPERVISOR"), handlers.ListContracts(otcClient))
 	r.POST("/otc/contracts/:id/exercise", middleware.RequireRole("CLIENT", "AGENT", "SUPERVISOR"), handlers.ExerciseContract(otcClient))
 	r.GET("/otc/market", middleware.RequireRole("CLIENT", "SUPERVISOR"), handlers.GetMarket(otcClient))
+	r.GET("/api/otc/external-stocks", middleware.RequireRole("CLIENT", "SUPERVISOR"), handlers.GetExternalStocks())
 	r.PUT("/client/portfolio/:ticker/public-mode", middleware.RequireRole("CLIENT", "SUPERVISOR"), handlers.SetPublicMode(portfolioClient))
 
 	// Investment funds

--- a/services/otc-service/handlers/grpc_server.go
+++ b/services/otc-service/handlers/grpc_server.go
@@ -193,6 +193,7 @@ func (s *OtcServer) ListNegotiations(ctx context.Context, req *pb.ListNegotiatio
 		SELECT id FROM otc_negotiations
 		WHERE (seller_id = $1 AND seller_type = $2)
 		   OR (buyer_id  = $1 AND buyer_type  = $2)
+		   OR ($2 = 'EMPLOYEE' AND seller_id = 0 AND seller_type = 'EMPLOYEE')
 		ORDER BY last_modified DESC`,
 		req.CallerId, req.CallerType,
 	)
@@ -251,7 +252,7 @@ func (s *OtcServer) CounterOffer(ctx context.Context, req *pb.CounterOfferReques
 		return nil, status.Errorf(codes.Internal, "failed to load negotiation: %v", err)
 	}
 
-	isSeller := req.CallerId == sellerID && req.CallerType == sellerType
+	isSeller := req.CallerType == sellerType && (req.CallerId == sellerID || sellerID == 0)
 	isBuyer := req.CallerId == buyerID && req.CallerType == buyerType
 	if !isSeller && !isBuyer {
 		return nil, status.Error(codes.PermissionDenied, "caller is not a participant in this negotiation")
@@ -318,7 +319,7 @@ func (s *OtcServer) AcceptNegotiation(ctx context.Context, req *pb.AcceptNegotia
 		return nil, status.Errorf(codes.Internal, "failed to load negotiation: %v", err)
 	}
 
-	isSeller := req.CallerId == sellerID && req.CallerType == sellerType
+	isSeller := req.CallerType == sellerType && (req.CallerId == sellerID || sellerID == 0)
 	isBuyer := req.CallerId == buyerID && req.CallerType == buyerType
 	if !isSeller && !isBuyer {
 		return nil, status.Error(codes.PermissionDenied, "caller is not a participant in this negotiation")
@@ -482,7 +483,7 @@ func (s *OtcServer) RejectNegotiation(ctx context.Context, req *pb.RejectNegotia
 		return nil, status.Errorf(codes.Internal, "failed to load negotiation: %v", err)
 	}
 
-	isSeller := req.CallerId == sellerID && req.CallerType == sellerType
+	isSeller := req.CallerType == sellerType && (req.CallerId == sellerID || sellerID == 0)
 	isBuyer := req.CallerId == buyerID && req.CallerType == buyerType
 	if !isSeller && !isBuyer {
 		return nil, status.Error(codes.PermissionDenied, "caller is not a participant in this negotiation")
@@ -514,7 +515,8 @@ func (s *OtcServer) ListContracts(ctx context.Context, req *pb.ListContractsRequ
 		       settlement_date::text, status, created_at
 		FROM otc_contracts
 		WHERE ((seller_id = $1 AND seller_type = $2)
-		    OR  (buyer_id  = $1 AND buyer_type  = $2))`
+		    OR  (buyer_id  = $1 AND buyer_type  = $2)
+		    OR  ($2 = 'EMPLOYEE' AND seller_id = 0 AND seller_type = 'EMPLOYEE'))`
 	args := []interface{}{req.CallerId, req.CallerType}
 
 	if req.StatusFilter != "" {

--- a/services/payment-service/handlers/interbank.go
+++ b/services/payment-service/handlers/interbank.go
@@ -161,34 +161,31 @@ func (s *PaymentServer) CommitInterbankPayment(ctx context.Context, req *pb.Comm
 		return nil, status.Errorf(codes.Internal, "failed to look up interbank transaction: %v", err)
 	}
 
-	if txStatus == "COMMITTED" {
-		return &pb.CommitRollbackInterbankResponse{}, nil
-	}
 	if txStatus == "ROLLED_BACK" {
 		return nil, status.Errorf(codes.FailedPrecondition, "transaction was already rolled back")
 	}
 
-	// Credit the receiver account and mark committed in a single DB transaction
-	dbTx, err := s.AccountDB.BeginTx(ctx, nil)
+	// Atomically claim the commit only if still PENDING — this is the idempotence guard.
+	// A retry will see 0 rows affected and exit before touching accounts, preventing double credit.
+	res, err := s.DB.ExecContext(ctx,
+		`UPDATE interbank_transactions SET status = 'COMMITTED' WHERE id = $1 AND status = 'PENDING'`, id,
+	)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to begin transaction: %v", err)
+		return nil, status.Errorf(codes.Internal, "failed to claim commit: %v", err)
 	}
-	defer func() { _ = dbTx.Rollback() }()
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to read rows affected: %v", err)
+	}
+	if rows == 0 {
+		return &pb.CommitRollbackInterbankResponse{}, nil
+	}
 
-	if _, err = dbTx.ExecContext(ctx,
+	if _, err = s.AccountDB.ExecContext(ctx,
 		`UPDATE accounts SET balance = balance + $1, available_balance = available_balance + $1 WHERE account_number = $2`,
 		amount, toAccount,
 	); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to credit receiver account: %v", err)
-	}
-	if err = dbTx.Commit(); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to commit account credit: %v", err)
-	}
-
-	if _, err = s.DB.ExecContext(ctx,
-		`UPDATE interbank_transactions SET status = 'COMMITTED' WHERE id = $1`, id,
-	); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to update interbank transaction status: %v", err)
 	}
 	return &pb.CommitRollbackInterbankResponse{}, nil
 }


### PR DESCRIPTION
…metadata

- ListNegotiations/ListContracts: employees now see bank (seller_id=0) records
- CounterOffer/AcceptNegotiation/RejectNegotiation: allow any employee to act as seller when seller_id=0 (bank's own portfolio)
- ExerciseContract: atomic status guard prevents double-credit on COMMIT_TX retry
- GetPublicStock: include name, price, currency in stock entry for partner banks
- GetExternalStocks: new endpoint proxying partner bank's /public-stock
- RegisterRoute: GET /api/otc/external-stocks for CLIENT and SUPERVISOR