### PR TITLE
feat(otc): allow buyer to pay premium/exercise cost from any currency…

### DIFF
--- a/services/otc-service/handlers/grpc_server.go
+++ b/services/otc-service/handlers/grpc_server.go
@@ -54,6 +54,7 @@ type OtcServer struct {
 	AccountDB    *sql.DB // account_db
 	PortfolioDB  *sql.DB // portfolio_db
 	SecuritiesDB *sql.DB // securities_db
+	ExchangeDB   *sql.DB // exchange_db (daily_exchange_rates)
 }
 
 func getUserName(employeeDB, clientDB *sql.DB, userID int64, userType string) string {
@@ -102,6 +103,54 @@ func findAccount(accountDB *sql.DB, ownerID int64, currencyID int64) (int64, err
 		return 0, fmt.Errorf("no active account found for owner %d with currency_id %d", ownerID, currencyID)
 	}
 	return id, err
+}
+
+// currencyCodeMap is the inverse of currencyIDMap.
+var currencyCodeMap = map[int64]string{
+	1: "RSD", 2: "EUR", 3: "CHF", 4: "USD",
+	5: "GBP", 6: "JPY", 7: "CAD", 8: "AUD",
+}
+
+// getAccountCurrencyID returns the currency_id of a given account.
+func getAccountCurrencyID(accountDB *sql.DB, accountID int64) (int64, error) {
+	var cid int64
+	err := accountDB.QueryRow(`SELECT currency_id FROM accounts WHERE id = $1`, accountID).Scan(&cid)
+	return cid, err
+}
+
+// convertAmount converts amount from fromCurrencyID to toCurrencyID using today's middle rates.
+// Returns amount unchanged when currencies are equal.
+func convertAmount(exchangeDB *sql.DB, amount float64, fromCurrencyID, toCurrencyID int64) (float64, error) {
+	if fromCurrencyID == toCurrencyID {
+		return amount, nil
+	}
+	fromCode, toCode := currencyCodeMap[fromCurrencyID], currencyCodeMap[toCurrencyID]
+
+	getRate := func(code string) (float64, error) {
+		if code == "RSD" {
+			return 1.0, nil
+		}
+		var r float64
+		err := exchangeDB.QueryRow(
+			`SELECT middle_rate FROM daily_exchange_rates WHERE currency_code = $1 AND date = CURRENT_DATE`,
+			code,
+		).Scan(&r)
+		if err != nil {
+			return 0, fmt.Errorf("no exchange rate for %s: %v", code, err)
+		}
+		return r, nil
+	}
+
+	fromRate, err := getRate(fromCode)
+	if err != nil {
+		return 0, err
+	}
+	toRate, err := getRate(toCode)
+	if err != nil {
+		return 0, err
+	}
+	// fromRate and toRate are both in RSD per 1 unit of currency
+	return amount * fromRate / toRate, nil
 }
 
 func (s *OtcServer) Ping(_ context.Context, _ *pb.PingRequest) (*pb.PingResponse, error) {
@@ -378,6 +427,14 @@ func (s *OtcServer) AcceptNegotiation(ctx context.Context, req *pb.AcceptNegotia
 			return nil, status.Errorf(codes.Internal, "failed to find buyer account: %v", err)
 		}
 	}
+	buyerCurrencyID, err := getAccountCurrencyID(s.AccountDB, buyerAccountID)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to read buyer account currency: %v", err)
+	}
+	premiumToPay, err := convertAmount(s.ExchangeDB, premium, currencyID, buyerCurrencyID)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "currency conversion failed: %v", err)
+	}
 	var buyerBalance float64
 	err = s.AccountDB.QueryRowContext(ctx,
 		`SELECT available_balance FROM accounts WHERE id = $1`, buyerAccountID,
@@ -385,7 +442,7 @@ func (s *OtcServer) AcceptNegotiation(ctx context.Context, req *pb.AcceptNegotia
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to check buyer balance: %v", err)
 	}
-	if buyerBalance < premium {
+	if buyerBalance < premiumToPay {
 		return nil, status.Error(codes.InvalidArgument, "Insufficient funds for premium")
 	}
 
@@ -398,7 +455,7 @@ func (s *OtcServer) AcceptNegotiation(ctx context.Context, req *pb.AcceptNegotia
 	// --- Deduct buyer premium (with retry compensation on failure) ---
 	if _, err = s.AccountDB.ExecContext(ctx,
 		`UPDATE accounts SET balance = balance - $1, available_balance = available_balance - $1 WHERE id = $2`,
-		premium, buyerAccountID,
+		premiumToPay, buyerAccountID,
 	); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to deduct premium from buyer: %v", err)
 	}
@@ -410,7 +467,7 @@ func (s *OtcServer) AcceptNegotiation(ctx context.Context, req *pb.AcceptNegotia
 	); err != nil {
 		retryExec(s.AccountDB,
 			`UPDATE accounts SET balance = balance + $1, available_balance = available_balance + $1 WHERE id = $2`,
-			premium, buyerAccountID)
+			premiumToPay, buyerAccountID)
 		return nil, status.Errorf(codes.Internal, "failed to credit premium to seller: %v", err)
 	}
 
@@ -427,7 +484,7 @@ func (s *OtcServer) AcceptNegotiation(ctx context.Context, req *pb.AcceptNegotia
 	).Scan(&contractID); err != nil {
 		retryExec(s.AccountDB,
 			`UPDATE accounts SET balance = balance + $1, available_balance = available_balance + $1 WHERE id = $2`,
-			premium, buyerAccountID)
+			premiumToPay, buyerAccountID)
 		retryExec(s.AccountDB,
 			`UPDATE accounts SET balance = balance - $1, available_balance = available_balance - $1 WHERE id = $2`,
 			premium, sellerAccountID)
@@ -443,7 +500,7 @@ func (s *OtcServer) AcceptNegotiation(ctx context.Context, req *pb.AcceptNegotia
 	); err != nil {
 		retryExec(s.AccountDB,
 			`UPDATE accounts SET balance = balance + $1, available_balance = available_balance + $1 WHERE id = $2`,
-			premium, buyerAccountID)
+			premiumToPay, buyerAccountID)
 		retryExec(s.AccountDB,
 			`UPDATE accounts SET balance = balance - $1, available_balance = available_balance - $1 WHERE id = $2`,
 			premium, sellerAccountID)
@@ -453,7 +510,7 @@ func (s *OtcServer) AcceptNegotiation(ctx context.Context, req *pb.AcceptNegotia
 	if err = tx.Commit(); err != nil {
 		retryExec(s.AccountDB,
 			`UPDATE accounts SET balance = balance + $1, available_balance = available_balance + $1 WHERE id = $2`,
-			premium, buyerAccountID)
+			premiumToPay, buyerAccountID)
 		retryExec(s.AccountDB,
 			`UPDATE accounts SET balance = balance - $1, available_balance = available_balance - $1 WHERE id = $2`,
 			premium, sellerAccountID)
@@ -636,6 +693,14 @@ func (s *OtcServer) ExerciseContract(ctx context.Context, req *pb.ExerciseContra
 			return nil, status.Errorf(codes.Internal, "failed to find buyer account: %v", err)
 		}
 	}
+	buyerCurrencyID, err := getAccountCurrencyID(s.AccountDB, buyerAccountID)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to read buyer account currency: %v", err)
+	}
+	totalCostToPay, err := convertAmount(s.ExchangeDB, totalCost, currencyID, buyerCurrencyID)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "currency conversion failed: %v", err)
+	}
 
 	// sagaLog writes a saga step record. It uses a fresh 5-second background context so
 	// it never blocks the calling goroutine (and therefore never prevents defer tx.Rollback()
@@ -652,18 +717,18 @@ func (s *OtcServer) ExerciseContract(ctx context.Context, req *pb.ExerciseContra
 	sellerPortfolioID := portfolioUserID(sellerID, sellerType)
 
 	// Step 1: Reserve buyer funds (deduct available_balance).
-	// Also checks balance >= totalCost to ensure consistency between the two balance fields.
+	// Also checks balance >= totalCostToPay to ensure consistency between the two balance fields.
 	result, err := s.AccountDB.ExecContext(ctx,
 		`UPDATE accounts SET available_balance = available_balance - $1
 		 WHERE id = $2 AND available_balance >= $1 AND balance >= $1`,
-		totalCost, buyerAccountID,
+		totalCostToPay, buyerAccountID,
 	)
 	if err != nil {
 		sagaLog(1, "FAILED", err.Error())
 		return nil, status.Errorf(codes.Internal, "step 1 failed: %v", err)
 	}
 	if rows, _ := result.RowsAffected(); rows == 0 {
-		sagaLog(1, "FAILED", fmt.Sprintf("insufficient funds: need %.2f", totalCost))
+		sagaLog(1, "FAILED", fmt.Sprintf("insufficient funds: need %.2f", totalCostToPay))
 		return nil, status.Error(codes.InvalidArgument, "Insufficient funds")
 	}
 	sagaLog(1, "SUCCESS", "")
@@ -671,7 +736,7 @@ func (s *OtcServer) ExerciseContract(ctx context.Context, req *pb.ExerciseContra
 	comp1 := func() {
 		retryExec(s.AccountDB,
 			`UPDATE accounts SET available_balance = available_balance + $1 WHERE id = $2`,
-			totalCost, buyerAccountID)
+			totalCostToPay, buyerAccountID)
 		sagaLog(1, "COMPENSATED", "")
 	}
 
@@ -714,7 +779,7 @@ func (s *OtcServer) ExerciseContract(ctx context.Context, req *pb.ExerciseContra
 	}
 	if _, err = s.AccountDB.ExecContext(ctx,
 		`UPDATE accounts SET balance = balance - $1 WHERE id = $2`,
-		totalCost, buyerAccountID,
+		totalCostToPay, buyerAccountID,
 	); err != nil {
 		sagaLog(3, "FAILED", err.Error())
 		comp2()
@@ -725,7 +790,7 @@ func (s *OtcServer) ExerciseContract(ctx context.Context, req *pb.ExerciseContra
 		`UPDATE accounts SET balance = balance + $1, available_balance = available_balance + $1 WHERE id = $2`,
 		totalCost, sellerAccountID,
 	); err != nil {
-		retryExec(s.AccountDB, `UPDATE accounts SET balance = balance + $1 WHERE id = $2`, totalCost, buyerAccountID)
+		retryExec(s.AccountDB, `UPDATE accounts SET balance = balance + $1 WHERE id = $2`, totalCostToPay, buyerAccountID)
 		sagaLog(3, "FAILED", err.Error())
 		comp2()
 		comp1()
@@ -734,7 +799,7 @@ func (s *OtcServer) ExerciseContract(ctx context.Context, req *pb.ExerciseContra
 	sagaLog(3, "SUCCESS", "")
 
 	comp3 := func() {
-		retryExec(s.AccountDB, `UPDATE accounts SET balance = balance + $1 WHERE id = $2`, totalCost, buyerAccountID)
+		retryExec(s.AccountDB, `UPDATE accounts SET balance = balance + $1 WHERE id = $2`, totalCostToPay, buyerAccountID)
 		retryExec(s.AccountDB, `UPDATE accounts SET balance = balance - $1, available_balance = available_balance - $1 WHERE id = $2`, totalCost, sellerAccountID)
 		sagaLog(3, "COMPENSATED", "")
 	}

--- a/services/otc-service/handlers/grpc_server_coverage_gaps_test.go
+++ b/services/otc-service/handlers/grpc_server_coverage_gaps_test.go
@@ -140,6 +140,7 @@ func TestAcceptNegotiation_CommitFails(t *testing.T) {
 	mainMock.ExpectQuery("SELECT COALESCE.*SUM").WillReturnRows(sqlmock.NewRows([]string{"sum"}).AddRow(int64(0)))
 	// BuyerAccountId=0 → findAccount buyer
 	mAcc.ExpectQuery("SELECT id FROM accounts WHERE owner_id").WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(100)))
+	mAcc.ExpectQuery("SELECT currency_id FROM accounts WHERE id").WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(4)))
 	mAcc.ExpectQuery("SELECT available_balance FROM accounts WHERE id").
 		WillReturnRows(sqlmock.NewRows([]string{"available_balance"}).AddRow(float64(500)))
 	// findAccount seller
@@ -225,6 +226,7 @@ func exerciseStep1to4(t *testing.T, mainMock, mAcc, mPort, mSec sqlmock.Sqlmock,
 	mainMock.ExpectBegin()
 	mainMock.ExpectQuery("SELECT .* FROM otc_contracts WHERE id").WillReturnRows(contractRow(10, 20, future))
 	mSec.ExpectQuery("SELECT id FROM listing").WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(42)))
+	mAcc.ExpectQuery("SELECT currency_id FROM accounts WHERE id").WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(4)))
 	// Step 1
 	mAcc.ExpectExec("UPDATE accounts SET available_balance = available_balance - ").WillReturnResult(sqlmock.NewResult(0, 1))
 	mainMock.ExpectExec("INSERT INTO otc_saga_log").WillReturnResult(sqlmock.NewResult(1, 1))

--- a/services/otc-service/handlers/grpc_server_test.go
+++ b/services/otc-service/handlers/grpc_server_test.go
@@ -433,6 +433,8 @@ func TestAcceptNegotiation_InsufficientFunds(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"sum"}).AddRow(int64(0)))
 	mAcc.ExpectQuery("SELECT id FROM accounts WHERE owner_id").
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(100)))
+	mAcc.ExpectQuery("SELECT currency_id FROM accounts WHERE id").
+		WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(4)))
 	mAcc.ExpectQuery("SELECT available_balance FROM accounts WHERE id").
 		WillReturnRows(sqlmock.NewRows([]string{"available_balance"}).AddRow(float64(50)))
 	mainMock.ExpectRollback()
@@ -457,6 +459,8 @@ func TestAcceptNegotiation_HappyPath(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"sum"}).AddRow(int64(0)))
 	mAcc.ExpectQuery("SELECT id FROM accounts WHERE owner_id"). // findAccount buyer
 									WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(100)))
+	mAcc.ExpectQuery("SELECT currency_id FROM accounts WHERE id").
+		WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(4)))
 	mAcc.ExpectQuery("SELECT available_balance FROM accounts WHERE id").
 		WillReturnRows(sqlmock.NewRows([]string{"available_balance"}).AddRow(float64(500)))
 	mAcc.ExpectQuery("SELECT id FROM accounts WHERE owner_id"). // findAccount seller
@@ -687,6 +691,8 @@ func TestExerciseContract_InsufficientFunds(t *testing.T) {
 	mSec.ExpectQuery("SELECT id FROM listing").
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(42)))
 	// Step 1: atomic UPDATE returns 0 rows (insufficient funds)
+	mAcc.ExpectQuery("SELECT currency_id FROM accounts WHERE id").
+		WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(4)))
 	mAcc.ExpectExec("UPDATE accounts SET available_balance = available_balance - ").
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mainMock.ExpectExec("INSERT INTO otc_saga_log"). // step 1 FAILED
@@ -711,6 +717,8 @@ func TestExerciseContract_SellerNoShares(t *testing.T) {
 	mSec.ExpectQuery("SELECT id FROM listing").
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(42)))
 	// Step 1: atomic UPDATE returns 1 row (success)
+	mAcc.ExpectQuery("SELECT currency_id FROM accounts WHERE id").
+		WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(4)))
 	mAcc.ExpectExec("UPDATE accounts SET available_balance = available_balance - ").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mainMock.ExpectExec("INSERT INTO otc_saga_log"). // step 1 SUCCESS
@@ -749,6 +757,8 @@ func TestExerciseContract_HappyPath(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(42)))
 
 	// Step 1: atomic UPDATE returns 1 row (success)
+	mAcc.ExpectQuery("SELECT currency_id FROM accounts WHERE id").
+		WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(4)))
 	mAcc.ExpectExec("UPDATE accounts SET available_balance = available_balance - ").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mainMock.ExpectExec("INSERT INTO otc_saga_log").
@@ -813,6 +823,8 @@ func TestExerciseContract_PublicAmountDecrement(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(42)))
 
 	// Step 1: atomic UPDATE
+	mAcc.ExpectQuery("SELECT currency_id FROM accounts WHERE id").
+		WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(4)))
 	mAcc.ExpectExec("UPDATE accounts SET available_balance = available_balance - ").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mainMock.ExpectExec("INSERT INTO otc_saga_log").WillReturnResult(sqlmock.NewResult(1, 1))
@@ -866,6 +878,8 @@ func TestExerciseContract_CompensationRetry(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(42)))
 
 	// Step 1: atomic UPDATE succeeds (1 row)
+	mAcc.ExpectQuery("SELECT currency_id FROM accounts WHERE id").
+		WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(4)))
 	mAcc.ExpectExec("UPDATE accounts SET available_balance = available_balance - ").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mainMock.ExpectExec("INSERT INTO otc_saga_log").WillReturnResult(sqlmock.NewResult(1, 1)) // step 1 SUCCESS
@@ -1196,6 +1210,8 @@ func TestAcceptNegotiation_BuyerBalanceQueryFails(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"sum"}).AddRow(int64(0)))
 	mAcc.ExpectQuery("SELECT id FROM accounts WHERE owner_id").
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(100)))
+	mAcc.ExpectQuery("SELECT currency_id FROM accounts WHERE id").
+		WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(4)))
 	mAcc.ExpectQuery("SELECT available_balance FROM accounts WHERE id").
 		WillReturnError(fmt.Errorf("db error"))
 	mainMock.ExpectRollback()
@@ -1220,6 +1236,8 @@ func TestAcceptNegotiation_FindSellerAccountFails(t *testing.T) {
 	// findAccount buyer
 	mAcc.ExpectQuery("SELECT id FROM accounts WHERE owner_id").
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(100)))
+	mAcc.ExpectQuery("SELECT currency_id FROM accounts WHERE id").
+		WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(4)))
 	mAcc.ExpectQuery("SELECT available_balance FROM accounts WHERE id").
 		WillReturnRows(sqlmock.NewRows([]string{"available_balance"}).AddRow(float64(500)))
 	// findAccount seller returns 0 rows
@@ -1246,6 +1264,8 @@ func TestAcceptNegotiation_DeductBuyerPremiumFails(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"sum"}).AddRow(int64(0)))
 	mAcc.ExpectQuery("SELECT id FROM accounts WHERE owner_id").
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(100)))
+	mAcc.ExpectQuery("SELECT currency_id FROM accounts WHERE id").
+		WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(4)))
 	mAcc.ExpectQuery("SELECT available_balance FROM accounts WHERE id").
 		WillReturnRows(sqlmock.NewRows([]string{"available_balance"}).AddRow(float64(500)))
 	mAcc.ExpectQuery("SELECT id FROM accounts WHERE owner_id").
@@ -1274,6 +1294,8 @@ func TestAcceptNegotiation_CreditSellerFails(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"sum"}).AddRow(int64(0)))
 	mAcc.ExpectQuery("SELECT id FROM accounts WHERE owner_id").
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(100)))
+	mAcc.ExpectQuery("SELECT currency_id FROM accounts WHERE id").
+		WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(4)))
 	mAcc.ExpectQuery("SELECT available_balance FROM accounts WHERE id").
 		WillReturnRows(sqlmock.NewRows([]string{"available_balance"}).AddRow(float64(500)))
 	mAcc.ExpectQuery("SELECT id FROM accounts WHERE owner_id").
@@ -1306,6 +1328,8 @@ func TestAcceptNegotiation_InsertContractFails(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"sum"}).AddRow(int64(0)))
 	mAcc.ExpectQuery("SELECT id FROM accounts WHERE owner_id").
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(100)))
+	mAcc.ExpectQuery("SELECT currency_id FROM accounts WHERE id").
+		WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(4)))
 	mAcc.ExpectQuery("SELECT available_balance FROM accounts WHERE id").
 		WillReturnRows(sqlmock.NewRows([]string{"available_balance"}).AddRow(float64(500)))
 	mAcc.ExpectQuery("SELECT id FROM accounts WHERE owner_id").
@@ -1338,6 +1362,8 @@ func TestAcceptNegotiation_UpdateNegotiationFails(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"sum"}).AddRow(int64(0)))
 	mAcc.ExpectQuery("SELECT id FROM accounts WHERE owner_id").
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(100)))
+	mAcc.ExpectQuery("SELECT currency_id FROM accounts WHERE id").
+		WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(4)))
 	mAcc.ExpectQuery("SELECT available_balance FROM accounts WHERE id").
 		WillReturnRows(sqlmock.NewRows([]string{"available_balance"}).AddRow(float64(500)))
 	mAcc.ExpectQuery("SELECT id FROM accounts WHERE owner_id").
@@ -1465,6 +1491,8 @@ func TestExerciseContract_Step1UpdateFails(t *testing.T) {
 	mSec.ExpectQuery("SELECT id FROM listing").
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(42)))
 	// Step 1: atomic UPDATE returns error
+	mAcc.ExpectQuery("SELECT currency_id FROM accounts WHERE id").
+		WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(4)))
 	mAcc.ExpectExec("UPDATE accounts SET available_balance = available_balance - ").
 		WillReturnError(fmt.Errorf("db error"))
 	mainMock.ExpectExec("INSERT INTO otc_saga_log"). // step 1 FAILED
@@ -1488,6 +1516,8 @@ func TestExerciseContract_Step2InternalError(t *testing.T) {
 	mSec.ExpectQuery("SELECT id FROM listing").
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(42)))
 	// Step 1: atomic UPDATE succeeds (1 row)
+	mAcc.ExpectQuery("SELECT currency_id FROM accounts WHERE id").
+		WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(4)))
 	mAcc.ExpectExec("UPDATE accounts SET available_balance = available_balance - ").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mainMock.ExpectExec("INSERT INTO otc_saga_log").WillReturnResult(sqlmock.NewResult(1, 1))
@@ -1518,6 +1548,8 @@ func TestExerciseContract_Step3SellerAccountNotFound(t *testing.T) {
 	mSec.ExpectQuery("SELECT id FROM listing").
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(42)))
 	// Step 1: atomic UPDATE succeeds
+	mAcc.ExpectQuery("SELECT currency_id FROM accounts WHERE id").
+		WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(4)))
 	mAcc.ExpectExec("UPDATE accounts SET available_balance = available_balance - ").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mainMock.ExpectExec("INSERT INTO otc_saga_log").WillReturnResult(sqlmock.NewResult(1, 1))
@@ -1556,6 +1588,8 @@ func TestExerciseContract_Step3DebitBuyerFails(t *testing.T) {
 	mSec.ExpectQuery("SELECT id FROM listing").
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(42)))
 	// Step 1: atomic UPDATE succeeds
+	mAcc.ExpectQuery("SELECT currency_id FROM accounts WHERE id").
+		WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(4)))
 	mAcc.ExpectExec("UPDATE accounts SET available_balance = available_balance - ").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mainMock.ExpectExec("INSERT INTO otc_saga_log").WillReturnResult(sqlmock.NewResult(1, 1))
@@ -1595,6 +1629,8 @@ func TestExerciseContract_Step3CreditSellerFails(t *testing.T) {
 	mSec.ExpectQuery("SELECT id FROM listing").
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(42)))
 	// Step 1: atomic UPDATE succeeds
+	mAcc.ExpectQuery("SELECT currency_id FROM accounts WHERE id").
+		WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(4)))
 	mAcc.ExpectExec("UPDATE accounts SET available_balance = available_balance - ").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mainMock.ExpectExec("INSERT INTO otc_saga_log").WillReturnResult(sqlmock.NewResult(1, 1))
@@ -1639,6 +1675,8 @@ func TestExerciseContract_Step4SellerUpdateFails(t *testing.T) {
 	mSec.ExpectQuery("SELECT id FROM listing").
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(42)))
 	// Step 1: atomic UPDATE succeeds
+	mAcc.ExpectQuery("SELECT currency_id FROM accounts WHERE id").
+		WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(4)))
 	mAcc.ExpectExec("UPDATE accounts SET available_balance = available_balance - ").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mainMock.ExpectExec("INSERT INTO otc_saga_log").WillReturnResult(sqlmock.NewResult(1, 1))
@@ -1686,6 +1724,8 @@ func TestExerciseContract_Step4BuyerUpsertFails(t *testing.T) {
 	mSec.ExpectQuery("SELECT id FROM listing").
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(42)))
 	// Step 1: atomic UPDATE succeeds
+	mAcc.ExpectQuery("SELECT currency_id FROM accounts WHERE id").
+		WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(4)))
 	mAcc.ExpectExec("UPDATE accounts SET available_balance = available_balance - ").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mainMock.ExpectExec("INSERT INTO otc_saga_log").WillReturnResult(sqlmock.NewResult(1, 1))
@@ -1737,6 +1777,8 @@ func TestExerciseContract_Step5UpdateContractFails(t *testing.T) {
 	mSec.ExpectQuery("SELECT id FROM listing").
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(42)))
 	// Step 1: atomic UPDATE succeeds
+	mAcc.ExpectQuery("SELECT currency_id FROM accounts WHERE id").
+		WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(4)))
 	mAcc.ExpectExec("UPDATE accounts SET available_balance = available_balance - ").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mainMock.ExpectExec("INSERT INTO otc_saga_log").WillReturnResult(sqlmock.NewResult(1, 1))
@@ -1801,6 +1843,8 @@ func TestExerciseContract_EmployeeSeller(t *testing.T) {
 	mSec.ExpectQuery("SELECT id FROM listing").
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(42)))
 	// Step 1: atomic UPDATE succeeds
+	mAcc.ExpectQuery("SELECT currency_id FROM accounts WHERE id").
+		WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(4)))
 	mAcc.ExpectExec("UPDATE accounts SET available_balance = available_balance - ").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mainMock.ExpectExec("INSERT INTO otc_saga_log").WillReturnResult(sqlmock.NewResult(1, 1))

--- a/services/otc-service/handlers/interbank_outgoing.go
+++ b/services/otc-service/handlers/interbank_outgoing.go
@@ -213,6 +213,14 @@ func (s *OtcServer) exerciseCrossBank(
 			return nil, status.Errorf(codes.Internal, "failed to find buyer account: %v", err)
 		}
 	}
+	buyerCurrencyID, err := getAccountCurrencyID(s.AccountDB, buyerAccountID)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to read buyer account currency: %v", err)
+	}
+	totalCostToPay, err := convertAmount(s.ExchangeDB, totalCost, currencyID, buyerCurrencyID)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "currency conversion failed: %v", err)
+	}
 	var buyerAccountNum string
 	if err = s.AccountDB.QueryRowContext(ctx,
 		`SELECT account_number FROM accounts WHERE id = $1`, buyerAccountID,
@@ -233,14 +241,14 @@ func (s *OtcServer) exerciseCrossBank(
 	result, err := s.AccountDB.ExecContext(ctx,
 		`UPDATE accounts SET available_balance = available_balance - $1
 		 WHERE id = $2 AND available_balance >= $1 AND balance >= $1`,
-		totalCost, buyerAccountID,
+		totalCostToPay, buyerAccountID,
 	)
 	if err != nil {
 		sagaLog(1, "FAILED", err.Error())
 		return nil, status.Errorf(codes.Internal, "step 1 failed: %v", err)
 	}
 	if rows, _ := result.RowsAffected(); rows == 0 {
-		sagaLog(1, "FAILED", fmt.Sprintf("insufficient funds: need %.2f", totalCost))
+		sagaLog(1, "FAILED", fmt.Sprintf("insufficient funds: need %.2f", totalCostToPay))
 		return nil, status.Error(codes.InvalidArgument, "Insufficient funds")
 	}
 	sagaLog(1, "SUCCESS", "")
@@ -248,7 +256,7 @@ func (s *OtcServer) exerciseCrossBank(
 	comp1 := func() {
 		retryExec(s.AccountDB,
 			`UPDATE accounts SET available_balance = available_balance + $1 WHERE id = $2`,
-			totalCost, buyerAccountID)
+			totalCostToPay, buyerAccountID)
 		sagaLog(1, "COMPENSATED", "")
 	}
 
@@ -281,7 +289,7 @@ func (s *OtcServer) exerciseCrossBank(
 	// Step 3: Debit buyer balance (available_balance already reserved in step 1).
 	_, _ = s.AccountDB.ExecContext(ctx,
 		`UPDATE accounts SET balance = balance - $1, available_balance = available_balance + $1 WHERE id = $2`,
-		totalCost, buyerAccountID)
+		totalCostToPay, buyerAccountID)
 
 	// Step 4: Add shares to buyer's portfolio.
 	listingID, _ := listingIDForTicker(s.SecuritiesDB, ticker)
@@ -529,10 +537,18 @@ func (s *OtcServer) acceptCrossBank(
 				return nil, status.Errorf(codes.Internal, "failed to find buyer account: %v", err)
 			}
 		}
+		buyerCurrencyID, err := getAccountCurrencyID(s.AccountDB, buyerAccountID)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to read buyer account currency: %v", err)
+		}
+		premiumToPay, err := convertAmount(s.ExchangeDB, premium, currencyID, buyerCurrencyID)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "currency conversion failed: %v", err)
+		}
 		var buyerBalance float64
 		if err = s.AccountDB.QueryRowContext(ctx,
 			`SELECT available_balance FROM accounts WHERE id = $1`, buyerAccountID,
-		).Scan(&buyerBalance); err != nil || buyerBalance < premium {
+		).Scan(&buyerBalance); err != nil || buyerBalance < premiumToPay {
 			return nil, status.Error(codes.InvalidArgument, "Insufficient funds for premium")
 		}
 		var buyerAccountNum string
@@ -544,7 +560,7 @@ func (s *OtcServer) acceptCrossBank(
 
 		if _, err = s.AccountDB.ExecContext(ctx,
 			`UPDATE accounts SET balance = balance - $1, available_balance = available_balance - $1 WHERE id = $2`,
-			premium, buyerAccountID,
+			premiumToPay, buyerAccountID,
 		); err != nil {
 			return nil, status.Errorf(codes.Internal, "failed to debit buyer premium: %v", err)
 		}
@@ -560,7 +576,7 @@ func (s *OtcServer) acceptCrossBank(
 		if commitErr != nil || voteResult != "YES" {
 			retryExec(s.AccountDB,
 				`UPDATE accounts SET balance = balance + $1, available_balance = available_balance + $1 WHERE id = $2`,
-				premium, buyerAccountID)
+				premiumToPay, buyerAccountID)
 			return nil, status.Errorf(codes.FailedPrecondition,
 				"partner rejected accept 2PC (vote=%s err=%v)", voteResult, commitErr)
 		}

--- a/services/otc-service/handlers/interbank_outgoing_test.go
+++ b/services/otc-service/handlers/interbank_outgoing_test.go
@@ -455,6 +455,8 @@ func TestAcceptNegotiation_CrossBank_WithPremium_Happy(t *testing.T) {
 			AddRow(int32(999), int64(42), "ext-seller-1"))
 
 	// buyer balance check (BuyerAccountId=5 → skip findAccount)
+	accMock.ExpectQuery("SELECT currency_id FROM accounts WHERE id").
+		WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(1)))
 	accMock.ExpectQuery("SELECT available_balance").
 		WillReturnRows(sqlmock.NewRows([]string{"available_balance"}).AddRow(float64(100.0)))
 	// buyer account number lookup
@@ -545,6 +547,8 @@ func TestAcceptNegotiation_CrossBank_InsufficientFunds(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"seller_routing_number", "partner_negotiation_id", "seller_external_id"}).
 			AddRow(int32(999), int64(42), "ext-seller-1"))
 	// BuyerAccountId=5 → no findAccount query; balance check: 10 < 50 → insufficient
+	accMock.ExpectQuery("SELECT currency_id FROM accounts WHERE id").
+		WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(1)))
 	accMock.ExpectQuery("SELECT available_balance").
 		WillReturnRows(sqlmock.NewRows([]string{"available_balance"}).AddRow(float64(10.0)))
 	mainMock.ExpectRollback()
@@ -585,6 +589,8 @@ func TestAcceptNegotiation_CrossBank_2PCVoteNo(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"seller_routing_number", "partner_negotiation_id", "seller_external_id"}).
 			AddRow(int32(999), int64(42), "ext-seller-1"))
 	// BuyerAccountId=5 → no findAccount query
+	accMock.ExpectQuery("SELECT currency_id FROM accounts WHERE id").
+		WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(1)))
 	accMock.ExpectQuery("SELECT available_balance").
 		WillReturnRows(sqlmock.NewRows([]string{"available_balance"}).AddRow(float64(100.0)))
 	accMock.ExpectQuery("SELECT account_number").

--- a/services/otc-service/main.go
+++ b/services/otc-service/main.go
@@ -51,6 +51,12 @@ func main() {
 	}
 	defer func() { _ = securitiesDB.Close() }()
 
+	exchangeDB, err := otcdb.Connect(os.Getenv("EXCHANGE_DB_URL"))
+	if err != nil {
+		log.Fatalf("failed to connect to exchange_db: %v", err)
+	}
+	defer func() { _ = exchangeDB.Close() }()
+
 	// Hourly contract expiration: marks ACTIVE contracts as EXPIRED once the
 	// buyer's exercise window (settlementDate + 24h) has passed.
 	// Runs immediately on startup so stale contracts are cleaned up at boot.
@@ -82,6 +88,7 @@ func main() {
 		AccountDB:    accountDB,
 		PortfolioDB:  portfolioDB,
 		SecuritiesDB: securitiesDB,
+		ExchangeDB:   exchangeDB,
 	})
 
 	log.Printf("otc-service gRPC server listening on %s", grpcPort)


### PR DESCRIPTION
… account

Buyer can now select which of their active accounts to debit when accepting a negotiation or exercising a contract, regardless of the offer currency. If the buyer account currency differs from the offer currency, the amount is converted using the daily exchange rate (middle_rate) from exchange_db. Seller always receives the original amount in the offer currency.

Applies to intra-bank AcceptNegotiation, ExerciseContract and cross-bank acceptCrossBank, exerciseCrossBank flows. Adds ExchangeDB connection to OtcServer and convertAmount/getAccountCurrencyID helpers.