### PR TITLE
ci: push image on any branch, deploy only on main

### DIFF
--- a/.github/workflows/account-docker.yml
+++ b/.github/workflows/account-docker.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           context: .
           file: services/account-service/Dockerfile
-          push: ${{ github.ref == 'refs/heads/main' }}
+          push: ${{ github.event_name == 'push' }}
           tags: ghcr.io/raf-si-2025/exbanka-4-backend/account-service:${{ github.sha }}
 
   deploy:

--- a/.github/workflows/api-gateway-docker.yml
+++ b/.github/workflows/api-gateway-docker.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           context: .
           file: services/api-gateway/Dockerfile
-          push: ${{ github.ref == 'refs/heads/main' }}
+          push: ${{ github.event_name == 'push' }}
           tags: ghcr.io/raf-si-2025/exbanka-4-backend/api-gateway:${{ github.sha }}
 
   deploy:

--- a/.github/workflows/auth-docker.yml
+++ b/.github/workflows/auth-docker.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           context: .
           file: services/auth-service/Dockerfile
-          push: ${{ github.ref == 'refs/heads/main' }}
+          push: ${{ github.event_name == 'push' }}
           tags: ghcr.io/raf-si-2025/exbanka-4-backend/auth-service:${{ github.sha }}
 
   deploy:

--- a/.github/workflows/card-docker.yml
+++ b/.github/workflows/card-docker.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           context: .
           file: services/card-service/Dockerfile
-          push: ${{ github.ref == 'refs/heads/main' }}
+          push: ${{ github.event_name == 'push' }}
           tags: ghcr.io/raf-si-2025/exbanka-4-backend/card-service:${{ github.sha }}
 
   deploy:

--- a/.github/workflows/client-docker.yml
+++ b/.github/workflows/client-docker.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           context: .
           file: services/client-service/Dockerfile
-          push: ${{ github.ref == 'refs/heads/main' }}
+          push: ${{ github.event_name == 'push' }}
           tags: ghcr.io/raf-si-2025/exbanka-4-backend/client-service:${{ github.sha }}
 
   deploy:

--- a/.github/workflows/email-docker.yml
+++ b/.github/workflows/email-docker.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           context: .
           file: services/email-service/Dockerfile
-          push: ${{ github.ref == 'refs/heads/main' }}
+          push: ${{ github.event_name == 'push' }}
           tags: ghcr.io/raf-si-2025/exbanka-4-backend/email-service:${{ github.sha }}
 
   deploy:

--- a/.github/workflows/employee-docker.yml
+++ b/.github/workflows/employee-docker.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           context: .
           file: services/employee-service/Dockerfile
-          push: ${{ github.ref == 'refs/heads/main' }}
+          push: ${{ github.event_name == 'push' }}
           tags: ghcr.io/raf-si-2025/exbanka-4-backend/employee-service:${{ github.sha }}
   deploy:
     name: Deploy to Kubernetes

--- a/.github/workflows/exchange-docker.yml
+++ b/.github/workflows/exchange-docker.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           context: .
           file: services/exchange-service/Dockerfile
-          push: ${{ github.ref == 'refs/heads/main' }}
+          push: ${{ github.event_name == 'push' }}
           tags: ghcr.io/raf-si-2025/exbanka-4-backend/exchange-service:${{ github.sha }}
 
   deploy:

--- a/.github/workflows/fund-docker.yml
+++ b/.github/workflows/fund-docker.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           context: .
           file: services/fund-service/Dockerfile
-          push: ${{ github.ref == 'refs/heads/main' }}
+          push: ${{ github.event_name == 'push' }}
           tags: ghcr.io/raf-si-2025/exbanka-4-backend/fund-service:${{ github.sha }}
 
   deploy:

--- a/.github/workflows/loan-docker.yml
+++ b/.github/workflows/loan-docker.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           context: .
           file: services/loan-service/Dockerfile
-          push: ${{ github.ref == 'refs/heads/main' }}
+          push: ${{ github.event_name == 'push' }}
           tags: ghcr.io/raf-si-2025/exbanka-4-backend/loan-service:${{ github.sha }}
 
   deploy:

--- a/.github/workflows/order-docker.yml
+++ b/.github/workflows/order-docker.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           context: .
           file: services/order-service/Dockerfile
-          push: ${{ github.ref == 'refs/heads/main' }}
+          push: ${{ github.event_name == 'push' }}
           tags: ghcr.io/raf-si-2025/exbanka-4-backend/order-service:${{ github.sha }}
 
   deploy:

--- a/.github/workflows/otc-docker.yml
+++ b/.github/workflows/otc-docker.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           context: .
           file: services/otc-service/Dockerfile
-          push: ${{ github.ref == 'refs/heads/main' }}
+          push: ${{ github.event_name == 'push' }}
           tags: ghcr.io/raf-si-2025/exbanka-4-backend/otc-service:${{ github.sha }}
 
   deploy:

--- a/.github/workflows/payment-docker.yml
+++ b/.github/workflows/payment-docker.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           context: .
           file: services/payment-service/Dockerfile
-          push: ${{ github.ref == 'refs/heads/main' }}
+          push: ${{ github.event_name == 'push' }}
           tags: ghcr.io/raf-si-2025/exbanka-4-backend/payment-service:${{ github.sha }}
 
   deploy:

--- a/.github/workflows/portfolio-docker.yml
+++ b/.github/workflows/portfolio-docker.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           context: .
           file: services/portfolio-service/Dockerfile
-          push: ${{ github.ref == 'refs/heads/main' }}
+          push: ${{ github.event_name == 'push' }}
           tags: ghcr.io/raf-si-2025/exbanka-4-backend/portfolio-service:${{ github.sha }}
 
   deploy:

--- a/.github/workflows/securities-docker.yml
+++ b/.github/workflows/securities-docker.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           context: .
           file: services/securities-service/Dockerfile
-          push: ${{ github.ref == 'refs/heads/main' }}
+          push: ${{ github.event_name == 'push' }}
           tags: ghcr.io/raf-si-2025/exbanka-4-backend/securities-service:${{ github.sha }}
 
   deploy:


### PR DESCRIPTION
## Summary

Changes image push to trigger on any branch push (not just main), while keeping the Kubernetes deploy restricted to main only.

This allows images to be built and pushed to GHCR from feature branches, enabling manual cluster deployments without merging to main first.

| Trigger | Build | Image pushed | Deploy |
|---|---|---|---|
| Push to any branch | ✅ | ✅ | ❌ |
| Push to main | ✅ | ✅ | ✅ |
| Pull request | ✅ | ❌ | ❌ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)