### PR TITLE
fix: resolve remaining lint errors in api-gateway and auth-service

### DIFF
--- a/services/api-gateway/handlers/otc_interbank.go
+++ b/services/api-gateway/handlers/otc_interbank.go
@@ -18,7 +18,7 @@ import (
 
 func gatewayOwnRoutingInt() int32 {
 	var n int32
-	fmt.Sscanf(os.Getenv("OWN_ROUTING_NUMBER"), "%d", &n)
+	_, _ = fmt.Sscanf(os.Getenv("OWN_ROUTING_NUMBER"), "%d", &n)
 	return n
 }
 
@@ -291,7 +291,7 @@ func GetExternalStocks() gin.HandlerFunc {
 			c.JSON(http.StatusOK, gin.H{"items": []any{}, "bankName": bank.BankName})
 			return
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 
 		var items []any
 		if err := json.NewDecoder(resp.Body).Decode(&items); err != nil {
@@ -349,7 +349,7 @@ func ForwardNegotiationToPartner(body otcNegotiationBody, partnerRoutingNumber s
 	if err != nil {
 		return 0, "", fmt.Errorf("partner request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
 		return 0, "", fmt.Errorf("partner returned status %d", resp.StatusCode)

--- a/services/auth-service/handlers/coverage_gaps_test.go
+++ b/services/auth-service/handlers/coverage_gaps_test.go
@@ -28,7 +28,7 @@ func newAuthServerFull(t *testing.T) (*AuthServer, sqlmock.Sqlmock) {
 	t.Helper()
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
-	t.Cleanup(func() { db.Close() })
+	t.Cleanup(func() { _ = db.Close() })
 	s := &AuthServer{
 		DB:             db,
 		EmployeeClient: new(mockEmployeeClient),
@@ -42,7 +42,7 @@ func newAuthServerWithRedis(t *testing.T) (*AuthServer, sqlmock.Sqlmock, *minire
 	t.Helper()
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
-	t.Cleanup(func() { db.Close() })
+	t.Cleanup(func() { _ = db.Close() })
 	mr := miniredis.RunT(t)
 	rc := redis.NewClient(&redis.Options{Addr: mr.Addr()})
 	s := &AuthServer{
@@ -151,7 +151,7 @@ func TestPollApproval_Redis_PendingExpired(t *testing.T) {
 	past := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
 	cached := approvalCache{Status: "PENDING", ActionType: "LOGIN", Payload: `{}`, ExpiresAt: past}
 	data, _ := json.Marshal(cached)
-	mr.Set(approvalCacheKey(42), string(data))
+	_ = mr.Set(approvalCacheKey(42), string(data))
 
 	dbMock.ExpectExec("UPDATE two_factor_approvals SET status = 'EXPIRED'").
 		WithArgs(int64(42)).
@@ -175,7 +175,7 @@ func TestPollApproval_Redis_ApprovedLogin(t *testing.T) {
 	future := time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
 	cached := approvalCache{Status: "APPROVED", ActionType: "LOGIN", Payload: string(payload), ExpiresAt: future}
 	data, _ := json.Marshal(cached)
-	mr.Set(approvalCacheKey(55), string(data))
+	_ = mr.Set(approvalCacheKey(55), string(data))
 
 	resp, err := s.PollApproval(context.Background(), &pb_auth.PollApprovalRequest{Id: 55})
 	require.NoError(t, err)

--- a/services/auth-service/handlers/redis_test.go
+++ b/services/auth-service/handlers/redis_test.go
@@ -244,7 +244,7 @@ func TestLoadApprovalCache_NilRedis_ReturnsNil(t *testing.T) {
 func TestLoadApprovalCache_InvalidJSON_ReturnsNil(t *testing.T) {
 	mr, rdb := newAuthRedis(t)
 	s := &AuthServer{Redis: rdb}
-	mr.Set(approvalCacheKey(50), "not-json")
+	_ = mr.Set(approvalCacheKey(50), "not-json")
 	assert.Nil(t, s.loadApprovalCache(context.Background(), 50))
 }
 


### PR DESCRIPTION
## Summary

- `api-gateway/handlers/otc_interbank.go`: wrap `fmt.Sscanf` with `_, _ =` and `resp.Body.Close()` calls in anonymous funcs (errcheck)
- `auth-service/handlers/coverage_gaps_test.go`: add `_ =` to `db.Close()` and `mr.Set(...)` calls (errcheck)
- `auth-service/handlers/redis_test.go`: add `_ =` to `mr.Set(...)` (errcheck)

## Test plan
- [ ] Lint CI passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)