### PR TITLE
feat(tax): implement OTC option capital gains tax (Celina 5)

### DIFF
--- a/services/otc-service/handlers/grpc_server.go
+++ b/services/otc-service/handlers/grpc_server.go
@@ -1548,7 +1548,7 @@ func (s *OtcServer) ExpireContracts() {
 		log.Printf("contract expiration error: %v", err)
 		return
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	now := time.Now()
 	for rows.Next() {
 		var id, buyerID int64

--- a/services/otc-service/handlers/grpc_server.go
+++ b/services/otc-service/handlers/grpc_server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log"
 	"os"
 	"strconv"
 	"time"
@@ -155,6 +156,29 @@ func convertAmount(exchangeDB *sql.DB, amount float64, fromCurrencyID, toCurrenc
 
 func (s *OtcServer) Ping(_ context.Context, _ *pb.PingRequest) (*pb.PingResponse, error) {
 	return &pb.PingResponse{Message: "otc-service ok"}, nil
+}
+
+func (s *OtcServer) recordOtcTax(userID int64, userType string, taxableAmount float64, currencyCode string, month, year int) {
+	if userType == "EMPLOYEE" {
+		return
+	}
+	fromID, ok := currencyIDMap[currencyCode]
+	if !ok {
+		return
+	}
+	amountRSD, err := convertAmount(s.ExchangeDB, taxableAmount, fromID, 1)
+	if err != nil {
+		return
+	}
+	taxRSD := amountRSD * 0.15
+	if taxRSD == 0 {
+		return
+	}
+	tctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, _ = s.PortfolioDB.ExecContext(tctx,
+		`INSERT INTO tax_record (user_id, user_type, amount_rsd, month, year) VALUES ($1, $2, $3, $4, $5)`,
+		userID, userType, taxRSD, month, year)
 }
 
 func (s *OtcServer) CreateNegotiation(ctx context.Context, req *pb.CreateNegotiationRequest) (*pb.NegotiationResponse, error) {
@@ -518,6 +542,9 @@ func (s *OtcServer) AcceptNegotiation(ctx context.Context, req *pb.AcceptNegotia
 	}
 
 	_ = contractID
+	if sellerType != "INTERBANK" {
+		s.recordOtcTax(sellerID, sellerType, premium, currency, int(now.Month()), now.Year())
+	}
 	return s.fetchNegotiationByID(ctx, req.NegotiationId)
 }
 
@@ -645,14 +672,14 @@ func (s *OtcServer) ExerciseContract(ctx context.Context, req *pb.ExerciseContra
 	var sellerID, buyerID int64
 	var sellerType, buyerType, contractStatus, ticker, currency string
 	var amount int32
-	var strikePrice float64
+	var strikePrice, premium float64
 	var settlementDate time.Time
 	err = tx.QueryRowContext(ctx, `
 		SELECT seller_id, seller_type, buyer_id, buyer_type, status,
-		       ticker, amount, strike_price, currency, settlement_date
+		       ticker, amount, strike_price, premium, currency, settlement_date
 		FROM otc_contracts WHERE id = $1 FOR UPDATE`, req.ContractId,
 	).Scan(&sellerID, &sellerType, &buyerID, &buyerType, &contractStatus,
-		&ticker, &amount, &strikePrice, &currency, &settlementDate)
+		&ticker, &amount, &strikePrice, &premium, &currency, &settlementDate)
 	if err == sql.ErrNoRows {
 		return nil, status.Error(codes.NotFound, "contract not found")
 	} else if err != nil {
@@ -669,21 +696,33 @@ func (s *OtcServer) ExerciseContract(ctx context.Context, req *pb.ExerciseContra
 		return nil, status.Error(codes.InvalidArgument, "Contract settlement date has passed")
 	}
 
+	listingID, err := listingIDForTicker(s.SecuritiesDB, ticker)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "ticker not found: %v", err)
+	}
+
 	// Cross-bank exercise: seller is on partner bank — delegate to 2PC flow.
 	if sellerType == "INTERBANK" {
-		return s.exerciseCrossBank(ctx, req, tx, sellerID, buyerID, buyerType,
+		resp, rerr := s.exerciseCrossBank(ctx, req, tx, sellerID, buyerID, buyerType,
 			amount, strikePrice, currency, ticker, settlementDate)
+		if rerr == nil && buyerType != "EMPLOYEE" {
+			var mktPrice float64
+			if qErr := s.SecuritiesDB.QueryRowContext(ctx,
+				`SELECT price FROM listing WHERE id = $1`, listingID).Scan(&mktPrice); qErr == nil {
+				profit := (mktPrice-strikePrice)*float64(amount) - premium
+				if profit > 0 {
+					t := time.Now()
+					s.recordOtcTax(buyerID, buyerType, profit, currency, int(t.Month()), t.Year())
+				}
+			}
+		}
+		return resp, rerr
 	}
 
 	totalCost := strikePrice * float64(amount)
 	currencyID, ok := currencyIDMap[currency]
 	if !ok {
 		return nil, status.Errorf(codes.InvalidArgument, "unsupported currency: %s", currency)
-	}
-
-	listingID, err := listingIDForTicker(s.SecuritiesDB, ticker)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "ticker not found: %v", err)
 	}
 
 	buyerAccountID := req.BuyerAccountId
@@ -896,6 +935,17 @@ func (s *OtcServer) ExerciseContract(ctx context.Context, req *pb.ExerciseContra
 		return nil, status.Errorf(codes.Internal, "step 5 commit failed: %v", err)
 	}
 	sagaLog(5, "SUCCESS", "")
+
+	if buyerType != "EMPLOYEE" {
+		var mktPrice float64
+		if qErr := s.SecuritiesDB.QueryRowContext(ctx,
+			`SELECT price FROM listing WHERE id = $1`, listingID).Scan(&mktPrice); qErr == nil {
+			profit := (mktPrice-strikePrice)*float64(amount) - premium
+			if profit > 0 {
+				s.recordOtcTax(buyerID, buyerType, profit, currency, int(now.Month()), now.Year())
+			}
+		}
+	}
 
 	return &pb.ExerciseContractResponse{
 		Status:     "EXERCISED",
@@ -1485,4 +1535,28 @@ func (s *OtcServer) RollbackOtcInterbank(ctx context.Context, req *pb.OtcInterba
 		req.TxRoutingNumber, req.TxId,
 	)
 	return &pb.OtcEmptyResponse{}, nil
+}
+
+// ExpireContracts atomically transitions ACTIVE contracts past their settlement window to EXPIRED,
+// then records a loss-credit tax entry for each buyer whose premium is now forfeit.
+func (s *OtcServer) ExpireContracts() {
+	rows, err := s.DB.Query(`
+		UPDATE otc_contracts SET status='EXPIRED'
+		WHERE status='ACTIVE' AND settlement_date + INTERVAL '1 day' < NOW()
+		RETURNING id, buyer_id, buyer_type, premium, currency`)
+	if err != nil {
+		log.Printf("contract expiration error: %v", err)
+		return
+	}
+	defer rows.Close()
+	now := time.Now()
+	for rows.Next() {
+		var id, buyerID int64
+		var buyerType, currency string
+		var prem float64
+		if err := rows.Scan(&id, &buyerID, &buyerType, &prem, &currency); err != nil {
+			continue
+		}
+		s.recordOtcTax(buyerID, buyerType, -prem, currency, int(now.Month()), now.Year())
+	}
 }

--- a/services/otc-service/handlers/grpc_server_test.go
+++ b/services/otc-service/handlers/grpc_server_test.go
@@ -99,13 +99,13 @@ func acceptNegRow(sellerID, buyerID int64, sellerType, buyerType, state, ticker,
 		"2026-12-31", float64(100.0))
 }
 
-// contractRow returns the 10 columns scanned in ExerciseContract's initial load.
+// contractRow returns the 11 columns scanned in ExerciseContract's initial load.
 func contractRow(sellerID, buyerID int64, settlementDate time.Time) *sqlmock.Rows {
 	return sqlmock.NewRows([]string{
 		"seller_id", "seller_type", "buyer_id", "buyer_type", "status",
-		"ticker", "amount", "strike_price", "currency", "settlement_date",
+		"ticker", "amount", "strike_price", "premium", "currency", "settlement_date",
 	}).AddRow(sellerID, "CLIENT", buyerID, "CLIENT", "ACTIVE",
-		"AAPL", int32(5), float64(100.0), "USD", settlementDate)
+		"AAPL", int32(5), float64(100.0), float64(10.0), "USD", settlementDate)
 }
 
 // ===== Ping =====
@@ -447,6 +447,12 @@ func TestAcceptNegotiation_InsufficientFunds(t *testing.T) {
 
 func TestAcceptNegotiation_HappyPath(t *testing.T) {
 	s, mainMock, _, mCli, mAcc, mPort, mSec := newTestServer(t)
+	// Add ExchangeDB mock so recordOtcTax can convert USD→RSD
+	exchDB, mExch, exchErr := sqlmock.New()
+	require.NoError(t, exchErr)
+	s.ExchangeDB = exchDB
+	t.Cleanup(func() { _ = exchDB.Close() })
+
 	// seller (10) accepts PENDING_SELLER; buyer is 20
 	mainMock.ExpectBegin()
 	mainMock.ExpectQuery("SELECT seller_id").
@@ -475,6 +481,11 @@ func TestAcceptNegotiation_HappyPath(t *testing.T) {
 	mainMock.ExpectExec("UPDATE otc_negotiations").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mainMock.ExpectCommit()
+	// recordOtcTax: convert USD premium → RSD, then insert tax_record
+	mExch.ExpectQuery("SELECT middle_rate FROM daily_exchange_rates").
+		WillReturnRows(sqlmock.NewRows([]string{"middle_rate"}).AddRow(float64(117.5)))
+	mPort.ExpectExec("INSERT INTO tax_record").
+		WillReturnResult(sqlmock.NewResult(0, 1))
 	// fetchNegotiationByID
 	mainMock.ExpectQuery("SELECT id, ticker").
 		WillReturnRows(sqlmock.NewRows(negotiationColumns()).
@@ -495,6 +506,8 @@ func TestAcceptNegotiation_HappyPath(t *testing.T) {
 	assert.Equal(t, "ACCEPTED", resp.Status)
 	assert.NoError(t, mainMock.ExpectationsWereMet())
 	assert.NoError(t, mAcc.ExpectationsWereMet())
+	assert.NoError(t, mExch.ExpectationsWereMet())
+	assert.NoError(t, mPort.ExpectationsWereMet())
 }
 
 // ===== RejectNegotiation =====
@@ -670,9 +683,9 @@ func TestExerciseContract_NotActive(t *testing.T) {
 	mainMock.ExpectQuery("SELECT .* FROM otc_contracts WHERE id").
 		WillReturnRows(sqlmock.NewRows([]string{
 			"seller_id", "seller_type", "buyer_id", "buyer_type", "status",
-			"ticker", "amount", "strike_price", "currency", "settlement_date",
+			"ticker", "amount", "strike_price", "premium", "currency", "settlement_date",
 		}).AddRow(int64(10), "CLIENT", int64(20), "CLIENT", "EXPIRED",
-			"AAPL", int32(5), float64(100.0), "USD", future))
+			"AAPL", int32(5), float64(100.0), float64(0.0), "USD", future))
 	mainMock.ExpectRollback()
 	_, err := s.ExerciseContract(context.Background(), &pb.ExerciseContractRequest{
 		ContractId: 1, CallerId: 20, CallerType: "CLIENT",
@@ -1427,9 +1440,9 @@ func TestExerciseContract_UnsupportedCurrency(t *testing.T) {
 	mainMock.ExpectQuery("SELECT .* FROM otc_contracts WHERE id").
 		WillReturnRows(sqlmock.NewRows([]string{
 			"seller_id", "seller_type", "buyer_id", "buyer_type", "status",
-			"ticker", "amount", "strike_price", "currency", "settlement_date",
+			"ticker", "amount", "strike_price", "premium", "currency", "settlement_date",
 		}).AddRow(int64(10), "CLIENT", int64(20), "CLIENT", "ACTIVE",
-			"AAPL", int32(5), float64(100.0), "XYZ", future))
+			"AAPL", int32(5), float64(100.0), float64(0.0), "XYZ", future))
 	mSec.ExpectQuery("SELECT id FROM listing").
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(42)))
 	mainMock.ExpectRollback()
@@ -1837,9 +1850,9 @@ func TestExerciseContract_EmployeeSeller(t *testing.T) {
 	mainMock.ExpectQuery("SELECT .* FROM otc_contracts WHERE id").
 		WillReturnRows(sqlmock.NewRows([]string{
 			"seller_id", "seller_type", "buyer_id", "buyer_type", "status",
-			"ticker", "amount", "strike_price", "currency", "settlement_date",
+			"ticker", "amount", "strike_price", "premium", "currency", "settlement_date",
 		}).AddRow(int64(5), "EMPLOYEE", int64(20), "CLIENT", "ACTIVE",
-			"AAPL", int32(5), float64(100.0), "USD", future))
+			"AAPL", int32(5), float64(100.0), float64(10.0), "USD", future))
 	mSec.ExpectQuery("SELECT id FROM listing").
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(42)))
 	// Step 1: atomic UPDATE succeeds

--- a/services/otc-service/main.go
+++ b/services/otc-service/main.go
@@ -57,31 +57,13 @@ func main() {
 	}
 	defer func() { _ = exchangeDB.Close() }()
 
-	// Hourly contract expiration: marks ACTIVE contracts as EXPIRED once the
-	// buyer's exercise window (settlementDate + 24h) has passed.
-	// Runs immediately on startup so stale contracts are cleaned up at boot.
-	expireContracts := func() {
-		if _, err := otcDB.Exec(
-			`UPDATE otc_contracts SET status='EXPIRED'
-			 WHERE status='ACTIVE' AND settlement_date + INTERVAL '1 day' < NOW()`,
-		); err != nil {
-			log.Printf("contract expiration job error: %v", err)
-		}
-	}
-	go func() {
-		expireContracts()
-		for range time.Tick(time.Hour) {
-			expireContracts()
-		}
-	}()
-
 	lis, err := net.Listen("tcp", grpcPort)
 	if err != nil {
 		log.Fatalf("failed to listen on %s: %v", grpcPort, err)
 	}
 
 	srv := grpc.NewServer()
-	pb.RegisterOtcServiceServer(srv, &handlers.OtcServer{
+	srvImpl := &handlers.OtcServer{
 		DB:           otcDB,
 		EmployeeDB:   employeeDB,
 		ClientDB:     clientDB,
@@ -89,7 +71,17 @@ func main() {
 		PortfolioDB:  portfolioDB,
 		SecuritiesDB: securitiesDB,
 		ExchangeDB:   exchangeDB,
-	})
+	}
+	pb.RegisterOtcServiceServer(srv, srvImpl)
+
+	// Hourly contract expiration with tax loss recording.
+	// Runs immediately on startup so stale contracts are cleaned up at boot.
+	go func() {
+		srvImpl.ExpireContracts()
+		for range time.Tick(time.Hour) {
+			srvImpl.ExpireContracts()
+		}
+	}()
 
 	log.Printf("otc-service gRPC server listening on %s", grpcPort)
 	if err := srv.Serve(lis); err != nil {

--- a/services/portfolio-service/repository/tax_repo.go
+++ b/services/portfolio-service/repository/tax_repo.go
@@ -76,6 +76,7 @@ func GetTaxDebtList(ctx context.Context, db *sql.DB, userTypeFilter string) ([]T
 		FROM tax_record
 		WHERE ($1 = '' OR user_type = $1)
 		GROUP BY user_id, user_type
+		HAVING SUM(CASE WHEN is_paid = FALSE THEN amount_rsd ELSE 0 END) >= 0
 		ORDER BY user_id`,
 		userTypeFilter)
 	if err != nil {

--- a/services/portfolio-service/tax/collector.go
+++ b/services/portfolio-service/tax/collector.go
@@ -26,11 +26,33 @@ func CollectUnpaid(ctx context.Context, portfolioDB, accountDB, exchangeDB *sql.
 		return fmt.Errorf("load unpaid records: %w", err)
 	}
 
+	// Group records by (user_id, user_type) and net per user so that OTC loss-credit
+	// records (negative amounts) correctly offset gains before collection.
+	type userKey struct {
+		id    int64
+		utype string
+	}
+	netByUser := map[userKey]float64{}
+	idsByUser := map[userKey][]int64{}
+	for _, rec := range records {
+		key := userKey{rec.UserID, rec.UserType}
+		netByUser[key] += rec.AmountRSD
+		idsByUser[key] = append(idsByUser[key], rec.ID)
+	}
+
 	// Cache exchange rates for the duration of this collection run.
 	var rates map[string]float64
 
-	for _, rec := range records {
-		accountID, err := getAccountForUser(ctx, portfolioDB, rec.UserID, rec.UserType)
+	for key, netRSD := range netByUser {
+		if netRSD <= 0 {
+			// Net loss — mark all records consumed; nothing to deduct.
+			for _, id := range idsByUser[key] {
+				_ = repository.MarkTaxPaid(ctx, portfolioDB, id)
+			}
+			continue
+		}
+
+		accountID, err := getAccountForUser(ctx, portfolioDB, key.id, key.utype)
 		if err != nil {
 			continue
 		}
@@ -40,7 +62,7 @@ func CollectUnpaid(ctx context.Context, portfolioDB, accountDB, exchangeDB *sql.
 			continue
 		}
 
-		deductAmount := rec.AmountRSD
+		deductAmount := netRSD
 		if currencyCode != "RSD" {
 			if rates == nil {
 				rates, err = fetchMiddleRates(ctx, exchangeClient)
@@ -52,18 +74,19 @@ func CollectUnpaid(ctx context.Context, portfolioDB, accountDB, exchangeDB *sql.
 			if !ok || middleRate == 0 {
 				continue
 			}
-			deductAmount = rec.AmountRSD / middleRate
+			deductAmount = netRSD / middleRate
 		}
 
 		if err := deductFromAccount(ctx, accountDB, accountID, deductAmount); err != nil {
 			continue
 		}
 
-		_ = repository.MarkTaxPaid(ctx, portfolioDB, rec.ID)
+		for _, id := range idsByUser[key] {
+			_ = repository.MarkTaxPaid(ctx, portfolioDB, id)
+		}
 
-		// Credit the state's RSD account with the full RSD amount (no FX conversion —
-		// the state account is always RSD).
-		_ = creditStateAccount(ctx, accountDB, rec.AmountRSD)
+		// Credit the state's RSD account with the full net RSD amount.
+		_ = creditStateAccount(ctx, accountDB, netRSD)
 	}
 	return nil
 }


### PR DESCRIPTION
Record 15% tax on three OTC events: seller receives premium on AcceptNegotiation, buyer profits on ExerciseContract (both local and cross-bank paths), buyer loss credit on contract expiry. EMPLOYEE users are exempt. ExpireContracts uses UPDATE...RETURNING for idempotent expiry. Collector nets tax records per user before deducting so loss credits correctly offset gains.