### PR TITLE
fix: resolve CI failures across multiple services

### DIFF
--- a/services/api-gateway/handlers/interbank.go
+++ b/services/api-gateway/handlers/interbank.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"strconv"
 
-	pb     "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/payment"
 	pb_otc "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/otc"
+	pb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/payment"
 	"github.com/gin-gonic/gin"
 )
 

--- a/services/api-gateway/handlers/payments_test.go
+++ b/services/api-gateway/handlers/payments_test.go
@@ -25,6 +25,7 @@ type stubPaymentClient struct {
 	deletePaymentRecipientFn   func(context.Context, *pb.DeletePaymentRecipientRequest, ...grpc.CallOption) (*pb.DeletePaymentRecipientResponse, error)
 	reorderPaymentRecipientsFn func(context.Context, *pb.ReorderPaymentRecipientsRequest, ...grpc.CallOption) (*pb.ReorderPaymentRecipientsResponse, error)
 	getTransfersFn             func(context.Context, *pb.GetTransfersRequest, ...grpc.CallOption) (*pb.GetTransfersResponse, error)
+	previewPaymentFn           func(context.Context, *pb.PreviewPaymentRequest, ...grpc.CallOption) (*pb.PreviewPaymentResponse, error)
 }
 
 func (s *stubPaymentClient) CreatePayment(ctx context.Context, in *pb.CreatePaymentRequest, opts ...grpc.CallOption) (*pb.CreatePaymentResponse, error) {
@@ -94,6 +95,12 @@ func (s *stubPaymentClient) CommitInterbankPayment(ctx context.Context, in *pb.C
 	return nil, fmt.Errorf("not implemented")
 }
 func (s *stubPaymentClient) RollbackInterbankPayment(ctx context.Context, in *pb.CommitRollbackInterbankRequest, opts ...grpc.CallOption) (*pb.CommitRollbackInterbankResponse, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+func (s *stubPaymentClient) PreviewPayment(ctx context.Context, in *pb.PreviewPaymentRequest, opts ...grpc.CallOption) (*pb.PreviewPaymentResponse, error) {
+	if s.previewPaymentFn != nil {
+		return s.previewPaymentFn(ctx, in, opts...)
+	}
 	return nil, fmt.Errorf("not implemented")
 }
 

--- a/services/auth-service/handlers/grpc_server_test.go
+++ b/services/auth-service/handlers/grpc_server_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"testing"
 	"time"
 
@@ -142,6 +143,10 @@ func (m *mockEmployeeClient) ResetAllActuaryUsedLimits(ctx context.Context, in *
 
 func (m *mockEmployeeClient) GetActuaryPerformers(ctx context.Context, in *pb_emp.GetActuaryPerformersRequest, opts ...grpc.CallOption) (*pb_emp.GetActuaryPerformersResponse, error) {
 	return nil, nil
+}
+
+func (m *mockEmployeeClient) GetSupervisors(ctx context.Context, in *pb_emp.GetSupervisorsRequest, opts ...grpc.CallOption) (*pb_emp.GetSupervisorsResponse, error) {
+	return nil, fmt.Errorf("not implemented")
 }
 
 type mockEmailClient struct {

--- a/services/fund-service/handlers/grpc_server.go
+++ b/services/fund-service/handlers/grpc_server.go
@@ -213,7 +213,7 @@ func (s *FundServer) fetchFundByID(ctx context.Context, id int64, includeAccount
 		`SELECT listing_id, quantity FROM fund_portfolio_positions WHERE fund_id = $1 AND quantity > 0`, id)
 	var portfolioValue float64
 	if pErr == nil {
-		defer portfolioRows.Close()
+		defer func() { _ = portfolioRows.Close() }()
 		for portfolioRows.Next() {
 			var listingID int64
 			var qty float64

--- a/services/fund-service/handlers/grpc_server_test.go
+++ b/services/fund-service/handlers/grpc_server_test.go
@@ -186,6 +186,10 @@ func TestCreateFund_Happy(t *testing.T) {
 	}
 	s, fundMock, accountDBMock, empMock := newFundServer(t, acct)
 
+	// permissions check for manager
+	empMock.ExpectQuery("SELECT array_to_string").
+		WillReturnRows(sqlmock.NewRows([]string{"permissions"}).AddRow("SUPERVISOR"))
+
 	// INSERT fund returns id=1
 	fundMock.ExpectQuery("INSERT INTO investment_funds").
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(1)))
@@ -230,7 +234,11 @@ func TestCreateFund_DuplicateName(t *testing.T) {
 			}, nil
 		},
 	}
-	s, fundMock, _, _ := newFundServer(t, acct)
+	s, fundMock, _, empMock := newFundServer(t, acct)
+
+	// permissions check for manager
+	empMock.ExpectQuery("SELECT array_to_string").
+		WillReturnRows(sqlmock.NewRows([]string{"permissions"}).AddRow("SUPERVISOR"))
 
 	// INSERT returns unique violation
 	fundMock.ExpectQuery("INSERT INTO investment_funds").
@@ -422,7 +430,11 @@ func TestCreateFund_AccountClientError(t *testing.T) {
 			return nil, fmt.Errorf("account service unavailable")
 		},
 	}
-	s, _, _, _ := newFundServer(t, acct)
+	s, _, _, empMock := newFundServer(t, acct)
+
+	// permissions check for manager
+	empMock.ExpectQuery("SELECT array_to_string").
+		WillReturnRows(sqlmock.NewRows([]string{"permissions"}).AddRow("SUPERVISOR"))
 
 	_, err := s.CreateFund(context.Background(), &pb.CreateFundRequest{
 		Name:                "New Fund",
@@ -464,7 +476,11 @@ func TestCreateFund_DBError(t *testing.T) {
 			}, nil
 		},
 	}
-	s, fundMock, _, _ := newFundServer(t, acct)
+	s, fundMock, _, empMock := newFundServer(t, acct)
+
+	// permissions check for manager
+	empMock.ExpectQuery("SELECT array_to_string").
+		WillReturnRows(sqlmock.NewRows([]string{"permissions"}).AddRow("SUPERVISOR"))
 
 	fundMock.ExpectQuery("INSERT INTO investment_funds").
 		WillReturnError(fmt.Errorf("connection reset by peer"))
@@ -847,13 +863,16 @@ func TestGetFundPortfolio_Happy(t *testing.T) {
 func TestWithdrawFund_Case1_Immediate(t *testing.T) {
 	s, fundMock, accountDBMock, empMock := newFundServer(t, &mockAccountClient{})
 
-	// SELECT fund: liquid_assets=500000, active=true
-	fundMock.ExpectQuery("SELECT liquid_assets, active FROM investment_funds").
+	// SELECT fund: liquid_assets=500000, active=true, account_id=42
+	fundMock.ExpectQuery("SELECT liquid_assets, active, account_id FROM investment_funds").
 		WithArgs(int64(1)).
-		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active"}).AddRow(500000.0, true))
+		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active", "account_id"}).AddRow(500000.0, true, int64(42)))
 	// SELECT position
 	fundMock.ExpectQuery("SELECT total_invested_amount FROM client_fund_positions").
 		WillReturnRows(sqlmock.NewRows([]string{"total_invested_amount"}).AddRow(1000.0))
+	// Debit fund account
+	accountDBMock.ExpectExec("UPDATE accounts SET balance").
+		WillReturnResult(sqlmock.NewResult(1, 1))
 	// Credit destination account
 	accountDBMock.ExpectExec("UPDATE accounts SET balance").
 		WithArgs(1000.0, int64(99)).
@@ -884,11 +903,15 @@ func TestWithdrawFund_Case1_WithdrawAll(t *testing.T) {
 	// amount=0 means withdraw full position
 	s, fundMock, accountDBMock, empMock := newFundServer(t, &mockAccountClient{})
 
-	fundMock.ExpectQuery("SELECT liquid_assets, active FROM investment_funds").
+	fundMock.ExpectQuery("SELECT liquid_assets, active, account_id FROM investment_funds").
 		WithArgs(int64(1)).
-		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active"}).AddRow(500000.0, true))
+		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active", "account_id"}).AddRow(500000.0, true, int64(42)))
 	fundMock.ExpectQuery("SELECT total_invested_amount FROM client_fund_positions").
 		WillReturnRows(sqlmock.NewRows([]string{"total_invested_amount"}).AddRow(2500.0))
+	// Debit fund account
+	accountDBMock.ExpectExec("UPDATE accounts SET balance").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	// Credit destination account
 	accountDBMock.ExpectExec("UPDATE accounts SET balance").
 		WithArgs(2500.0, int64(99)).
 		WillReturnResult(sqlmock.NewResult(1, 1))
@@ -924,9 +947,9 @@ func TestWithdrawFund_Case2_ClientAutoLiquidate(t *testing.T) {
 	s, fundMock, _, _ := newFundServerFull(t, &mockAccountClient{}, order)
 
 	// liquid_assets=100 < amount=1000 → Case 2
-	fundMock.ExpectQuery("SELECT liquid_assets, active FROM investment_funds").
+	fundMock.ExpectQuery("SELECT liquid_assets, active, account_id FROM investment_funds").
 		WithArgs(int64(1)).
-		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active"}).AddRow(100.0, true))
+		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active", "account_id"}).AddRow(100.0, true, int64(0)))
 	fundMock.ExpectQuery("SELECT total_invested_amount FROM client_fund_positions").
 		WillReturnRows(sqlmock.NewRows([]string{"total_invested_amount"}).AddRow(1000.0))
 	// fetch account_id, manager_id for SELL orders
@@ -957,9 +980,9 @@ func TestWithdrawFund_Case2_BankNoAutoLiquidate(t *testing.T) {
 	s, fundMock, _, _ := newFundServer(t, &mockAccountClient{})
 
 	// liquid_assets=100 < amount=1000, clientType=BANK → FailedPrecondition
-	fundMock.ExpectQuery("SELECT liquid_assets, active FROM investment_funds").
+	fundMock.ExpectQuery("SELECT liquid_assets, active, account_id FROM investment_funds").
 		WithArgs(int64(1)).
-		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active"}).AddRow(100.0, true))
+		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active", "account_id"}).AddRow(100.0, true, int64(0)))
 	fundMock.ExpectQuery("SELECT total_invested_amount FROM client_fund_positions").
 		WillReturnRows(sqlmock.NewRows([]string{"total_invested_amount"}).AddRow(1000.0))
 
@@ -1093,7 +1116,7 @@ func TestInvestFund_NegativeAmount(t *testing.T) {
 
 func TestInvestFund_FundNotFound(t *testing.T) {
 	s, fundMock, _, _ := newFundServer(t, &mockAccountClient{})
-	fundMock.ExpectQuery("SELECT minimum_contribution, active FROM investment_funds").
+	fundMock.ExpectQuery("SELECT minimum_contribution, active, account_id FROM investment_funds").
 		WillReturnError(sql.ErrNoRows)
 	_, err := s.InvestFund(context.Background(), &pb.InvestFundRequest{FundId: 99, Amount: 1000})
 	require.Error(t, err)
@@ -1102,7 +1125,7 @@ func TestInvestFund_FundNotFound(t *testing.T) {
 
 func TestInvestFund_FundDBError(t *testing.T) {
 	s, fundMock, _, _ := newFundServer(t, &mockAccountClient{})
-	fundMock.ExpectQuery("SELECT minimum_contribution, active FROM investment_funds").
+	fundMock.ExpectQuery("SELECT minimum_contribution, active, account_id FROM investment_funds").
 		WillReturnError(fmt.Errorf("connection reset"))
 	_, err := s.InvestFund(context.Background(), &pb.InvestFundRequest{FundId: 1, Amount: 1000})
 	require.Error(t, err)
@@ -1111,8 +1134,8 @@ func TestInvestFund_FundDBError(t *testing.T) {
 
 func TestInvestFund_FundInactive(t *testing.T) {
 	s, fundMock, _, _ := newFundServer(t, &mockAccountClient{})
-	fundMock.ExpectQuery("SELECT minimum_contribution, active FROM investment_funds").
-		WillReturnRows(sqlmock.NewRows([]string{"minimum_contribution", "active"}).AddRow(500.0, false))
+	fundMock.ExpectQuery("SELECT minimum_contribution, active, account_id FROM investment_funds").
+		WillReturnRows(sqlmock.NewRows([]string{"minimum_contribution", "active", "account_id"}).AddRow(500.0, false, int64(0)))
 	_, err := s.InvestFund(context.Background(), &pb.InvestFundRequest{FundId: 1, Amount: 1000})
 	require.Error(t, err)
 	assert.Equal(t, codes.NotFound, status.Code(err))
@@ -1120,8 +1143,8 @@ func TestInvestFund_FundInactive(t *testing.T) {
 
 func TestInvestFund_BelowMinimum(t *testing.T) {
 	s, fundMock, _, _ := newFundServer(t, &mockAccountClient{})
-	fundMock.ExpectQuery("SELECT minimum_contribution, active FROM investment_funds").
-		WillReturnRows(sqlmock.NewRows([]string{"minimum_contribution", "active"}).AddRow(5000.0, true))
+	fundMock.ExpectQuery("SELECT minimum_contribution, active, account_id FROM investment_funds").
+		WillReturnRows(sqlmock.NewRows([]string{"minimum_contribution", "active", "account_id"}).AddRow(5000.0, true, int64(0)))
 	_, err := s.InvestFund(context.Background(), &pb.InvestFundRequest{FundId: 1, Amount: 100})
 	require.Error(t, err)
 	assert.Equal(t, codes.InvalidArgument, status.Code(err))
@@ -1129,8 +1152,8 @@ func TestInvestFund_BelowMinimum(t *testing.T) {
 
 func TestInvestFund_AccountNotFound(t *testing.T) {
 	s, fundMock, accountDBMock, _ := newFundServer(t, &mockAccountClient{})
-	fundMock.ExpectQuery("SELECT minimum_contribution, active FROM investment_funds").
-		WillReturnRows(sqlmock.NewRows([]string{"minimum_contribution", "active"}).AddRow(500.0, true))
+	fundMock.ExpectQuery("SELECT minimum_contribution, active, account_id FROM investment_funds").
+		WillReturnRows(sqlmock.NewRows([]string{"minimum_contribution", "active", "account_id"}).AddRow(500.0, true, int64(0)))
 	accountDBMock.ExpectQuery("SELECT available_balance FROM accounts").
 		WillReturnError(sql.ErrNoRows)
 	_, err := s.InvestFund(context.Background(), &pb.InvestFundRequest{
@@ -1142,8 +1165,8 @@ func TestInvestFund_AccountNotFound(t *testing.T) {
 
 func TestInvestFund_AccountDBError(t *testing.T) {
 	s, fundMock, accountDBMock, _ := newFundServer(t, &mockAccountClient{})
-	fundMock.ExpectQuery("SELECT minimum_contribution, active FROM investment_funds").
-		WillReturnRows(sqlmock.NewRows([]string{"minimum_contribution", "active"}).AddRow(500.0, true))
+	fundMock.ExpectQuery("SELECT minimum_contribution, active, account_id FROM investment_funds").
+		WillReturnRows(sqlmock.NewRows([]string{"minimum_contribution", "active", "account_id"}).AddRow(500.0, true, int64(0)))
 	accountDBMock.ExpectQuery("SELECT available_balance FROM accounts").
 		WillReturnError(fmt.Errorf("db error"))
 	_, err := s.InvestFund(context.Background(), &pb.InvestFundRequest{
@@ -1155,8 +1178,8 @@ func TestInvestFund_AccountDBError(t *testing.T) {
 
 func TestInvestFund_InsufficientBalance(t *testing.T) {
 	s, fundMock, accountDBMock, _ := newFundServer(t, &mockAccountClient{})
-	fundMock.ExpectQuery("SELECT minimum_contribution, active FROM investment_funds").
-		WillReturnRows(sqlmock.NewRows([]string{"minimum_contribution", "active"}).AddRow(500.0, true))
+	fundMock.ExpectQuery("SELECT minimum_contribution, active, account_id FROM investment_funds").
+		WillReturnRows(sqlmock.NewRows([]string{"minimum_contribution", "active", "account_id"}).AddRow(500.0, true, int64(0)))
 	accountDBMock.ExpectQuery("SELECT available_balance FROM accounts").
 		WillReturnRows(sqlmock.NewRows([]string{"available_balance"}).AddRow(200.0))
 	_, err := s.InvestFund(context.Background(), &pb.InvestFundRequest{
@@ -1168,8 +1191,8 @@ func TestInvestFund_InsufficientBalance(t *testing.T) {
 
 func TestInvestFund_DebitFails(t *testing.T) {
 	s, fundMock, accountDBMock, _ := newFundServer(t, &mockAccountClient{})
-	fundMock.ExpectQuery("SELECT minimum_contribution, active FROM investment_funds").
-		WillReturnRows(sqlmock.NewRows([]string{"minimum_contribution", "active"}).AddRow(500.0, true))
+	fundMock.ExpectQuery("SELECT minimum_contribution, active, account_id FROM investment_funds").
+		WillReturnRows(sqlmock.NewRows([]string{"minimum_contribution", "active", "account_id"}).AddRow(500.0, true, int64(0)))
 	accountDBMock.ExpectQuery("SELECT available_balance FROM accounts").
 		WillReturnRows(sqlmock.NewRows([]string{"available_balance"}).AddRow(5000.0))
 	accountDBMock.ExpectExec("UPDATE accounts SET balance = balance -").
@@ -1183,8 +1206,8 @@ func TestInvestFund_DebitFails(t *testing.T) {
 
 func TestInvestFund_BeginTxFails(t *testing.T) {
 	s, fundMock, accountDBMock, _ := newFundServer(t, &mockAccountClient{})
-	fundMock.ExpectQuery("SELECT minimum_contribution, active FROM investment_funds").
-		WillReturnRows(sqlmock.NewRows([]string{"minimum_contribution", "active"}).AddRow(500.0, true))
+	fundMock.ExpectQuery("SELECT minimum_contribution, active, account_id FROM investment_funds").
+		WillReturnRows(sqlmock.NewRows([]string{"minimum_contribution", "active", "account_id"}).AddRow(500.0, true, int64(0)))
 	accountDBMock.ExpectQuery("SELECT available_balance FROM accounts").
 		WillReturnRows(sqlmock.NewRows([]string{"available_balance"}).AddRow(5000.0))
 	accountDBMock.ExpectExec("UPDATE accounts SET balance = balance -").
@@ -1202,8 +1225,8 @@ func TestInvestFund_BeginTxFails(t *testing.T) {
 
 func TestInvestFund_UpdateLiquidAssetsFails(t *testing.T) {
 	s, fundMock, accountDBMock, _ := newFundServer(t, &mockAccountClient{})
-	fundMock.ExpectQuery("SELECT minimum_contribution, active FROM investment_funds").
-		WillReturnRows(sqlmock.NewRows([]string{"minimum_contribution", "active"}).AddRow(500.0, true))
+	fundMock.ExpectQuery("SELECT minimum_contribution, active, account_id FROM investment_funds").
+		WillReturnRows(sqlmock.NewRows([]string{"minimum_contribution", "active", "account_id"}).AddRow(500.0, true, int64(0)))
 	accountDBMock.ExpectQuery("SELECT available_balance FROM accounts").
 		WillReturnRows(sqlmock.NewRows([]string{"available_balance"}).AddRow(5000.0))
 	accountDBMock.ExpectExec("UPDATE accounts SET balance = balance -").
@@ -1223,8 +1246,8 @@ func TestInvestFund_UpdateLiquidAssetsFails(t *testing.T) {
 
 func TestInvestFund_UpsertPositionFails(t *testing.T) {
 	s, fundMock, accountDBMock, _ := newFundServer(t, &mockAccountClient{})
-	fundMock.ExpectQuery("SELECT minimum_contribution, active FROM investment_funds").
-		WillReturnRows(sqlmock.NewRows([]string{"minimum_contribution", "active"}).AddRow(500.0, true))
+	fundMock.ExpectQuery("SELECT minimum_contribution, active, account_id FROM investment_funds").
+		WillReturnRows(sqlmock.NewRows([]string{"minimum_contribution", "active", "account_id"}).AddRow(500.0, true, int64(0)))
 	accountDBMock.ExpectQuery("SELECT available_balance FROM accounts").
 		WillReturnRows(sqlmock.NewRows([]string{"available_balance"}).AddRow(5000.0))
 	accountDBMock.ExpectExec("UPDATE accounts SET balance = balance -").
@@ -1246,8 +1269,8 @@ func TestInvestFund_UpsertPositionFails(t *testing.T) {
 
 func TestInvestFund_InsertTransactionFails(t *testing.T) {
 	s, fundMock, accountDBMock, _ := newFundServer(t, &mockAccountClient{})
-	fundMock.ExpectQuery("SELECT minimum_contribution, active FROM investment_funds").
-		WillReturnRows(sqlmock.NewRows([]string{"minimum_contribution", "active"}).AddRow(500.0, true))
+	fundMock.ExpectQuery("SELECT minimum_contribution, active, account_id FROM investment_funds").
+		WillReturnRows(sqlmock.NewRows([]string{"minimum_contribution", "active", "account_id"}).AddRow(500.0, true, int64(0)))
 	accountDBMock.ExpectQuery("SELECT available_balance FROM accounts").
 		WillReturnRows(sqlmock.NewRows([]string{"available_balance"}).AddRow(5000.0))
 	accountDBMock.ExpectExec("UPDATE accounts SET balance = balance -").
@@ -1271,8 +1294,8 @@ func TestInvestFund_InsertTransactionFails(t *testing.T) {
 
 func TestInvestFund_CommitFails(t *testing.T) {
 	s, fundMock, accountDBMock, _ := newFundServer(t, &mockAccountClient{})
-	fundMock.ExpectQuery("SELECT minimum_contribution, active FROM investment_funds").
-		WillReturnRows(sqlmock.NewRows([]string{"minimum_contribution", "active"}).AddRow(500.0, true))
+	fundMock.ExpectQuery("SELECT minimum_contribution, active, account_id FROM investment_funds").
+		WillReturnRows(sqlmock.NewRows([]string{"minimum_contribution", "active", "account_id"}).AddRow(500.0, true, int64(0)))
 	accountDBMock.ExpectQuery("SELECT available_balance FROM accounts").
 		WillReturnRows(sqlmock.NewRows([]string{"available_balance"}).AddRow(5000.0))
 	accountDBMock.ExpectExec("UPDATE accounts SET balance = balance -").
@@ -1298,7 +1321,7 @@ func TestInvestFund_CommitFails(t *testing.T) {
 
 func TestWithdrawFund_FundNotFound(t *testing.T) {
 	s, fundMock, _, _ := newFundServer(t, &mockAccountClient{})
-	fundMock.ExpectQuery("SELECT liquid_assets, active FROM investment_funds").
+	fundMock.ExpectQuery("SELECT liquid_assets, active, account_id FROM investment_funds").
 		WillReturnError(sql.ErrNoRows)
 	_, err := s.WithdrawFund(context.Background(), &pb.WithdrawFundRequest{FundId: 99, ClientId: 1, ClientType: "CLIENT", Amount: 100})
 	require.Error(t, err)
@@ -1307,7 +1330,7 @@ func TestWithdrawFund_FundNotFound(t *testing.T) {
 
 func TestWithdrawFund_FundDBError(t *testing.T) {
 	s, fundMock, _, _ := newFundServer(t, &mockAccountClient{})
-	fundMock.ExpectQuery("SELECT liquid_assets, active FROM investment_funds").
+	fundMock.ExpectQuery("SELECT liquid_assets, active, account_id FROM investment_funds").
 		WillReturnError(fmt.Errorf("db error"))
 	_, err := s.WithdrawFund(context.Background(), &pb.WithdrawFundRequest{FundId: 1, ClientId: 1, ClientType: "CLIENT", Amount: 100})
 	require.Error(t, err)
@@ -1316,8 +1339,8 @@ func TestWithdrawFund_FundDBError(t *testing.T) {
 
 func TestWithdrawFund_FundInactive(t *testing.T) {
 	s, fundMock, _, _ := newFundServer(t, &mockAccountClient{})
-	fundMock.ExpectQuery("SELECT liquid_assets, active FROM investment_funds").
-		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active"}).AddRow(10000.0, false))
+	fundMock.ExpectQuery("SELECT liquid_assets, active, account_id FROM investment_funds").
+		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active", "account_id"}).AddRow(10000.0, false, int64(0)))
 	_, err := s.WithdrawFund(context.Background(), &pb.WithdrawFundRequest{FundId: 1, ClientId: 1, ClientType: "CLIENT", Amount: 100})
 	require.Error(t, err)
 	assert.Equal(t, codes.NotFound, status.Code(err))
@@ -1325,8 +1348,8 @@ func TestWithdrawFund_FundInactive(t *testing.T) {
 
 func TestWithdrawFund_PositionNotFound(t *testing.T) {
 	s, fundMock, _, _ := newFundServer(t, &mockAccountClient{})
-	fundMock.ExpectQuery("SELECT liquid_assets, active FROM investment_funds").
-		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active"}).AddRow(10000.0, true))
+	fundMock.ExpectQuery("SELECT liquid_assets, active, account_id FROM investment_funds").
+		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active", "account_id"}).AddRow(10000.0, true, int64(0)))
 	fundMock.ExpectQuery("SELECT total_invested_amount FROM client_fund_positions").
 		WillReturnError(sql.ErrNoRows)
 	_, err := s.WithdrawFund(context.Background(), &pb.WithdrawFundRequest{FundId: 1, ClientId: 7, ClientType: "CLIENT", Amount: 100})
@@ -1336,8 +1359,8 @@ func TestWithdrawFund_PositionNotFound(t *testing.T) {
 
 func TestWithdrawFund_PositionDBError(t *testing.T) {
 	s, fundMock, _, _ := newFundServer(t, &mockAccountClient{})
-	fundMock.ExpectQuery("SELECT liquid_assets, active FROM investment_funds").
-		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active"}).AddRow(10000.0, true))
+	fundMock.ExpectQuery("SELECT liquid_assets, active, account_id FROM investment_funds").
+		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active", "account_id"}).AddRow(10000.0, true, int64(0)))
 	fundMock.ExpectQuery("SELECT total_invested_amount FROM client_fund_positions").
 		WillReturnError(fmt.Errorf("db error"))
 	_, err := s.WithdrawFund(context.Background(), &pb.WithdrawFundRequest{FundId: 1, ClientId: 7, ClientType: "CLIENT", Amount: 100})
@@ -1347,8 +1370,8 @@ func TestWithdrawFund_PositionDBError(t *testing.T) {
 
 func TestWithdrawFund_AmountExceedsPosition(t *testing.T) {
 	s, fundMock, _, _ := newFundServer(t, &mockAccountClient{})
-	fundMock.ExpectQuery("SELECT liquid_assets, active FROM investment_funds").
-		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active"}).AddRow(10000.0, true))
+	fundMock.ExpectQuery("SELECT liquid_assets, active, account_id FROM investment_funds").
+		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active", "account_id"}).AddRow(10000.0, true, int64(0)))
 	fundMock.ExpectQuery("SELECT total_invested_amount FROM client_fund_positions").
 		WillReturnRows(sqlmock.NewRows([]string{"total_invested_amount"}).AddRow(500.0))
 	_, err := s.WithdrawFund(context.Background(), &pb.WithdrawFundRequest{
@@ -1360,8 +1383,8 @@ func TestWithdrawFund_AmountExceedsPosition(t *testing.T) {
 
 func TestWithdrawFund_CreditAccountFails(t *testing.T) {
 	s, fundMock, accountDBMock, _ := newFundServer(t, &mockAccountClient{})
-	fundMock.ExpectQuery("SELECT liquid_assets, active FROM investment_funds").
-		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active"}).AddRow(10000.0, true))
+	fundMock.ExpectQuery("SELECT liquid_assets, active, account_id FROM investment_funds").
+		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active", "account_id"}).AddRow(10000.0, true, int64(0)))
 	fundMock.ExpectQuery("SELECT total_invested_amount FROM client_fund_positions").
 		WillReturnRows(sqlmock.NewRows([]string{"total_invested_amount"}).AddRow(1000.0))
 	accountDBMock.ExpectExec("UPDATE accounts SET balance = balance \\+").
@@ -1375,8 +1398,8 @@ func TestWithdrawFund_CreditAccountFails(t *testing.T) {
 
 func TestWithdrawFund_BeginTxFails(t *testing.T) {
 	s, fundMock, accountDBMock, _ := newFundServer(t, &mockAccountClient{})
-	fundMock.ExpectQuery("SELECT liquid_assets, active FROM investment_funds").
-		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active"}).AddRow(10000.0, true))
+	fundMock.ExpectQuery("SELECT liquid_assets, active, account_id FROM investment_funds").
+		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active", "account_id"}).AddRow(10000.0, true, int64(0)))
 	fundMock.ExpectQuery("SELECT total_invested_amount FROM client_fund_positions").
 		WillReturnRows(sqlmock.NewRows([]string{"total_invested_amount"}).AddRow(1000.0))
 	accountDBMock.ExpectExec("UPDATE accounts SET balance = balance \\+").
@@ -1393,8 +1416,8 @@ func TestWithdrawFund_BeginTxFails(t *testing.T) {
 
 func TestWithdrawFund_UpdateLiquidAssetsFails(t *testing.T) {
 	s, fundMock, accountDBMock, _ := newFundServer(t, &mockAccountClient{})
-	fundMock.ExpectQuery("SELECT liquid_assets, active FROM investment_funds").
-		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active"}).AddRow(10000.0, true))
+	fundMock.ExpectQuery("SELECT liquid_assets, active, account_id FROM investment_funds").
+		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active", "account_id"}).AddRow(10000.0, true, int64(0)))
 	fundMock.ExpectQuery("SELECT total_invested_amount FROM client_fund_positions").
 		WillReturnRows(sqlmock.NewRows([]string{"total_invested_amount"}).AddRow(1000.0))
 	accountDBMock.ExpectExec("UPDATE accounts SET balance = balance \\+").
@@ -1414,8 +1437,8 @@ func TestWithdrawFund_UpdateLiquidAssetsFails(t *testing.T) {
 
 func TestWithdrawFund_UpdatePositionFails(t *testing.T) {
 	s, fundMock, accountDBMock, _ := newFundServer(t, &mockAccountClient{})
-	fundMock.ExpectQuery("SELECT liquid_assets, active FROM investment_funds").
-		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active"}).AddRow(10000.0, true))
+	fundMock.ExpectQuery("SELECT liquid_assets, active, account_id FROM investment_funds").
+		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active", "account_id"}).AddRow(10000.0, true, int64(0)))
 	fundMock.ExpectQuery("SELECT total_invested_amount FROM client_fund_positions").
 		WillReturnRows(sqlmock.NewRows([]string{"total_invested_amount"}).AddRow(1000.0))
 	accountDBMock.ExpectExec("UPDATE accounts SET balance = balance \\+").
@@ -1437,8 +1460,8 @@ func TestWithdrawFund_UpdatePositionFails(t *testing.T) {
 
 func TestWithdrawFund_InsertTransactionFails(t *testing.T) {
 	s, fundMock, accountDBMock, _ := newFundServer(t, &mockAccountClient{})
-	fundMock.ExpectQuery("SELECT liquid_assets, active FROM investment_funds").
-		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active"}).AddRow(10000.0, true))
+	fundMock.ExpectQuery("SELECT liquid_assets, active, account_id FROM investment_funds").
+		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active", "account_id"}).AddRow(10000.0, true, int64(0)))
 	fundMock.ExpectQuery("SELECT total_invested_amount FROM client_fund_positions").
 		WillReturnRows(sqlmock.NewRows([]string{"total_invested_amount"}).AddRow(1000.0))
 	accountDBMock.ExpectExec("UPDATE accounts SET balance = balance \\+").
@@ -1462,8 +1485,8 @@ func TestWithdrawFund_InsertTransactionFails(t *testing.T) {
 
 func TestWithdrawFund_CommitFails(t *testing.T) {
 	s, fundMock, accountDBMock, _ := newFundServer(t, &mockAccountClient{})
-	fundMock.ExpectQuery("SELECT liquid_assets, active FROM investment_funds").
-		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active"}).AddRow(10000.0, true))
+	fundMock.ExpectQuery("SELECT liquid_assets, active, account_id FROM investment_funds").
+		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active", "account_id"}).AddRow(10000.0, true, int64(0)))
 	fundMock.ExpectQuery("SELECT total_invested_amount FROM client_fund_positions").
 		WillReturnRows(sqlmock.NewRows([]string{"total_invested_amount"}).AddRow(1000.0))
 	accountDBMock.ExpectExec("UPDATE accounts SET balance = balance \\+").
@@ -1490,8 +1513,8 @@ func TestWithdrawFund_CommitFails(t *testing.T) {
 func TestAutoLiquidate_FetchFundDetailFails(t *testing.T) {
 	s, fundMock, _, _ := newFundServerFull(t, &mockAccountClient{}, &mockOrderClient{})
 	// fund select (liquid < amount → Case 2)
-	fundMock.ExpectQuery("SELECT liquid_assets, active FROM investment_funds").
-		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active"}).AddRow(50.0, true))
+	fundMock.ExpectQuery("SELECT liquid_assets, active, account_id FROM investment_funds").
+		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active", "account_id"}).AddRow(50.0, true, int64(0)))
 	fundMock.ExpectQuery("SELECT total_invested_amount FROM client_fund_positions").
 		WillReturnRows(sqlmock.NewRows([]string{"total_invested_amount"}).AddRow(1000.0))
 	// autoLiquidate: SELECT account_id, manager_id
@@ -1506,8 +1529,8 @@ func TestAutoLiquidate_FetchFundDetailFails(t *testing.T) {
 
 func TestAutoLiquidate_PortfolioQueryFails(t *testing.T) {
 	s, fundMock, _, _ := newFundServerFull(t, &mockAccountClient{}, &mockOrderClient{})
-	fundMock.ExpectQuery("SELECT liquid_assets, active FROM investment_funds").
-		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active"}).AddRow(50.0, true))
+	fundMock.ExpectQuery("SELECT liquid_assets, active, account_id FROM investment_funds").
+		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active", "account_id"}).AddRow(50.0, true, int64(0)))
 	fundMock.ExpectQuery("SELECT total_invested_amount FROM client_fund_positions").
 		WillReturnRows(sqlmock.NewRows([]string{"total_invested_amount"}).AddRow(1000.0))
 	fundMock.ExpectQuery("SELECT account_id, manager_id FROM investment_funds").
@@ -1523,8 +1546,8 @@ func TestAutoLiquidate_PortfolioQueryFails(t *testing.T) {
 
 func TestAutoLiquidate_InsertPendingFails(t *testing.T) {
 	s, fundMock, _, _ := newFundServerFull(t, &mockAccountClient{}, &mockOrderClient{})
-	fundMock.ExpectQuery("SELECT liquid_assets, active FROM investment_funds").
-		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active"}).AddRow(50.0, true))
+	fundMock.ExpectQuery("SELECT liquid_assets, active, account_id FROM investment_funds").
+		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active", "account_id"}).AddRow(50.0, true, int64(0)))
 	fundMock.ExpectQuery("SELECT total_invested_amount FROM client_fund_positions").
 		WillReturnRows(sqlmock.NewRows([]string{"total_invested_amount"}).AddRow(1000.0))
 	fundMock.ExpectQuery("SELECT account_id, manager_id FROM investment_funds").
@@ -1831,8 +1854,8 @@ func TestGetFundPerformanceHistory_ScanError(t *testing.T) {
 
 func TestAutoLiquidate_ScanError(t *testing.T) {
 	s, fundMock, _, _ := newFundServerFull(t, &mockAccountClient{}, &mockOrderClient{})
-	fundMock.ExpectQuery("SELECT liquid_assets, active FROM investment_funds").
-		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active"}).AddRow(50.0, true))
+	fundMock.ExpectQuery("SELECT liquid_assets, active, account_id FROM investment_funds").
+		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active", "account_id"}).AddRow(50.0, true, int64(0)))
 	fundMock.ExpectQuery("SELECT total_invested_amount FROM client_fund_positions").
 		WillReturnRows(sqlmock.NewRows([]string{"total_invested_amount"}).AddRow(1000.0))
 	fundMock.ExpectQuery("SELECT account_id, manager_id FROM investment_funds").
@@ -1898,8 +1921,8 @@ func TestAutoLiquidate_BreakWhenDeficitCovered(t *testing.T) {
 	s, fundMock, _, _ := newFundServerFull(t, &mockAccountClient{}, order)
 
 	// liquid=100, position=1000, deficit=900
-	fundMock.ExpectQuery("SELECT liquid_assets, active FROM investment_funds").
-		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active"}).AddRow(100.0, true))
+	fundMock.ExpectQuery("SELECT liquid_assets, active, account_id FROM investment_funds").
+		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active", "account_id"}).AddRow(100.0, true, int64(0)))
 	fundMock.ExpectQuery("SELECT total_invested_amount FROM client_fund_positions").
 		WillReturnRows(sqlmock.NewRows([]string{"total_invested_amount"}).AddRow(1000.0))
 	fundMock.ExpectQuery("SELECT account_id, manager_id FROM investment_funds").
@@ -1924,8 +1947,8 @@ func TestAutoLiquidate_BreakWhenDeficitCovered(t *testing.T) {
 func TestWithdrawFund_FetchFundError(t *testing.T) {
 	// All steps succeed but fetchFundByID fails after commit
 	s, fundMock, accountDBMock, _ := newFundServer(t, &mockAccountClient{})
-	fundMock.ExpectQuery("SELECT liquid_assets, active FROM investment_funds").
-		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active"}).AddRow(10000.0, true))
+	fundMock.ExpectQuery("SELECT liquid_assets, active, account_id FROM investment_funds").
+		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active", "account_id"}).AddRow(10000.0, true, int64(0)))
 	fundMock.ExpectQuery("SELECT total_invested_amount FROM client_fund_positions").
 		WillReturnRows(sqlmock.NewRows([]string{"total_invested_amount"}).AddRow(1000.0))
 	accountDBMock.ExpectExec("UPDATE accounts SET balance = balance \\+").
@@ -1952,8 +1975,8 @@ func TestWithdrawFund_FetchFundError(t *testing.T) {
 func TestWithdrawFund_ZeroPositionZeroAmount(t *testing.T) {
 	// positionAmount=0, amount=0 → amount becomes positionAmount=0 → InvalidArgument "nothing to withdraw"
 	s, fundMock, _, _ := newFundServer(t, &mockAccountClient{})
-	fundMock.ExpectQuery("SELECT liquid_assets, active FROM investment_funds").
-		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active"}).AddRow(10000.0, true))
+	fundMock.ExpectQuery("SELECT liquid_assets, active, account_id FROM investment_funds").
+		WillReturnRows(sqlmock.NewRows([]string{"liquid_assets", "active", "account_id"}).AddRow(10000.0, true, int64(0)))
 	fundMock.ExpectQuery("SELECT total_invested_amount FROM client_fund_positions").
 		WillReturnRows(sqlmock.NewRows([]string{"total_invested_amount"}).AddRow(0.0))
 	_, err := s.WithdrawFund(context.Background(), &pb.WithdrawFundRequest{
@@ -1965,11 +1988,15 @@ func TestWithdrawFund_ZeroPositionZeroAmount(t *testing.T) {
 
 func TestInvestFund_Happy(t *testing.T) {
 	s, fundMock, accountDBMock, empMock := newFundServer(t, &mockAccountClient{})
-	fundMock.ExpectQuery("SELECT minimum_contribution, active FROM investment_funds").
-		WillReturnRows(sqlmock.NewRows([]string{"minimum_contribution", "active"}).AddRow(500.0, true))
+	fundMock.ExpectQuery("SELECT minimum_contribution, active, account_id FROM investment_funds").
+		WillReturnRows(sqlmock.NewRows([]string{"minimum_contribution", "active", "account_id"}).AddRow(500.0, true, int64(42)))
 	accountDBMock.ExpectQuery("SELECT available_balance FROM accounts").
 		WillReturnRows(sqlmock.NewRows([]string{"available_balance"}).AddRow(5000.0))
+	// Debit source account
 	accountDBMock.ExpectExec("UPDATE accounts SET balance = balance -").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	// Credit fund account
+	accountDBMock.ExpectExec("UPDATE accounts SET balance = balance \\+").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	fundMock.ExpectBegin()
 	fundMock.ExpectExec("UPDATE investment_funds SET liquid_assets = liquid_assets \\+").

--- a/services/otc-service/handlers/interbank_outgoing.go
+++ b/services/otc-service/handlers/interbank_outgoing.go
@@ -75,7 +75,7 @@ func otcGenerateUUID() string {
 
 func otcOwnRoutingInt() int {
 	var n int
-	fmt.Sscanf(os.Getenv("OWN_ROUTING_NUMBER"), "%d", &n)
+	_, _ = fmt.Sscanf(os.Getenv("OWN_ROUTING_NUMBER"), "%d", &n)
 	return n
 }
 

--- a/services/otc-service/handlers/interbank_outgoing_test.go
+++ b/services/otc-service/handlers/interbank_outgoing_test.go
@@ -50,24 +50,6 @@ func mockPartnerForwardServer(t *testing.T) *httptest.Server {
 	}))
 }
 
-// mockPartnerAcceptServer returns a test HTTP server that handles
-// GET /otc/interbank/negotiations/888/<id>/accept → 204.
-func mockPartnerAcceptServer(t *testing.T, forwardPath string) *httptest.Server {
-	t.Helper()
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodPost && r.URL.Path == "/otc/interbank/negotiations":
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusCreated)
-			_ = json.NewEncoder(w).Encode(map[string]interface{}{"routingNumber": 999, "id": "42"})
-		case r.Method == http.MethodGet && r.URL.Path == forwardPath:
-			w.WriteHeader(http.StatusNoContent)
-		default:
-			w.WriteHeader(http.StatusNotFound)
-		}
-	}))
-}
-
 // mock2PCServer returns an HTTP server handling NEW_TX (vote YES) and COMMIT_TX (204).
 func mock2PCServer(t *testing.T, voteYes bool) *httptest.Server {
 	t.Helper()

--- a/services/payment-service/handlers/interbank_outgoing.go
+++ b/services/payment-service/handlers/interbank_outgoing.go
@@ -78,7 +78,7 @@ func generateUUID() string {
 // ownRoutingInt returns OWN_ROUTING_NUMBER as int.
 func ownRoutingInt() int {
 	var n int
-	fmt.Sscanf(os.Getenv("OWN_ROUTING_NUMBER"), "%d", &n)
+	_, _ = fmt.Sscanf(os.Getenv("OWN_ROUTING_NUMBER"), "%d", &n)
 	return n
 }
 
@@ -236,7 +236,7 @@ func executeOutgoing2PC(ctx context.Context, s *PaymentServer, req *pb.CreatePay
 		releaseReservation()
 		return nil, status.Errorf(codes.Unavailable, "NEW_TX request failed: %v", err)
 	}
-	defer newTxResp.Body.Close()
+	defer func() { _ = newTxResp.Body.Close() }()
 
 	if newTxResp.StatusCode != http.StatusOK {
 		releaseReservation()
@@ -269,7 +269,7 @@ func executeOutgoing2PC(ctx context.Context, s *PaymentServer, req *pb.CreatePay
 		releaseReservation()
 		return nil, status.Errorf(codes.Unavailable, "COMMIT_TX request failed: %v", err)
 	}
-	defer commitResp.Body.Close()
+	defer func() { _ = commitResp.Body.Close() }()
 
 	if commitResp.StatusCode != http.StatusNoContent {
 		sendRollback(ctx, bankURL, bank.APIKey, txID)

--- a/services/payment-service/handlers/preview.go
+++ b/services/payment-service/handlers/preview.go
@@ -89,7 +89,7 @@ func (s *PaymentServer) previewCrossBank(ctx context.Context, req *pb.PreviewPay
 	if probeErr != nil || probeResp.StatusCode != http.StatusOK {
 		return fallback, nil
 	}
-	defer probeResp.Body.Close()
+	defer func() { _ = probeResp.Body.Close() }()
 
 	var vote ibVoteResponse
 	if err := json.NewDecoder(probeResp.Body).Decode(&vote); err != nil || vote.Vote != "YES" {
@@ -160,7 +160,6 @@ func (s *PaymentServer) previewOwnBank(ctx context.Context, req *pb.PreviewPayme
 	}
 
 	var exchangeRate, finalAmount float64
-	finalAmount = req.Amount
 	switch {
 	case fromCurrencyCode == "RSD":
 		toSelling, err := getRate(toCurrencyCode, "selling_rate")

--- a/services/securities-service/handlers/coverage_gaps_test.go
+++ b/services/securities-service/handlers/coverage_gaps_test.go
@@ -276,7 +276,7 @@ func TestGetListings_ScanError(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
 	mock.ExpectQuery("SELECT l.id").
 		WillReturnRows(sqlmock.NewRows(listingSummaryCols).
-			AddRow("bad", "AAPL", "Apple", "STOCK", "NASDAQ",
+			AddRow("bad", "AAPL", "Apple", "STOCK", "NASDAQ", "USD",
 				150.0, 151.0, 149.0, int64(1000), 0.0,
 				int64(0), 1.0, nil, 0.0,
 				nil, nil, nil, nil))
@@ -294,7 +294,7 @@ func TestGetListings_WithOptionFields(t *testing.T) {
 	settlementDate := time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC)
 	mock.ExpectQuery("SELECT l.id").
 		WillReturnRows(sqlmock.NewRows(listingSummaryCols).
-			AddRow(int64(10), "AAPL260101C00150", "AAPL Call", "OPTION", "CBOE",
+			AddRow(int64(10), "AAPL260101C00150", "AAPL Call", "OPTION", "CBOE", "USD",
 				5.0, 5.1, 4.9, int64(200), 0.0,
 				int64(0), 1.0, int64(1), 200.0,
 				"CALL", 150.0, settlementDate, int64(5000)))

--- a/services/securities-service/handlers/listing_test.go
+++ b/services/securities-service/handlers/listing_test.go
@@ -16,14 +16,14 @@ import (
 
 // Column sets for row builders
 var listingSummaryCols = []string{
-	"id", "ticker", "name", "type", "acronym",
+	"id", "ticker", "name", "type", "acronym", "currency",
 	"price", "ask", "bid", "volume", "change",
 	"outstanding_shares", "contract_size", "stock_listing_id", "stock_price",
 	"option_type", "strike_price", "settlement_date", "open_interest",
 }
 
 var listingDetailCols = []string{
-	"id", "ticker", "name", "type", "acronym",
+	"id", "ticker", "name", "type", "acronym", "currency",
 	"price", "ask", "bid", "volume", "change",
 	"outstanding_shares", "dividend_yield",
 	"base_currency", "quote_currency", "liquidity",
@@ -59,7 +59,7 @@ func TestGetListings_StockDerivedFields(t *testing.T) {
 			// price=200, change=10 → prev=190, changePercent=5.263...
 			// maintenanceMargin(STOCK) = 0.5*200 = 100
 			// nominalValue(STOCK) = 200
-			AddRow(1, "AAPL", "Apple Inc", "STOCK", "NASDAQ",
+			AddRow(1, "AAPL", "Apple Inc", "STOCK", "NASDAQ", "USD",
 				200.0, 202.0, 198.0, int64(1000000), 10.0,
 				int64(5000000), 1.0, nil, 0.0,
 				nil, nil, nil, nil))
@@ -88,7 +88,7 @@ func TestGetListings_ForexDerivedFields(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows(listingSummaryCols).
 			// maintenanceMargin(FOREX_PAIR) = 1000 * 1.1 * 0.10 = 110
 			// nominalValue(FOREX_PAIR) = 1000 * 1.1 = 1100
-			AddRow(2, "EUR/USD", "Euro / US Dollar", "FOREX_PAIR", "FOREX",
+			AddRow(2, "EUR/USD", "Euro / US Dollar", "FOREX_PAIR", "FOREX", "USD",
 				1.1, 1.101, 1.099, int64(0), 0.0,
 				int64(0), 1.0, nil, 0.0,
 				nil, nil, nil, nil))
@@ -108,7 +108,7 @@ func TestGetListings_FuturesDerivedFields(t *testing.T) {
 	mock.ExpectQuery("SELECT l.id").
 		WillReturnRows(sqlmock.NewRows(listingSummaryCols).
 			// contractSize=1000, price=80 → maintenanceMargin = 1000*80*0.10 = 8000
-			AddRow(3, "CLJ25", "Crude Oil Jul 2025", "FUTURES_CONTRACT", "NYMEX",
+			AddRow(3, "CLJ25", "Crude Oil Jul 2025", "FUTURES_CONTRACT", "NYMEX", "USD",
 				80.0, 80.5, 79.5, int64(50000), 0.0,
 				int64(0), 1000.0, nil, 0.0,
 				nil, nil, nil, nil))
@@ -128,7 +128,7 @@ func TestGetListings_OptionDerivedFields(t *testing.T) {
 	mock.ExpectQuery("SELECT l.id").
 		WillReturnRows(sqlmock.NewRows(listingSummaryCols).
 			// stock_listing_id=1, stockPrice=200 → maintenanceMargin = 100*0.5*200 = 10000
-			AddRow(4, "AAPL240101C00150000", "AAPL Call", "OPTION", "CBOE",
+			AddRow(4, "AAPL240101C00150000", "AAPL Call", "OPTION", "CBOE", "USD",
 				5.0, 5.1, 4.9, int64(200), 0.0,
 				int64(0), 1.0, int64(1), 200.0,
 				nil, nil, nil, nil))
@@ -191,7 +191,7 @@ func TestGetListings_QueryDBError(t *testing.T) {
 
 func addStockDetailRow(rows *sqlmock.Rows) *sqlmock.Rows {
 	return rows.AddRow(
-		int64(1), "AAPL", "Apple Inc", "STOCK", "NASDAQ",
+		int64(1), "AAPL", "Apple Inc", "STOCK", "NASDAQ", "USD",
 		150.0, 151.0, 149.0, int64(500000), 5.0,
 		// stock
 		int64(1000000), 0.02,
@@ -238,7 +238,7 @@ func TestGetListingById_Forex(t *testing.T) {
 	mock.ExpectQuery("SELECT l.id, l.ticker").
 		WithArgs(int64(2)).
 		WillReturnRows(sqlmock.NewRows(listingDetailCols).AddRow(
-			int64(2), "EUR/USD", "Euro / US Dollar", "FOREX_PAIR", "FOREX",
+			int64(2), "EUR/USD", "Euro / US Dollar", "FOREX_PAIR", "FOREX", "USD",
 			1.1, 1.101, 1.099, int64(0), 0.0,
 			// stock (nil)
 			nil, nil,
@@ -270,7 +270,7 @@ func TestGetListingById_Futures(t *testing.T) {
 	mock.ExpectQuery("SELECT l.id, l.ticker").
 		WithArgs(int64(3)).
 		WillReturnRows(sqlmock.NewRows(listingDetailCols).AddRow(
-			int64(3), "CLJ25", "Crude Oil", "FUTURES_CONTRACT", "NYMEX",
+			int64(3), "CLJ25", "Crude Oil", "FUTURES_CONTRACT", "NYMEX", "USD",
 			80.0, 80.5, 79.5, int64(50000), 0.0,
 			// stock (nil)
 			nil, nil,
@@ -300,7 +300,7 @@ func TestGetListingById_Option(t *testing.T) {
 	mock.ExpectQuery("SELECT l.id, l.ticker").
 		WithArgs(int64(4)).
 		WillReturnRows(sqlmock.NewRows(listingDetailCols).AddRow(
-			int64(4), "AAPL250321C00150000", "AAPL Call 150", "OPTION", "CBOE",
+			int64(4), "AAPL250321C00150000", "AAPL Call 150", "OPTION", "CBOE", "USD",
 			5.0, 5.2, 4.8, int64(200), 0.0,
 			// stock (nil)
 			nil, nil,

--- a/services/securities-service/handlers/redis_test.go
+++ b/services/securities-service/handlers/redis_test.go
@@ -59,7 +59,7 @@ func TestLoadCachedListing_KeyMissing_ReturnsNil(t *testing.T) {
 
 func TestLoadCachedListing_InvalidProto_ReturnsNil(t *testing.T) {
 	mr, rdb := newMiniRedis(t)
-	mr.Set(listingCacheKey(1), "not-valid-proto-json")
+	_ = mr.Set(listingCacheKey(1), "not-valid-proto-json")
 
 	s := &SecuritiesServer{Redis: rdb}
 	assert.Nil(t, s.loadCachedListing(context.Background(), 1))
@@ -70,7 +70,7 @@ func TestLoadCachedListing_ValidCache_ReturnsResponse(t *testing.T) {
 	resp := sampleListingResponse(1)
 	data, err := protojson.Marshal(resp)
 	require.NoError(t, err)
-	mr.Set(listingCacheKey(1), string(data))
+	_ = mr.Set(listingCacheKey(1), string(data))
 
 	s := &SecuritiesServer{Redis: rdb}
 	result := s.loadCachedListing(context.Background(), 1)
@@ -185,7 +185,7 @@ func TestGetListingById_CacheMiss_QueriesDBAndPopulatesCache(t *testing.T) {
 
 	// Minimal DB row for a STOCK listing.
 	cols := []string{
-		"id", "ticker", "name", "type", "acronym",
+		"id", "ticker", "name", "type", "acronym", "currency",
 		"price", "ask", "bid", "volume", "change",
 		"outstanding_shares", "dividend_yield",
 		"base_currency", "quote_currency", "liquidity",
@@ -195,7 +195,7 @@ func TestGetListingById_CacheMiss_QueriesDBAndPopulatesCache(t *testing.T) {
 	}
 	mock.ExpectQuery(`SELECT l.id`).WillReturnRows(
 		sqlmock.NewRows(cols).AddRow(
-			int64(10), "MSFT", "Microsoft", "STOCK", "NASDAQ",
+			int64(10), "MSFT", "Microsoft", "STOCK", "NASDAQ", "USD",
 			300.0, 301.0, 299.0, int64(5000000), 5.0,
 			int64(7000000), 0.5,
 			nil, nil, nil,


### PR DESCRIPTION
## Summary

- api-gateway: fix gofmt on interbank.go; add `PreviewPayment` to `stubPaymentClient`
- auth-service: add `GetSupervisors` to `mockEmployeeClient`
- fund-service: fix `portfolioRows.Close` errcheck; update test mocks for `account_id` and fund account debit/credit operations
- otc-service: fix `fmt.Sscanf` errcheck; remove unused `mockPartnerAcceptServer`
- payment-service: fix `fmt.Sscanf` and `Body.Close` errcheck; remove ineffectual `finalAmount` assignment
- securities-service: add missing `currency` column to `listingDetailCols` and all related `AddRow` calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)