### PR TITLE
feat(interbank): implement Banka 4 OTC interbank integration

### DIFF
--- a/services/api-gateway/handlers/interbank.go
+++ b/services/api-gateway/handlers/interbank.go
@@ -2,6 +2,8 @@ package handlers
 
 import (
 	"encoding/json"
+	"fmt"
+	"math"
 	"net/http"
 	"os"
 	"strconv"
@@ -9,6 +11,8 @@ import (
 	pb_otc "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/otc"
 	pb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/payment"
 	"github.com/gin-gonic/gin"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type interbankTransactionId struct {
@@ -27,19 +31,36 @@ type interbankEnvelope struct {
 	Message        json.RawMessage         `json:"message"`
 }
 
+// Nested posting format as used by Banka 4.
+type ibPartyID struct {
+	RoutingNumber int32  `json:"routingNumber"`
+	ID            string `json:"id"`
+}
+type ibAccount struct {
+	Type string     `json:"type"` // "ACCOUNT" | "PERSON" | "OPTION"
+	Num  string     `json:"num,omitempty"`
+	ID   *ibPartyID `json:"id,omitempty"`
+}
+type ibAssetInner struct {
+	Currency      string     `json:"currency,omitempty"`
+	Ticker        string     `json:"ticker,omitempty"`
+	NegotiationID *ibPartyID `json:"negotiationId,omitempty"`
+}
+type ibAsset struct {
+	Type  string        `json:"type"` // "MONAS" | "STOCK" | "OPTION"
+	Asset *ibAssetInner `json:"asset,omitempty"`
+}
+type interbankPosting struct {
+	Account ibAccount `json:"account"`
+	Amount  float64   `json:"amount"`
+	Asset   ibAsset   `json:"asset"`
+}
+
 type newTxMessage struct {
 	TransactionId  interbankTransactionId `json:"transactionId"`
 	Postings       []interbankPosting     `json:"postings"`
 	PaymentCode    string                 `json:"paymentCode"`
 	PaymentPurpose string                 `json:"paymentPurpose"`
-}
-
-type interbankPosting struct {
-	AccountType string  `json:"accountType"`
-	AccountNum  string  `json:"accountNum"`
-	Amount      float64 `json:"amount"`
-	AssetType   string  `json:"assetType"`
-	Currency    string  `json:"currency"`
 }
 
 type commitRollbackMessage struct {
@@ -82,27 +103,86 @@ func handleNewTx(c *gin.Context, client pb.PaymentServiceClient, otcClient pb_ot
 		return
 	}
 
-	// Detect OPTION posting (cross-bank OTC).
-	var optionPosting *interbankPosting
-	for i := range msg.Postings {
-		if msg.Postings[i].AccountType == "OPTION" {
-			optionPosting = &msg.Postings[i]
-			break
-		}
-	}
-
-	pbPostings := make([]*pb.InterbankPosting, len(msg.Postings))
-	for i, p := range msg.Postings {
-		pbPostings[i] = &pb.InterbankPosting{
-			AccountType: p.AccountType,
-			AccountNum:  p.AccountNum,
-			Amount:      p.Amount,
-			AssetType:   p.AssetType,
-			Currency:    p.Currency,
-		}
-	}
-
 	ctx := c.Request.Context()
+	ownRouting := gatewayOwnRoutingInt()
+
+	// Detect OTC postings in the nested Banka 4 format.
+	var exercisePosting, acceptPosting *interbankPosting
+	for i := range msg.Postings {
+		p := &msg.Postings[i]
+		if p.Account.ID == nil {
+			continue
+		}
+		rn := p.Account.ID.RoutingNumber
+		// Exercise: OPTION account on our bank gives STOCK (amount < 0 means asset leaves)
+		if p.Account.Type == "OPTION" && rn == ownRouting && p.Asset.Type == "STOCK" && p.Amount < 0 {
+			exercisePosting = p
+		}
+		// Accept: PERSON account on our bank receives OPTION right (amount > 0 means asset enters)
+		if p.Account.Type == "PERSON" && rn == ownRouting && p.Asset.Type == "OPTION" && p.Amount > 0 {
+			acceptPosting = p
+		}
+	}
+
+	if exercisePosting != nil || acceptPosting != nil {
+		// OTC transaction — skip payment service entirely.
+		var negID int64
+		var stockAmt int32
+		var isAccept bool
+		if acceptPosting != nil {
+			if acceptPosting.Asset.Asset != nil && acceptPosting.Asset.Asset.NegotiationID != nil {
+				negID, _ = strconv.ParseInt(acceptPosting.Asset.Asset.NegotiationID.ID, 10, 64)
+			}
+			stockAmt = 1
+			isAccept = true
+		} else {
+			negID, _ = strconv.ParseInt(exercisePosting.Account.ID.ID, 10, 64)
+			stockAmt = int32(math.Abs(exercisePosting.Amount))
+			isAccept = false
+		}
+		otcResp, otcErr := otcClient.PrepareOtcInterbank(ctx, &pb_otc.OtcInterbankPrepareRequest{
+			IdemRoutingNumber: fmt.Sprintf("%d", env.IdempotenceKey.RoutingNumber),
+			IdemKey:           env.IdempotenceKey.LocallyGeneratedKey,
+			TxRoutingNumber:   fmt.Sprintf("%d", msg.TransactionId.RoutingNumber),
+			TxId:              msg.TransactionId.ID,
+			NegotiationId:     negID,
+			StockAmount:       stockAmt,
+			IsAccept:          isAccept,
+		})
+		vote := "NO"
+		reason := ""
+		if otcErr == nil && otcResp != nil && otcResp.Vote == "YES" {
+			vote = "YES"
+		} else if otcResp != nil {
+			reason = otcResp.Reason
+		}
+		c.JSON(http.StatusOK, gin.H{"vote": vote, "reasons": []string{reason}})
+		return
+	}
+
+	// Non-OTC: convert nested Banka 4 format → flat proto for payment service.
+	var protoPostings []*pb.InterbankPosting
+	for _, p := range msg.Postings {
+		accountNum := p.Account.Num // set for "ACCOUNT" type
+		if accountNum == "" && p.Account.ID != nil {
+			accountNum = p.Account.ID.ID // set for "PERSON" type
+		}
+		currency := ""
+		if p.Asset.Asset != nil {
+			currency = p.Asset.Asset.Currency
+		}
+		protoPostings = append(protoPostings, &pb.InterbankPosting{
+			AccountType: p.Account.Type,
+			AccountNum:  accountNum,
+			Amount:      p.Amount,
+			AssetType:   p.Asset.Type,
+			Currency:    currency,
+		})
+	}
+
+	type reason struct {
+		Reason string `json:"reason"`
+	}
 
 	paymentResp, err := client.PrepareInterbankPayment(ctx, &pb.PrepareInterbankPaymentRequest{
 		IdempotenceKey: &pb.InterbankIdempotenceKey{
@@ -113,7 +193,7 @@ func handleNewTx(c *gin.Context, client pb.PaymentServiceClient, otcClient pb_ot
 			RoutingNumber: msg.TransactionId.RoutingNumber,
 			Id:            msg.TransactionId.ID,
 		},
-		Postings:       pbPostings,
+		Postings:       protoPostings,
 		PaymentCode:    msg.PaymentCode,
 		PaymentPurpose: msg.PaymentPurpose,
 	})
@@ -122,63 +202,7 @@ func handleNewTx(c *gin.Context, client pb.PaymentServiceClient, otcClient pb_ot
 		return
 	}
 
-	type reason struct {
-		Reason string `json:"reason"`
-	}
-
-	if optionPosting != nil {
-		negID, parseErr := strconv.ParseInt(optionPosting.AccountNum, 10, 64)
-		if parseErr != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid OPTION account num"})
-			return
-		}
-		stockAmount := int32(optionPosting.Amount)
-		if stockAmount < 0 {
-			stockAmount = -stockAmount
-		}
-
-		otcResp, otcErr := otcClient.PrepareOtcInterbank(ctx, &pb_otc.OtcInterbankPrepareRequest{
-			IdemRoutingNumber: strconv.Itoa(int(env.IdempotenceKey.RoutingNumber)),
-			IdemKey:           env.IdempotenceKey.LocallyGeneratedKey,
-			TxRoutingNumber:   strconv.Itoa(int(msg.TransactionId.RoutingNumber)),
-			TxId:              msg.TransactionId.ID,
-			NegotiationId:     negID,
-			StockAmount:       stockAmount,
-			IsAccept:          optionPosting.Amount > 0,
-		})
-
-		// If OTC voted NO (or errored), rollback payment if it voted YES.
-		if otcErr != nil || (otcResp != nil && otcResp.Vote != "YES") {
-			if paymentResp.Vote == "YES" {
-				_, _ = client.RollbackInterbankPayment(ctx, &pb.CommitRollbackInterbankRequest{
-					TransactionId: &pb.InterbankTransactionId{
-						RoutingNumber: msg.TransactionId.RoutingNumber,
-						Id:            msg.TransactionId.ID,
-					},
-				})
-			}
-			otcReason := "OTC_INTERNAL_ERROR"
-			if otcResp != nil {
-				otcReason = otcResp.Reason
-			}
-			c.JSON(http.StatusOK, gin.H{"vote": "NO", "reasons": []reason{{Reason: otcReason}}})
-			return
-		}
-
-		// If payment voted NO, rollback OTC.
-		if paymentResp.Vote != "YES" {
-			_, _ = otcClient.RollbackOtcInterbank(ctx, &pb_otc.OtcInterbankTxRequest{
-				TxRoutingNumber: strconv.Itoa(int(msg.TransactionId.RoutingNumber)),
-				TxId:            msg.TransactionId.ID,
-			})
-			reasons := make([]reason, len(paymentResp.Reasons))
-			for i, r := range paymentResp.Reasons {
-				reasons[i] = reason{Reason: r.Reason}
-			}
-			c.JSON(http.StatusOK, gin.H{"vote": "NO", "reasons": reasons})
-			return
-		}
-	} else if paymentResp.Vote != "YES" {
+	if paymentResp.Vote != "YES" {
 		reasons := make([]reason, len(paymentResp.Reasons))
 		for i, r := range paymentResp.Reasons {
 			reasons[i] = reason{Reason: r.Reason}
@@ -213,13 +237,18 @@ func handleCommitRollbackTx(c *gin.Context, client pb.PaymentServiceClient, otcC
 		_, _ = client.RollbackInterbankPayment(ctx, paymentReq)
 		_, _ = otcClient.RollbackOtcInterbank(ctx, otcReq)
 	} else {
+		// Payment service returns codes.NotFound for OTC-only transactions — treat as no-op.
 		if _, err := client.CommitInterbankPayment(ctx, paymentReq); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-			return
+			if status.Code(err) != codes.NotFound {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+				return
+			}
 		}
 		if _, err := otcClient.CommitOtcInterbank(ctx, otcReq); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-			return
+			if status.Code(err) != codes.NotFound {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+				return
+			}
 		}
 	}
 	c.Status(http.StatusNoContent)

--- a/services/api-gateway/handlers/otc_interbank.go
+++ b/services/api-gateway/handlers/otc_interbank.go
@@ -13,6 +13,7 @@ import (
 	pb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/otc"
 	"github.com/gin-gonic/gin"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
 
@@ -44,13 +45,15 @@ type otcNegotiationBody struct {
 	Stock struct {
 		Ticker string `json:"ticker"`
 	} `json:"stock"`
-	SettlementDate string         `json:"settlementDate"`
-	PricePerUnit   otcMoneyAmount `json:"pricePerUnit"`
-	Premium        otcMoneyAmount `json:"premium"`
-	BuyerID        otcPartyID     `json:"buyerId"`
-	SellerID       otcPartyID     `json:"sellerId"`
-	Amount         int32          `json:"amount"`
-	SellerType     string         `json:"sellerType"`
+	SettlementDate     string         `json:"settlementDate"`
+	PricePerUnit       otcMoneyAmount `json:"pricePerUnit"`
+	Premium            otcMoneyAmount `json:"premium"`
+	BuyerID            otcPartyID     `json:"buyerId"`
+	SellerID           otcPartyID     `json:"sellerId"`
+	Amount             int32          `json:"amount"`
+	SellerType         string         `json:"sellerType"`
+	BuyerAccountNumber string         `json:"buyerAccountNumber"` // required by Banka 4
+	LastModifiedBy     *otcPartyID    `json:"lastModifiedBy"`     // turn-tracking
 }
 
 type otcNegotiationResponse struct {
@@ -110,6 +113,10 @@ func IncomingCreateNegotiation(otcClient pb.OtcServiceClient) gin.HandlerFunc {
 
 		ctx, cancel := context.WithTimeout(c.Request.Context(), 10*time.Second)
 		defer cancel()
+
+		// Forward buyer account number to otc-service via gRPC metadata (no proto change needed).
+		md := metadata.Pairs("buyer-account-number", body.BuyerAccountNumber)
+		ctx = metadata.NewOutgoingContext(ctx, md)
 
 		resp, err := otcClient.CreateInterbankNegotiation(ctx, &pb.CreateInterbankNegotiationRequest{
 			Ticker:               body.Stock.Ticker,
@@ -337,7 +344,7 @@ func sendOtcRequest(method, url, apiKey string, body any) (*http.Response, error
 	return client.Do(req)
 }
 
-// ForwardNegotiationToPartner calls POST <PARTNER_BANK_URL>/otc/interbank/negotiations.
+// ForwardNegotiationToPartner calls POST <PARTNER_BANK_URL>/negotiations.
 // Returns the partner's (routingNumber, id) tuple, or an error.
 func ForwardNegotiationToPartner(body otcNegotiationBody, partnerRoutingNumber string) (int32, string, error) {
 	bank, err := gwinterbank.ResolveBankByRoutingNumber(partnerRoutingNumber)
@@ -345,7 +352,7 @@ func ForwardNegotiationToPartner(body otcNegotiationBody, partnerRoutingNumber s
 		return 0, "", fmt.Errorf("cannot resolve partner bank: %w", err)
 	}
 
-	resp, err := sendOtcRequest(http.MethodPost, bank.BankURL+"/otc/interbank/negotiations", bank.APIKey, body)
+	resp, err := sendOtcRequest(http.MethodPost, bank.BankURL+"/negotiations", bank.APIKey, body)
 	if err != nil {
 		return 0, "", fmt.Errorf("partner request failed: %w", err)
 	}

--- a/services/api-gateway/main.go
+++ b/services/api-gateway/main.go
@@ -126,12 +126,15 @@ func main() {
 	// Public stock listing for partner banks — authenticated by X-Api-Key, no JWT
 	r.GET("/public-stock", handlers.GetPublicStock(otcClient))
 
-	// OTC interbank endpoints (partner bank calls, no JWT)
-	r.POST("/otc/interbank/negotiations", handlers.IncomingCreateNegotiation(otcClient))
-	r.PUT("/otc/interbank/negotiations/:routingNumber/:id", handlers.IncomingCounterOffer(otcClient))
-	r.GET("/otc/interbank/negotiations/:routingNumber/:id", handlers.IncomingGetNegotiation(otcClient))
-	r.DELETE("/otc/interbank/negotiations/:routingNumber/:id", handlers.IncomingDeleteNegotiation(otcClient))
-	r.GET("/otc/interbank/negotiations/:routingNumber/:id/accept", handlers.IncomingAcceptNegotiation(otcClient))
+	// OTC interbank endpoints (partner bank calls, no JWT).
+	// Registered at both /otc/interbank/negotiations/... (legacy) and /negotiations/... (protocol standard).
+	for _, prefix := range []string{"/otc/interbank/negotiations", "/negotiations"} {
+		r.POST(prefix, handlers.IncomingCreateNegotiation(otcClient))
+		r.PUT(prefix+"/:routingNumber/:id", handlers.IncomingCounterOffer(otcClient))
+		r.GET(prefix+"/:routingNumber/:id", handlers.IncomingGetNegotiation(otcClient))
+		r.DELETE(prefix+"/:routingNumber/:id", handlers.IncomingDeleteNegotiation(otcClient))
+		r.GET(prefix+"/:routingNumber/:id/accept", handlers.IncomingAcceptNegotiation(otcClient))
+	}
 
 	r.Use(cors.New(cors.Config{
 		AllowOrigins:     []string{"http://localhost:5173", "http://localhost:3000"},

--- a/services/otc-service/db/schema.sql
+++ b/services/otc-service/db/schema.sql
@@ -77,3 +77,4 @@ CREATE TABLE IF NOT EXISTS otc_interbank_tx (
     UNIQUE(idem_routing_number, idem_key)
 );
 ALTER TABLE otc_interbank_tx ADD COLUMN IF NOT EXISTS created_at TIMESTAMP NOT NULL DEFAULT NOW();
+ALTER TABLE otc_negotiations ADD COLUMN IF NOT EXISTS buyer_account_number VARCHAR(50);

--- a/services/otc-service/handlers/grpc_server.go
+++ b/services/otc-service/handlers/grpc_server.go
@@ -11,6 +11,7 @@ import (
 
 	pb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/otc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
 
@@ -25,7 +26,7 @@ func retryExec(db *sql.DB, query string, args ...interface{}) {
 	}
 }
 
-func (s *OtcServer) insertOtcInterbankTx(ctx context.Context, req *pb.OtcInterbankPrepareRequest, vote string) {
+func (s *OtcServer) insertOtcInterbankTx(ctx context.Context, req *pb.OtcInterbankPrepareRequest, negID int64, vote string) {
 	txType := "EXERCISE"
 	if req.IsAccept {
 		txType = "ACCEPT"
@@ -37,7 +38,7 @@ func (s *OtcServer) insertOtcInterbankTx(ctx context.Context, req *pb.OtcInterba
 		VALUES ($1, $2, $3, $4, $5, $6, $7, 'PENDING', $8)
 		ON CONFLICT (idem_routing_number, idem_key) DO NOTHING`,
 		req.IdemRoutingNumber, req.IdemKey, req.TxRoutingNumber, req.TxId,
-		req.NegotiationId, txType, req.StockAmount, vote,
+		negID, txType, req.StockAmount, vote,
 	)
 }
 
@@ -1101,10 +1102,24 @@ func (s *OtcServer) fetchInterbankNegotiationByID(ctx context.Context, id int64)
 	return &r, nil
 }
 
-// lookupInterbankNegotiation returns the local id of a cross-bank negotiation by its creator key.
+// lookupInterbankNegotiation resolves a cross-bank negotiation by path params.
+// Protocol path: {sellerRn}/{sellerLocalId} — sellerRn is our routing, sellerLocalId is our DB id.
+// Falls back to creator-key lookup for backward compatibility.
 func (s *OtcServer) lookupInterbankNegotiation(ctx context.Context, routingNumber int32, externalID string) (int64, string, error) {
 	var localID int64
 	var currentStatus string
+
+	// Primary: {sellerRn}/{ourLocalId} — look up by local primary-key id.
+	if localIDInt, parseErr := strconv.ParseInt(externalID, 10, 64); parseErr == nil {
+		err := s.DB.QueryRowContext(ctx,
+			`SELECT id, status FROM otc_negotiations WHERE id = $1`, localIDInt,
+		).Scan(&localID, &currentStatus)
+		if err == nil {
+			return localID, currentStatus, nil
+		}
+	}
+
+	// Fallback: {creatorRn}/{creatorExtId} — backward compat for callers that pass buyer routing/id.
 	err := s.DB.QueryRowContext(ctx, `
 		SELECT id, status FROM otc_negotiations
 		WHERE creator_routing_number = $1 AND creator_external_id = $2`,
@@ -1140,6 +1155,14 @@ func (s *OtcServer) CreateInterbankNegotiation(ctx context.Context, req *pb.Crea
 		return nil, status.Errorf(codes.InvalidArgument, "seller_external_id must be a numeric local user ID")
 	}
 
+	// Read buyer account number from gRPC metadata (forwarded by api-gateway from Banka 4's request body).
+	var buyerAccountNum string
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		if v := md.Get("buyer-account-number"); len(v) > 0 {
+			buyerAccountNum = v[0]
+		}
+	}
+
 	// Idempotency: return existing row if this creator key already exists
 	if existingID, _, err := s.lookupInterbankNegotiation(ctx, req.CreatorRoutingNumber, req.CreatorExternalId); err == nil {
 		return s.fetchInterbankNegotiationByID(ctx, existingID)
@@ -1154,9 +1177,10 @@ func (s *OtcServer) CreateInterbankNegotiation(ctx context.Context, req *pb.Crea
 			 last_modified, modified_by_id, modified_by_type, status,
 			 buyer_routing_number, buyer_external_id,
 			 seller_routing_number, seller_external_id,
-			 creator_routing_number, creator_external_id)
+			 creator_routing_number, creator_external_id,
+			 buyer_account_number)
 		VALUES ($1, $2, $3, 0, 'INTERBANK', $4, $5, $6, $7, $8, $9, 0, 'INTERBANK', 'PENDING_SELLER',
-		        $10, $11, $12, $13, $14, $15)
+		        $10, $11, $12, $13, $14, $15, $16)
 		RETURNING id`,
 		req.Ticker, sellerID, sellerType,
 		req.Amount, req.PricePerUnit, req.SettlementDate, req.Premium, req.PriceCurrency,
@@ -1164,6 +1188,7 @@ func (s *OtcServer) CreateInterbankNegotiation(ctx context.Context, req *pb.Crea
 		req.BuyerRoutingNumber, req.BuyerExternalId,
 		req.SellerRoutingNumber, req.SellerExternalId,
 		req.CreatorRoutingNumber, req.CreatorExternalId,
+		buyerAccountNum,
 	).Scan(&id)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to create interbank negotiation: %v", err)
@@ -1241,12 +1266,17 @@ func (s *OtcServer) InterbankAcceptNegotiation(ctx context.Context, req *pb.Inte
 	var premium, strikePrice float64
 	var sellerID int64
 	var sellerType string
+	// Protocol path: {sellerRn}/{sellerLocalId} — look up by local id first.
+	localIDInt, parseErr := strconv.ParseInt(req.ExternalId, 10, 64)
+	if parseErr != nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid negotiation id")
+	}
 	err = tx.QueryRowContext(ctx, `
 		SELECT id, status, ticker, currency, settlement_date::text, amount, premium, price_per_stock,
 		       seller_id, seller_type
 		FROM otc_negotiations
-		WHERE creator_routing_number = $1 AND creator_external_id = $2 FOR UPDATE`,
-		req.RoutingNumber, req.ExternalId,
+		WHERE id = $1 FOR UPDATE`,
+		localIDInt,
 	).Scan(&localID, &currentStatus, &ticker, &currency, &settlementDate, &amount, &premium, &strikePrice,
 		&sellerID, &sellerType)
 	if err == sql.ErrNoRows {
@@ -1277,6 +1307,12 @@ func (s *OtcServer) InterbankAcceptNegotiation(ctx context.Context, req *pb.Inte
 
 	if err = tx.Commit(); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to commit: %v", err)
+	}
+
+	if twopcErr := s.executeInterbankAcceptOutgoing(ctx, localID); twopcErr != nil {
+		_, _ = s.DB.ExecContext(context.Background(),
+			`UPDATE otc_negotiations SET status='PENDING_BUYER' WHERE id = $1`, localID)
+		return nil, status.Errorf(codes.Unavailable, "accept 2PC failed: %v", twopcErr)
 	}
 	return &pb.OtcEmptyResponse{}, nil
 }
@@ -1335,7 +1371,49 @@ func (s *OtcServer) PrepareOtcInterbank(ctx context.Context, req *pb.OtcInterban
 		return nil, status.Errorf(codes.Internal, "idempotency check failed: %v", err)
 	}
 
-	// Load negotiation.
+	// BUYER-SIDE accept: Banka 4 is seller; req.NegotiationId is their local ID, not ours.
+	// Must be handled before the general negotiation load (which uses our local IDs).
+	if req.IsAccept {
+		partnerRouting := os.Getenv("PARTNER_ROUTING_NUMBER")
+		if req.IdemRoutingNumber == partnerRouting {
+			partnerRoutingInt, _ := strconv.ParseInt(partnerRouting, 10, 64)
+			var localNegID int64
+			if lookupErr := s.DB.QueryRowContext(ctx,
+				`SELECT id FROM otc_negotiations WHERE partner_negotiation_id = $1 AND seller_routing_number = $2`,
+				req.NegotiationId, partnerRoutingInt,
+			).Scan(&localNegID); lookupErr == sql.ErrNoRows {
+				s.insertOtcInterbankTx(ctx, req, req.NegotiationId, "NO")
+				return &pb.OtcInterbankVoteResponse{Vote: "NO", Reason: "OPTION_NEGOTIATION_NOT_FOUND"}, nil
+			} else if lookupErr != nil {
+				return nil, status.Errorf(codes.Internal, "lookup failed: %v", lookupErr)
+			}
+
+			var buyerAcctNum, buyerNegStatus string
+			var prem float64
+			if err = s.DB.QueryRowContext(ctx,
+				`SELECT buyer_account_number, premium, status FROM otc_negotiations WHERE id = $1`,
+				localNegID,
+			).Scan(&buyerAcctNum, &prem, &buyerNegStatus); err != nil {
+				return nil, status.Errorf(codes.Internal, "failed to load negotiation: %v", err)
+			}
+			if buyerNegStatus != "ACCEPTED" {
+				s.insertOtcInterbankTx(ctx, req, localNegID, "NO")
+				return &pb.OtcInterbankVoteResponse{Vote: "NO", Reason: "OPTION_USED_OR_EXPIRED"}, nil
+			}
+			var availBal float64
+			_ = s.AccountDB.QueryRowContext(ctx,
+				`SELECT available_balance FROM accounts WHERE account_number = $1`, buyerAcctNum,
+			).Scan(&availBal)
+			if availBal < prem {
+				s.insertOtcInterbankTx(ctx, req, localNegID, "NO")
+				return &pb.OtcInterbankVoteResponse{Vote: "NO", Reason: "INSUFFICIENT_FUNDS"}, nil
+			}
+			s.insertOtcInterbankTx(ctx, req, localNegID, "YES")
+			return &pb.OtcInterbankVoteResponse{Vote: "YES"}, nil
+		}
+	}
+
+	// Load negotiation (by our local ID; applies to seller-side accept and all exercise requests).
 	var negStatus, ticker, sellerType string
 	var sellerID int64
 	var negAmount int32
@@ -1344,7 +1422,7 @@ func (s *OtcServer) PrepareOtcInterbank(ctx context.Context, req *pb.OtcInterban
 		 FROM otc_negotiations WHERE id = $1`, req.NegotiationId,
 	).Scan(&negStatus, &ticker, &sellerID, &sellerType, &negAmount)
 	if err == sql.ErrNoRows {
-		s.insertOtcInterbankTx(ctx, req, "NO")
+		s.insertOtcInterbankTx(ctx, req, req.NegotiationId, "NO")
 		return &pb.OtcInterbankVoteResponse{Vote: "NO", Reason: "OPTION_NEGOTIATION_NOT_FOUND"}, nil
 	}
 	if err != nil {
@@ -1352,8 +1430,9 @@ func (s *OtcServer) PrepareOtcInterbank(ctx context.Context, req *pb.OtcInterban
 	}
 
 	if req.IsAccept {
+		// SELLER-SIDE accept: partner bank is buyer, req.NegotiationId is our local ID.
 		if negStatus != "ACCEPTED" {
-			s.insertOtcInterbankTx(ctx, req, "NO")
+			s.insertOtcInterbankTx(ctx, req, req.NegotiationId, "NO")
 			return &pb.OtcInterbankVoteResponse{Vote: "NO", Reason: "OPTION_USED_OR_EXPIRED"}, nil
 		}
 		var contractExists bool
@@ -1362,11 +1441,11 @@ func (s *OtcServer) PrepareOtcInterbank(ctx context.Context, req *pb.OtcInterban
 			req.NegotiationId,
 		).Scan(&contractExists)
 		if contractExists {
-			s.insertOtcInterbankTx(ctx, req, "NO")
+			s.insertOtcInterbankTx(ctx, req, req.NegotiationId, "NO")
 			return &pb.OtcInterbankVoteResponse{Vote: "NO", Reason: "OPTION_USED_OR_EXPIRED"}, nil
 		}
 		if req.StockAmount != negAmount {
-			s.insertOtcInterbankTx(ctx, req, "NO")
+			s.insertOtcInterbankTx(ctx, req, req.NegotiationId, "NO")
 			return &pb.OtcInterbankVoteResponse{Vote: "NO", Reason: "OPTION_AMOUNT_INCORRECT"}, nil
 		}
 		listingID, err := listingIDForTicker(s.SecuritiesDB, ticker)
@@ -1380,7 +1459,7 @@ func (s *OtcServer) PrepareOtcInterbank(ctx context.Context, req *pb.OtcInterban
 			portfolioUserID(sellerID, sellerType), sellerType, listingID,
 		).Scan(&freeShares)
 		if freeShares < int64(req.StockAmount) {
-			s.insertOtcInterbankTx(ctx, req, "NO")
+			s.insertOtcInterbankTx(ctx, req, req.NegotiationId, "NO")
 			return &pb.OtcInterbankVoteResponse{Vote: "NO", Reason: "OPTION_AMOUNT_INCORRECT"}, nil
 		}
 	} else {
@@ -1394,24 +1473,24 @@ func (s *OtcServer) PrepareOtcInterbank(ctx context.Context, req *pb.OtcInterban
 			req.NegotiationId,
 		).Scan(&contractStatus, &contractAmount, &settlementDate)
 		if err == sql.ErrNoRows {
-			s.insertOtcInterbankTx(ctx, req, "NO")
+			s.insertOtcInterbankTx(ctx, req, req.NegotiationId, "NO")
 			return &pb.OtcInterbankVoteResponse{Vote: "NO", Reason: "OPTION_NEGOTIATION_NOT_FOUND"}, nil
 		}
 		if contractStatus != "ACTIVE" {
-			s.insertOtcInterbankTx(ctx, req, "NO")
+			s.insertOtcInterbankTx(ctx, req, req.NegotiationId, "NO")
 			return &pb.OtcInterbankVoteResponse{Vote: "NO", Reason: "OPTION_USED_OR_EXPIRED"}, nil
 		}
 		if time.Now().After(settlementDate.Add(24 * time.Hour)) {
-			s.insertOtcInterbankTx(ctx, req, "NO")
+			s.insertOtcInterbankTx(ctx, req, req.NegotiationId, "NO")
 			return &pb.OtcInterbankVoteResponse{Vote: "NO", Reason: "OPTION_USED_OR_EXPIRED"}, nil
 		}
 		if contractAmount != req.StockAmount {
-			s.insertOtcInterbankTx(ctx, req, "NO")
+			s.insertOtcInterbankTx(ctx, req, req.NegotiationId, "NO")
 			return &pb.OtcInterbankVoteResponse{Vote: "NO", Reason: "OPTION_AMOUNT_INCORRECT"}, nil
 		}
 	}
 
-	s.insertOtcInterbankTx(ctx, req, "YES")
+	s.insertOtcInterbankTx(ctx, req, req.NegotiationId, "YES")
 	return &pb.OtcInterbankVoteResponse{Vote: "YES"}, nil
 }
 
@@ -1453,6 +1532,36 @@ func (s *OtcServer) CommitOtcInterbank(ctx context.Context, req *pb.OtcInterbank
 			return nil, status.Errorf(codes.Internal, "failed to load negotiation: %v", err)
 		}
 
+		if sellerType == "INTERBANK" {
+			// BUYER-SIDE accept: we are the buyer, Banka 4 is seller.
+			var buyerAcctNum string
+			var buyerID int64
+			var buyerType string
+			if err = s.DB.QueryRowContext(ctx,
+				`SELECT buyer_account_number, buyer_id, buyer_type FROM otc_negotiations WHERE id = $1`,
+				negotiationID,
+			).Scan(&buyerAcctNum, &buyerID, &buyerType); err != nil {
+				return nil, status.Errorf(codes.Internal, "failed to load buyer info: %v", err)
+			}
+			// Debit buyer's account for premium.
+			_, _ = s.AccountDB.ExecContext(ctx,
+				`UPDATE accounts SET balance = balance - $1, available_balance = available_balance - $1
+				 WHERE account_number = $2 AND available_balance >= $1`,
+				premium, buyerAcctNum)
+			// Create buyer-side contract (seller is INTERBANK).
+			_, _ = s.DB.ExecContext(ctx, `
+				INSERT INTO otc_contracts
+					(negotiation_id, seller_id, seller_type, buyer_id, buyer_type,
+					 ticker, amount, strike_price, premium, currency, settlement_date)
+				VALUES ($1, 0, 'INTERBANK', $2, $3, $4, $5, $6, $7, $8, $9)
+				ON CONFLICT (negotiation_id) DO NOTHING`,
+				negotiationID, buyerID, buyerType,
+				ticker, amount, strikePrice, premium, currency, settlementDate)
+			_, _ = s.DB.ExecContext(ctx, `UPDATE otc_interbank_tx SET status='COMMITTED' WHERE id = $1`, id)
+			return &pb.OtcEmptyResponse{}, nil
+		}
+
+		// SELLER-SIDE accept: we are the seller, partner bank is buyer.
 		listingID, err := listingIDForTicker(s.SecuritiesDB, ticker)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "ticker not found: %v", err)
@@ -1486,12 +1595,13 @@ func (s *OtcServer) CommitOtcInterbank(ctx context.Context, req *pb.OtcInterbank
 		}
 	} else { // EXERCISE
 		var sellerID int64
-		var sellerType, ticker string
+		var sellerType, ticker, currency string
 		var amount int32
+		var strikePrice float64
 		err = s.DB.QueryRowContext(ctx,
-			`SELECT seller_id, seller_type, ticker, amount FROM otc_contracts WHERE negotiation_id = $1`,
+			`SELECT seller_id, seller_type, ticker, amount, currency, strike_price FROM otc_contracts WHERE negotiation_id = $1`,
 			negotiationID,
-		).Scan(&sellerID, &sellerType, &ticker, &amount)
+		).Scan(&sellerID, &sellerType, &ticker, &amount, &currency, &strikePrice)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "failed to load contract: %v", err)
 		}
@@ -1516,6 +1626,16 @@ func (s *OtcServer) CommitOtcInterbank(ctx context.Context, req *pb.OtcInterbank
 			`DELETE FROM portfolio_entry WHERE user_id=$1 AND user_type=$2 AND listing_id=$3 AND amount <= 0`,
 			portfolioUserID(sellerID, sellerType), sellerType, listingID,
 		)
+
+		// Credit seller's account with strike payment (buyer's bank sent us the exercise 2PC).
+		strikePayment := float64(stockAmount) * strikePrice
+		if currID, ok := currencyIDMap[currency]; ok && strikePayment > 0 {
+			if sellerAcctID, findErr := findAccount(s.AccountDB, portfolioUserID(sellerID, sellerType), currID); findErr == nil {
+				_, _ = s.AccountDB.ExecContext(ctx,
+					`UPDATE accounts SET balance = balance + $1, available_balance = available_balance + $1 WHERE id = $2`,
+					strikePayment, sellerAcctID)
+			}
+		}
 
 		if _, err = s.DB.ExecContext(ctx,
 			`UPDATE otc_contracts SET status='EXERCISED' WHERE negotiation_id = $1`, negotiationID,

--- a/services/otc-service/handlers/interbank_outgoing.go
+++ b/services/otc-service/handlers/interbank_outgoing.go
@@ -81,7 +81,7 @@ type otcIbVoteResponse struct {
 type otcOutgoing2PCReq struct {
 	sellerExtID          string
 	partnerNegotiationID int64
-	partnerRoutingNum    int    // seller's bank routing number
+	partnerRoutingNum    int // seller's bank routing number
 	stockAmount          int32
 	buyerAccountNum      string
 	buyerExternalID      string // buyer's local ID as string

--- a/services/otc-service/handlers/interbank_outgoing.go
+++ b/services/otc-service/handlers/interbank_outgoing.go
@@ -30,17 +30,37 @@ type otcIbIdempotenceKey struct {
 	LocallyGeneratedKey string `json:"locallyGeneratedKey"`
 }
 
-type otcIbPosting struct {
-	AccountType string  `json:"accountType"`
-	AccountNum  string  `json:"accountNum"`
-	Amount      float64 `json:"amount"`
-	AssetType   string  `json:"assetType,omitempty"`
-	Currency    string  `json:"currency,omitempty"`
+// Nested posting structs matching Banka 4's interbank format.
+type ibOutPartyID struct {
+	RoutingNumber int    `json:"routingNumber"`
+	ID            string `json:"id"`
+}
+type ibOutAccount struct {
+	Type string        `json:"type"`
+	Num  string        `json:"num,omitempty"`
+	ID   *ibOutPartyID `json:"id,omitempty"`
+}
+type ibOutAssetInner struct {
+	Currency      string        `json:"currency,omitempty"`
+	Ticker        string        `json:"ticker,omitempty"`
+	NegotiationID *ibOutPartyID `json:"negotiationId,omitempty"`
+}
+type ibOutAsset struct {
+	Type  string           `json:"type"`
+	Asset *ibOutAssetInner `json:"asset,omitempty"`
+}
+type ibOutPosting struct {
+	Account ibOutAccount `json:"account"`
+	Amount  float64      `json:"amount"`
+	Asset   ibOutAsset   `json:"asset"`
 }
 
 type otcIbNewTxMessage struct {
-	TransactionID otcIbTransactionID `json:"transactionId"`
-	Postings      []otcIbPosting     `json:"postings"`
+	TransactionID  otcIbTransactionID `json:"transactionId"`
+	Message        string             `json:"message"`
+	PaymentCode    string             `json:"paymentCode"`
+	PaymentPurpose string             `json:"paymentPurpose"`
+	Postings       []ibOutPosting     `json:"postings"`
 }
 
 type otcIbCommitMessage struct {
@@ -61,10 +81,13 @@ type otcIbVoteResponse struct {
 type otcOutgoing2PCReq struct {
 	sellerExtID          string
 	partnerNegotiationID int64
+	partnerRoutingNum    int    // seller's bank routing number
 	stockAmount          int32
 	buyerAccountNum      string
+	buyerExternalID      string // buyer's local ID as string
 	totalCost            float64
 	currency             string
+	ticker               string // stock ticker for STOCK asset posting
 }
 
 func otcGenerateUUID() string {
@@ -117,14 +140,40 @@ func executeOtcOutgoing2PC(ctx context.Context, bank otcInterbank.BankInfo, req 
 		IdempotenceKey: idemKey,
 		MessageType:    "NEW_TX",
 		Message: otcIbNewTxMessage{
-			TransactionID: txID,
-			Postings: []otcIbPosting{
-				// Credit seller on partner bank (identified by owner_id / external ID)
-				{AccountType: "PERSON", AccountNum: req.sellerExtID, Amount: +req.totalCost, AssetType: "MONAS", Currency: req.currency},
-				// Consume the OPTION (partner's local negotiation ID)
-				{AccountType: "OPTION", AccountNum: fmt.Sprintf("%d", req.partnerNegotiationID), Amount: -float64(req.stockAmount)},
-				// Debit buyer account on our side
-				{AccountType: "ACCOUNT", AccountNum: req.buyerAccountNum, Amount: -req.totalCost, AssetType: "MONAS", Currency: req.currency},
+			TransactionID:  txID,
+			Message:        "Peer OTC option exercise",
+			PaymentCode:    "289",
+			PaymentPurpose: "OTC option exercise",
+			Postings: []ibOutPosting{
+				{ // buyer's settlement account debited
+					Account: ibOutAccount{Type: "ACCOUNT", Num: req.buyerAccountNum},
+					Amount:  -req.totalCost,
+					Asset:   ibOutAsset{Type: "MONAS", Asset: &ibOutAssetInner{Currency: req.currency}},
+				},
+				{ // OPTION contract receives money (seller's bank credits seller via escrow)
+					Account: ibOutAccount{Type: "OPTION", ID: &ibOutPartyID{
+						RoutingNumber: req.partnerRoutingNum,
+						ID:            fmt.Sprintf("%d", req.partnerNegotiationID),
+					}},
+					Amount: req.totalCost,
+					Asset:  ibOutAsset{Type: "MONAS", Asset: &ibOutAssetInner{Currency: req.currency}},
+				},
+				{ // OPTION contract gives shares
+					Account: ibOutAccount{Type: "OPTION", ID: &ibOutPartyID{
+						RoutingNumber: req.partnerRoutingNum,
+						ID:            fmt.Sprintf("%d", req.partnerNegotiationID),
+					}},
+					Amount: -float64(req.stockAmount),
+					Asset:  ibOutAsset{Type: "STOCK", Asset: &ibOutAssetInner{Ticker: req.ticker}},
+				},
+				{ // buyer receives shares at our bank
+					Account: ibOutAccount{Type: "PERSON", ID: &ibOutPartyID{
+						RoutingNumber: otcOwnRoutingInt(),
+						ID:            req.buyerExternalID,
+					}},
+					Amount: float64(req.stockAmount),
+					Asset:  ibOutAsset{Type: "STOCK", Asset: &ibOutAssetInner{Ticker: req.ticker}},
+				},
 			},
 		},
 	})
@@ -271,10 +320,13 @@ func (s *OtcServer) exerciseCrossBank(
 	voteResult, commitErr := executeOtcOutgoing2PC(ctx, bank, otcOutgoing2PCReq{
 		sellerExtID:          sellerExtID,
 		partnerNegotiationID: partnerNegotiationID,
+		partnerRoutingNum:    int(sellerRoutingNum),
 		stockAmount:          amount,
 		buyerAccountNum:      buyerAccountNum,
+		buyerExternalID:      fmt.Sprintf("%d", buyerID),
 		totalCost:            totalCost,
 		currency:             currency,
+		ticker:               ticker,
 	})
 	if commitErr != nil || voteResult != "YES" {
 		sagaLog(2, "FAILED", fmt.Sprintf("2PC result: %v / vote=%s", commitErr, voteResult))
@@ -314,10 +366,11 @@ func (s *OtcServer) exerciseCrossBank(
 }
 
 // forwardNegotiationToPartner sends an outgoing negotiation to the partner bank's
-// /otc/interbank/negotiations endpoint and returns the partner bank's local negotiation ID.
+// /negotiations endpoint and returns the partner bank's local negotiation ID.
 func (s *OtcServer) forwardNegotiationToPartner(
 	bank otcInterbank.BankInfo,
 	req *pb.CreateNegotiationRequest,
+	buyerAccountNum string,
 ) (int64, error) {
 	type partyID struct {
 		RoutingNumber int    `json:"routingNumber"`
@@ -331,28 +384,32 @@ func (s *OtcServer) forwardNegotiationToPartner(
 		Ticker string `json:"ticker"`
 	}
 	type body struct {
-		Stock          stock   `json:"stock"`
-		SettlementDate string  `json:"settlementDate"`
-		PricePerUnit   money   `json:"pricePerUnit"`
-		Premium        money   `json:"premium"`
-		BuyerID        partyID `json:"buyerId"`
-		SellerID       partyID `json:"sellerId"`
-		Amount         int32   `json:"amount"`
-		SellerType     string  `json:"sellerType"`
+		Stock              stock   `json:"stock"`
+		SettlementDate     string  `json:"settlementDate"`
+		PricePerUnit       money   `json:"pricePerUnit"`
+		Premium            money   `json:"premium"`
+		BuyerID            partyID `json:"buyerId"`
+		SellerID           partyID `json:"sellerId"`
+		Amount             int32   `json:"amount"`
+		SellerType         string  `json:"sellerType"`
+		LastModifiedBy     partyID `json:"lastModifiedBy"`
+		BuyerAccountNumber string  `json:"buyerAccountNumber"`
 	}
 	ownRouting := otcOwnRoutingInt()
 	b := body{
-		Stock:          stock{Ticker: req.Ticker},
-		SettlementDate: req.SettlementDate,
-		PricePerUnit:   money{Currency: req.Currency, Amount: req.PricePerStock},
-		Premium:        money{Currency: req.Currency, Amount: req.Premium},
-		BuyerID:        partyID{RoutingNumber: ownRouting, ID: fmt.Sprintf("%d", req.BuyerId)},
-		SellerID:       partyID{RoutingNumber: int(req.SellerRoutingNumber), ID: req.SellerExternalId},
-		Amount:         req.Amount,
-		SellerType:     req.SellerType,
+		Stock:              stock{Ticker: req.Ticker},
+		SettlementDate:     req.SettlementDate,
+		PricePerUnit:       money{Currency: req.Currency, Amount: req.PricePerStock},
+		Premium:            money{Currency: req.Currency, Amount: req.Premium},
+		BuyerID:            partyID{RoutingNumber: ownRouting, ID: fmt.Sprintf("%d", req.BuyerId)},
+		SellerID:           partyID{RoutingNumber: int(req.SellerRoutingNumber), ID: req.SellerExternalId},
+		Amount:             req.Amount,
+		SellerType:         req.SellerType,
+		LastModifiedBy:     partyID{RoutingNumber: ownRouting, ID: fmt.Sprintf("%d", req.BuyerId)},
+		BuyerAccountNumber: buyerAccountNum,
 	}
 	data, _ := json.Marshal(b)
-	httpReq, err := http.NewRequest(http.MethodPost, bank.BankURL+"/otc/interbank/negotiations", bytes.NewReader(data))
+	httpReq, err := http.NewRequest(http.MethodPost, bank.BankURL+"/negotiations", bytes.NewReader(data))
 	if err != nil {
 		return 0, fmt.Errorf("create request: %w", err)
 	}
@@ -387,6 +444,14 @@ func (s *OtcServer) createNegotiationCrossBank(ctx context.Context, req *pb.Crea
 		return nil, status.Errorf(codes.Internal, "cannot resolve seller bank: %v", err)
 	}
 
+	// Resolve buyer's settlement account for this currency so CommitOtcInterbank can debit it.
+	currencyID := currencyIDMap[req.Currency]
+	var buyerAccountNum string
+	_ = s.AccountDB.QueryRowContext(ctx,
+		`SELECT account_number FROM accounts WHERE owner_id = $1 AND currency_id = $2 AND status = 'ACTIVE' LIMIT 1`,
+		req.BuyerId, currencyID,
+	).Scan(&buyerAccountNum)
+
 	now := time.Now()
 	var id int64
 	if err = s.DB.QueryRowContext(ctx, `
@@ -394,18 +459,20 @@ func (s *OtcServer) createNegotiationCrossBank(ctx context.Context, req *pb.Crea
 			(ticker, seller_id, seller_type, buyer_id, buyer_type,
 			 amount, price_per_stock, settlement_date, premium, currency,
 			 last_modified, modified_by_id, modified_by_type, status,
-			 seller_routing_number, seller_external_id)
-		VALUES ($1, 0, 'INTERBANK', $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, 'PENDING_SELLER', $12, $13)
+			 seller_routing_number, seller_external_id,
+			 buyer_account_number)
+		VALUES ($1, 0, 'INTERBANK', $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, 'PENDING_SELLER', $12, $13, $14)
 		RETURNING id`,
 		req.Ticker, req.BuyerId, req.BuyerType,
 		req.Amount, req.PricePerStock, req.SettlementDate, req.Premium, req.Currency,
 		now, req.BuyerId, req.BuyerType,
 		req.SellerRoutingNumber, req.SellerExternalId,
+		buyerAccountNum,
 	).Scan(&id); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to create cross-bank negotiation: %v", err)
 	}
 
-	partnerNegID, fwdErr := s.forwardNegotiationToPartner(bank, req)
+	partnerNegID, fwdErr := s.forwardNegotiationToPartner(bank, req, buyerAccountNum)
 	if fwdErr != nil {
 		_, _ = s.DB.ExecContext(ctx, `DELETE FROM otc_negotiations WHERE id = $1`, id)
 		return nil, status.Errorf(codes.Unavailable, "failed to forward negotiation to partner bank: %v", fwdErr)
@@ -422,66 +489,10 @@ func (s *OtcServer) createNegotiationCrossBank(ctx context.Context, req *pb.Crea
 	return s.fetchNegotiationByID(ctx, id)
 }
 
-// executeOtcAccept2PC sends a premium-payment 2PC to the partner bank during cross-bank accept.
-// The OPTION posting uses a positive amount (reserve/accept), unlike exercise which uses negative.
-func executeOtcAccept2PC(ctx context.Context, bank otcInterbank.BankInfo, req otcOutgoing2PCReq) (string, error) {
-	bankURL := bank.BankURL + "/interbank"
-	ownRouting := otcOwnRoutingInt()
-	txID := otcIbTransactionID{RoutingNumber: ownRouting, ID: otcGenerateUUID()}
-	idemKey := otcIbIdempotenceKey{RoutingNumber: ownRouting, LocallyGeneratedKey: otcGenerateUUID()}
-
-	resp, err := otcSendInterbankRequest(ctx, bankURL, bank.APIKey, otcIbEnvelope{
-		IdempotenceKey: idemKey,
-		MessageType:    "NEW_TX",
-		Message: otcIbNewTxMessage{
-			TransactionID: txID,
-			Postings: []otcIbPosting{
-				{AccountType: "PERSON", AccountNum: req.sellerExtID, Amount: +req.totalCost, AssetType: "MONAS", Currency: req.currency},
-				{AccountType: "OPTION", AccountNum: fmt.Sprintf("%d", req.partnerNegotiationID), Amount: +float64(req.stockAmount)},
-				{AccountType: "ACCOUNT", AccountNum: req.buyerAccountNum, Amount: -req.totalCost, AssetType: "MONAS", Currency: req.currency},
-			},
-		},
-	})
-	if err != nil {
-		return "NO", fmt.Errorf("NEW_TX: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	var vote otcIbVoteResponse
-	if err := json.NewDecoder(resp.Body).Decode(&vote); err != nil {
-		return "NO", err
-	}
-	if vote.Vote != "YES" {
-		return "NO", nil
-	}
-
-	commitResp, err := otcSendInterbankRequest(ctx, bankURL, bank.APIKey, otcIbEnvelope{
-		IdempotenceKey: otcIbIdempotenceKey{RoutingNumber: ownRouting, LocallyGeneratedKey: otcGenerateUUID()},
-		MessageType:    "COMMIT_TX",
-		Message:        otcIbCommitMessage{TransactionID: txID},
-	})
-	if err != nil {
-		_, _ = otcSendInterbankRequest(ctx, bankURL, bank.APIKey, otcIbEnvelope{
-			IdempotenceKey: otcIbIdempotenceKey{RoutingNumber: ownRouting, LocallyGeneratedKey: otcGenerateUUID()},
-			MessageType:    "ROLLBACK_TX",
-			Message:        otcIbCommitMessage{TransactionID: txID},
-		})
-		return "NO", fmt.Errorf("COMMIT_TX: %w", err)
-	}
-	defer func() { _ = commitResp.Body.Close() }()
-
-	if commitResp.StatusCode != http.StatusNoContent {
-		_, _ = otcSendInterbankRequest(ctx, bankURL, bank.APIKey, otcIbEnvelope{
-			IdempotenceKey: otcIbIdempotenceKey{RoutingNumber: ownRouting, LocallyGeneratedKey: otcGenerateUUID()},
-			MessageType:    "ROLLBACK_TX",
-			Message:        otcIbCommitMessage{TransactionID: txID},
-		})
-		return "NO", fmt.Errorf("COMMIT_TX status %d", commitResp.StatusCode)
-	}
-	return "YES", nil
-}
-
 // acceptCrossBank handles AcceptNegotiation when the seller_type is 'INTERBANK'.
+// Banka 4 is the seller: we commit ACCEPTED, then call their /accept endpoint.
+// Banka 4 synchronously sends us a NEW_TX→COMMIT_TX (our /interbank) which creates
+// the contract and debits the buyer via CommitOtcInterbank.
 func (s *OtcServer) acceptCrossBank(
 	ctx context.Context,
 	req *pb.AcceptNegotiationRequest,
@@ -494,117 +505,193 @@ func (s *OtcServer) acceptCrossBank(
 ) (*pb.NegotiationResponse, error) {
 	var sellerRoutingNum int32
 	var partnerNegotiationID int64
-	var sellerExtID string
 	if err := s.DB.QueryRowContext(ctx,
-		`SELECT COALESCE(seller_routing_number, 0), COALESCE(partner_negotiation_id, 0),
-		        COALESCE(seller_external_id, '')
+		`SELECT COALESCE(seller_routing_number, 0), COALESCE(partner_negotiation_id, 0)
 		 FROM otc_negotiations WHERE id = $1`, negotiationID,
-	).Scan(&sellerRoutingNum, &partnerNegotiationID, &sellerExtID); err != nil || sellerRoutingNum == 0 {
+	).Scan(&sellerRoutingNum, &partnerNegotiationID); err != nil || sellerRoutingNum == 0 {
 		return nil, status.Error(codes.Internal, "cross-bank accept: missing seller routing info")
 	}
-
 	bank, err := otcInterbank.ResolveBankByRoutingNumber(fmt.Sprintf("%d", sellerRoutingNum))
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "cannot resolve seller bank: %v", err)
 	}
 
-	// Call partner bank's accept endpoint.
-	// Partner identifies the negotiation by creator_routing_number + creator_external_id,
-	// which was set to OWN_ROUTING_NUMBER + buyerID when we forwarded the negotiation.
-	acceptURL := fmt.Sprintf("%s/otc/interbank/negotiations/%s/%d/accept",
-		bank.BankURL, os.Getenv("OWN_ROUTING_NUMBER"), buyerID)
-	acceptReq, _ := http.NewRequestWithContext(ctx, http.MethodGet, acceptURL, nil)
-	acceptReq.Header.Set("X-Api-Key", bank.APIKey)
-	acceptResp, acceptErr := (&http.Client{Timeout: 10 * time.Second}).Do(acceptReq)
-	if acceptErr != nil {
-		return nil, status.Errorf(codes.Unavailable, "partner accept call failed: %v", acceptErr)
-	}
-	_ = acceptResp.Body.Close()
-	if acceptResp.StatusCode != http.StatusNoContent && acceptResp.StatusCode != http.StatusOK {
-		return nil, status.Errorf(codes.FailedPrecondition, "partner accept returned %d", acceptResp.StatusCode)
-	}
-
-	// If premium > 0: debit buyer locally, then 2PC to partner for PERSON credit + OPTION reserve.
-	if premium > 0 {
-		currencyID, ok := currencyIDMap[currency]
-		if !ok {
-			return nil, status.Errorf(codes.InvalidArgument, "unsupported currency: %s", currency)
-		}
-		buyerAccountID := req.BuyerAccountId
-		if buyerAccountID == 0 {
-			buyerAccountID, err = findAccount(s.AccountDB, portfolioUserID(buyerID, buyerType), currencyID)
-			if err != nil {
-				return nil, status.Errorf(codes.Internal, "failed to find buyer account: %v", err)
-			}
-		}
-		buyerCurrencyID, err := getAccountCurrencyID(s.AccountDB, buyerAccountID)
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "failed to read buyer account currency: %v", err)
-		}
-		premiumToPay, err := convertAmount(s.ExchangeDB, premium, currencyID, buyerCurrencyID)
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "currency conversion failed: %v", err)
-		}
-		var buyerBalance float64
-		if err = s.AccountDB.QueryRowContext(ctx,
-			`SELECT available_balance FROM accounts WHERE id = $1`, buyerAccountID,
-		).Scan(&buyerBalance); err != nil || buyerBalance < premiumToPay {
-			return nil, status.Error(codes.InvalidArgument, "Insufficient funds for premium")
-		}
-		var buyerAccountNum string
-		if err = s.AccountDB.QueryRowContext(ctx,
-			`SELECT account_number FROM accounts WHERE id = $1`, buyerAccountID,
-		).Scan(&buyerAccountNum); err != nil {
-			return nil, status.Errorf(codes.Internal, "failed to load buyer account: %v", err)
-		}
-
-		if _, err = s.AccountDB.ExecContext(ctx,
-			`UPDATE accounts SET balance = balance - $1, available_balance = available_balance - $1 WHERE id = $2`,
-			premiumToPay, buyerAccountID,
-		); err != nil {
-			return nil, status.Errorf(codes.Internal, "failed to debit buyer premium: %v", err)
-		}
-
-		voteResult, commitErr := executeOtcAccept2PC(ctx, bank, otcOutgoing2PCReq{
-			sellerExtID:          sellerExtID,
-			partnerNegotiationID: partnerNegotiationID,
-			stockAmount:          amount,
-			buyerAccountNum:      buyerAccountNum,
-			totalCost:            premium,
-			currency:             currency,
-		})
-		if commitErr != nil || voteResult != "YES" {
-			retryExec(s.AccountDB,
-				`UPDATE accounts SET balance = balance + $1, available_balance = available_balance + $1 WHERE id = $2`,
-				premiumToPay, buyerAccountID)
-			return nil, status.Errorf(codes.FailedPrecondition,
-				"partner rejected accept 2PC (vote=%s err=%v)", voteResult, commitErr)
-		}
-	}
-
+	// Commit ACCEPTED status BEFORE calling Banka 4 so the row lock is released.
+	// PrepareOtcInterbank (triggered by Banka 4's synchronous 2PC) must read ACCEPTED.
 	now := time.Now()
-	settlDate, _ := time.Parse("2006-01-02", settlementDate)
-	var contractID int64
-	if err = tx.QueryRowContext(ctx, `
-		INSERT INTO otc_contracts
-			(negotiation_id, seller_id, seller_type, buyer_id, buyer_type,
-			 ticker, amount, strike_price, premium, currency, settlement_date)
-		VALUES ($1, $2, 'INTERBANK', $3, $4, $5, $6, $7, $8, $9, $10)
-		RETURNING id`,
-		negotiationID, sellerID, buyerID, buyerType,
-		ticker, amount, strikePrice, premium, currency, settlDate,
-	).Scan(&contractID); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to create contract: %v", err)
-	}
-
 	if _, err = tx.ExecContext(ctx,
-		`UPDATE otc_negotiations SET status='ACCEPTED', last_modified=$1 WHERE id=$2`,
-		now, negotiationID,
+		`UPDATE otc_negotiations SET status='ACCEPTED', last_modified=$1 WHERE id=$2`, now, negotiationID,
 	); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to update negotiation: %v", err)
+		return nil, status.Errorf(codes.Internal, "failed to accept negotiation: %v", err)
 	}
 	if err = tx.Commit(); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to commit: %v", err)
 	}
+
+	// Call Banka 4's accept endpoint. Banka 4 will synchronously send us a NEW_TX→COMMIT_TX
+	// via /interbank, which creates the contract and debits buyer in CommitOtcInterbank.
+	acceptURL := fmt.Sprintf("%s/negotiations/%d/%d/accept",
+		bank.BankURL, sellerRoutingNum, partnerNegotiationID)
+	acceptReq, _ := http.NewRequestWithContext(ctx, http.MethodGet, acceptURL, nil)
+	acceptReq.Header.Set("X-Api-Key", bank.APIKey)
+	acceptResp, acceptErr := (&http.Client{Timeout: 30 * time.Second}).Do(acceptReq)
+	if acceptErr != nil {
+		_, _ = s.DB.ExecContext(context.Background(),
+			`UPDATE otc_negotiations SET status='PENDING_BUYER' WHERE id=$1`, negotiationID)
+		return nil, status.Errorf(codes.Unavailable, "partner accept call failed: %v", acceptErr)
+	}
+	_ = acceptResp.Body.Close()
+	if acceptResp.StatusCode != http.StatusNoContent && acceptResp.StatusCode != http.StatusOK {
+		_, _ = s.DB.ExecContext(context.Background(),
+			`UPDATE otc_negotiations SET status='PENDING_BUYER' WHERE id=$1`, negotiationID)
+		return nil, status.Errorf(codes.FailedPrecondition, "partner accept returned %d", acceptResp.StatusCode)
+	}
+	// Contract and buyer debit created by CommitOtcInterbank during synchronous 2PC above.
 	return s.fetchNegotiationByID(ctx, negotiationID)
+}
+
+// executeInterbankAcceptOutgoing is called by InterbankAcceptNegotiation (seller-side) after
+// the negotiation row is committed to ACCEPTED. It sends a 4-posting accept 2PC to the buyer's
+// bank, reserves seller shares, and inserts the seller-side contract.
+func (s *OtcServer) executeInterbankAcceptOutgoing(ctx context.Context, localNegID int64) error {
+	var buyerAcctNum, buyerExtID, currency, ticker, sellerType string
+	var buyerRoutingNum int32
+	var sellerID int64
+	var premium float64
+	var amount int32
+	err := s.DB.QueryRowContext(ctx, `
+		SELECT buyer_account_number, buyer_routing_number, buyer_external_id,
+		       seller_id, seller_type, premium, currency, amount, ticker
+		FROM otc_negotiations WHERE id = $1`, localNegID,
+	).Scan(&buyerAcctNum, &buyerRoutingNum, &buyerExtID,
+		&sellerID, &sellerType, &premium, &currency, &amount, &ticker)
+	if err != nil {
+		return fmt.Errorf("load negotiation: %w", err)
+	}
+
+	bank, err := otcInterbank.ResolveBankByRoutingNumber(fmt.Sprintf("%d", buyerRoutingNum))
+	if err != nil {
+		return fmt.Errorf("resolve buyer bank: %w", err)
+	}
+
+	bankURL := bank.BankURL + "/interbank"
+	ownRouting := otcOwnRoutingInt()
+	txID := otcIbTransactionID{RoutingNumber: ownRouting, ID: otcGenerateUUID()}
+	idemKey := otcIbIdempotenceKey{RoutingNumber: ownRouting, LocallyGeneratedKey: otcGenerateUUID()}
+
+	envelope := otcIbEnvelope{
+		IdempotenceKey: idemKey,
+		MessageType:    "NEW_TX",
+		Message: otcIbNewTxMessage{
+			TransactionID:  txID,
+			Message:        "Peer OTC option premium and contract acceptance",
+			PaymentCode:    "289",
+			PaymentPurpose: "OTC option premium",
+			Postings: []ibOutPosting{
+				{ // buyer's account debited (premium)
+					Account: ibOutAccount{Type: "ACCOUNT", Num: buyerAcctNum},
+					Amount:  -premium,
+					Asset:   ibOutAsset{Type: "MONAS", Asset: &ibOutAssetInner{Currency: currency}},
+				},
+				{ // seller (us) receives premium
+					Account: ibOutAccount{Type: "PERSON", ID: &ibOutPartyID{RoutingNumber: ownRouting, ID: fmt.Sprintf("%d", sellerID)}},
+					Amount:  premium,
+					Asset:   ibOutAsset{Type: "MONAS", Asset: &ibOutAssetInner{Currency: currency}},
+				},
+				{ // seller gives option right
+					Account: ibOutAccount{Type: "PERSON", ID: &ibOutPartyID{RoutingNumber: ownRouting, ID: fmt.Sprintf("%d", sellerID)}},
+					Amount:  -1,
+					Asset:   ibOutAsset{Type: "OPTION", Asset: &ibOutAssetInner{NegotiationID: &ibOutPartyID{RoutingNumber: ownRouting, ID: fmt.Sprintf("%d", localNegID)}}},
+				},
+				{ // buyer receives option right
+					Account: ibOutAccount{Type: "PERSON", ID: &ibOutPartyID{RoutingNumber: int(buyerRoutingNum), ID: buyerExtID}},
+					Amount:  1,
+					Asset:   ibOutAsset{Type: "OPTION", Asset: &ibOutAssetInner{NegotiationID: &ibOutPartyID{RoutingNumber: ownRouting, ID: fmt.Sprintf("%d", localNegID)}}},
+				},
+			},
+		},
+	}
+
+	resp, err := otcSendInterbankRequest(ctx, bankURL, bank.APIKey, envelope)
+	if err != nil {
+		return fmt.Errorf("NEW_TX: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var vote otcIbVoteResponse
+	if jsonErr := json.NewDecoder(resp.Body).Decode(&vote); jsonErr != nil || vote.Vote != "YES" {
+		_, _ = otcSendInterbankRequest(ctx, bankURL, bank.APIKey, otcIbEnvelope{
+			IdempotenceKey: otcIbIdempotenceKey{RoutingNumber: ownRouting, LocallyGeneratedKey: otcGenerateUUID()},
+			MessageType:    "ROLLBACK_TX",
+			Message:        otcIbCommitMessage{TransactionID: txID},
+		})
+		return fmt.Errorf("buyer bank voted NO or decode error")
+	}
+
+	// YES: reserve seller shares and create seller-side contract.
+	listingID, err := listingIDForTicker(s.SecuritiesDB, ticker)
+	if err != nil {
+		_, _ = otcSendInterbankRequest(ctx, bankURL, bank.APIKey, otcIbEnvelope{
+			IdempotenceKey: otcIbIdempotenceKey{RoutingNumber: ownRouting, LocallyGeneratedKey: otcGenerateUUID()},
+			MessageType:    "ROLLBACK_TX",
+			Message:        otcIbCommitMessage{TransactionID: txID},
+		})
+		return fmt.Errorf("ticker not found: %w", err)
+	}
+	result, err := s.PortfolioDB.ExecContext(ctx,
+		`UPDATE portfolio_entry SET reserved_amount = reserved_amount + $1
+		 WHERE user_id = $2 AND user_type = $3 AND listing_id = $4
+		   AND (amount - reserved_amount) >= $1`,
+		amount, portfolioUserID(sellerID, sellerType), sellerType, listingID,
+	)
+	if err != nil {
+		_, _ = otcSendInterbankRequest(ctx, bankURL, bank.APIKey, otcIbEnvelope{
+			IdempotenceKey: otcIbIdempotenceKey{RoutingNumber: ownRouting, LocallyGeneratedKey: otcGenerateUUID()},
+			MessageType:    "ROLLBACK_TX",
+			Message:        otcIbCommitMessage{TransactionID: txID},
+		})
+		return fmt.Errorf("reserve shares: %w", err)
+	}
+	if rows, _ := result.RowsAffected(); rows == 0 {
+		_, _ = otcSendInterbankRequest(ctx, bankURL, bank.APIKey, otcIbEnvelope{
+			IdempotenceKey: otcIbIdempotenceKey{RoutingNumber: ownRouting, LocallyGeneratedKey: otcGenerateUUID()},
+			MessageType:    "ROLLBACK_TX",
+			Message:        otcIbCommitMessage{TransactionID: txID},
+		})
+		return fmt.Errorf("seller has insufficient free shares")
+	}
+
+	var settlementDate, strikeStr string
+	_ = s.DB.QueryRowContext(ctx, `SELECT settlement_date::text, price_per_stock::text FROM otc_negotiations WHERE id = $1`, localNegID).Scan(&settlementDate, &strikeStr)
+	var strikePrice float64
+	_, _ = fmt.Sscanf(strikeStr, "%f", &strikePrice)
+
+	_, _ = s.DB.ExecContext(ctx, `
+		INSERT INTO otc_contracts
+			(negotiation_id, seller_id, seller_type, buyer_id, buyer_type,
+			 ticker, amount, strike_price, premium, currency, settlement_date)
+		VALUES ($1, $2, $3, 0, 'INTERBANK', $4, $5, $6, $7, $8, $9)
+		ON CONFLICT (negotiation_id) DO NOTHING`,
+		localNegID, sellerID, sellerType,
+		ticker, amount, strikePrice, premium, currency, settlementDate,
+	)
+
+	// COMMIT.
+	_, _ = otcSendInterbankRequest(ctx, bankURL, bank.APIKey, otcIbEnvelope{
+		IdempotenceKey: otcIbIdempotenceKey{RoutingNumber: ownRouting, LocallyGeneratedKey: otcGenerateUUID()},
+		MessageType:    "COMMIT_TX",
+		Message:        otcIbCommitMessage{TransactionID: txID},
+	})
+
+	// Credit seller's account locally — the 2PC posting notifies Banka 4 but does not
+	// touch our account DB. We credit after COMMIT so the buyer's debit is already settled.
+	if currID, ok := currencyIDMap[currency]; ok && premium > 0 {
+		if sellerAcctID, findErr := findAccount(s.AccountDB, portfolioUserID(sellerID, sellerType), currID); findErr == nil {
+			_, _ = s.AccountDB.ExecContext(ctx,
+				`UPDATE accounts SET balance = balance + $1, available_balance = available_balance + $1 WHERE id = $2`,
+				premium, sellerAcctID)
+		}
+	}
+
+	return nil
 }

--- a/services/otc-service/handlers/interbank_outgoing_test.go
+++ b/services/otc-service/handlers/interbank_outgoing_test.go
@@ -502,7 +502,6 @@ func TestAcceptNegotiation_CrossBank_PartnerAcceptFails(t *testing.T) {
 	assert.Contains(t, err.Error(), "partner accept returned 403")
 }
 
-
 // ─── executeOtcOutgoing2PC: OPTION amount sign check ──────────────────────
 
 func TestOtcExercise2PC_OptionAmountIsNegative(t *testing.T) {

--- a/services/otc-service/handlers/interbank_outgoing_test.go
+++ b/services/otc-service/handlers/interbank_outgoing_test.go
@@ -50,32 +50,6 @@ func mockPartnerForwardServer(t *testing.T) *httptest.Server {
 	}))
 }
 
-// mock2PCServer returns an HTTP server handling NEW_TX (vote YES) and COMMIT_TX (204).
-func mock2PCServer(t *testing.T, voteYes bool) *httptest.Server {
-	t.Helper()
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var env struct {
-			MessageType string `json:"messageType"`
-		}
-		_ = json.NewDecoder(r.Body).Decode(&env)
-		switch env.MessageType {
-		case "NEW_TX":
-			vote := "YES"
-			if !voteYes {
-				vote = "NO"
-			}
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]string{"vote": vote})
-		case "COMMIT_TX":
-			w.WriteHeader(http.StatusNoContent)
-		case "ROLLBACK_TX":
-			w.WriteHeader(http.StatusNoContent)
-		default:
-			w.WriteHeader(http.StatusBadRequest)
-		}
-	}))
-}
-
 // addFetchNegotiationRowsCrossBank sets up mock rows for fetchNegotiationByID
 // where seller_type = "INTERBANK" and seller_id = 0 (no seller name lookup).
 func addFetchNegotiationRowsCrossBank(mainMock, clientMock sqlmock.Sqlmock, id, buyerID int64, buyerType string) {

--- a/services/otc-service/handlers/interbank_outgoing_test.go
+++ b/services/otc-service/handlers/interbank_outgoing_test.go
@@ -33,11 +33,11 @@ func setupPartnerEnv(t *testing.T, partnerURL string) {
 }
 
 // mockPartnerForwardServer returns a test HTTP server that accepts
-// POST /otc/interbank/negotiations and returns {"routingNumber":999,"id":"42"}.
+// POST /negotiations and returns {"routingNumber":999,"id":"42"}.
 func mockPartnerForwardServer(t *testing.T) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost || r.URL.Path != "/otc/interbank/negotiations" {
+		if r.Method != http.MethodPost || r.URL.Path != "/negotiations" {
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
@@ -124,7 +124,7 @@ func TestForwardNegotiationToPartner_Happy(t *testing.T) {
 		SellerType: "CLIENT",
 	}
 
-	partnerID, err := s.forwardNegotiationToPartner(bank, req)
+	partnerID, err := s.forwardNegotiationToPartner(bank, req, "")
 	require.NoError(t, err)
 	assert.Equal(t, int64(42), partnerID)
 }
@@ -143,7 +143,7 @@ func TestForwardNegotiationToPartner_BadStatus(t *testing.T) {
 		Ticker: "AAPL", Amount: 10, PricePerStock: 100.0,
 		SettlementDate: "2027-01-01", Currency: "RSD",
 		BuyerId: 20, BuyerType: "CLIENT",
-	})
+	}, "")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "500")
 }
@@ -162,7 +162,7 @@ func TestForwardNegotiationToPartner_BadJSON(t *testing.T) {
 	_, err := s.forwardNegotiationToPartner(bank, &pb.CreateNegotiationRequest{
 		Ticker: "AAPL", Amount: 10, PricePerStock: 100.0,
 		SettlementDate: "2027-01-01", Currency: "RSD",
-	})
+	}, "")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "decode")
 }
@@ -184,7 +184,7 @@ func TestForwardNegotiationToPartner_NonNumericID(t *testing.T) {
 	_, err := s.forwardNegotiationToPartner(bank, &pb.CreateNegotiationRequest{
 		Ticker: "AAPL", Amount: 10, PricePerStock: 100.0,
 		SettlementDate: "2027-01-01", Currency: "RSD",
-	})
+	}, "")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "parse")
 }
@@ -374,7 +374,7 @@ func acceptNegRowCrossBank(buyerID int64, buyerType, state string, premium float
 }
 
 func TestAcceptNegotiation_CrossBank_NoPremium_Happy(t *testing.T) {
-	// Partner accept server: accepts GET /otc/interbank/negotiations/888/20/accept
+	// Partner accept server: accepts any GET request (new URL: /negotiations/999/42/accept)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet {
 			w.WriteHeader(http.StatusNoContent)
@@ -392,20 +392,17 @@ func TestAcceptNegotiation_CrossBank_NoPremium_Happy(t *testing.T) {
 	mainMock.ExpectQuery("SELECT seller_id, seller_type, buyer_id, buyer_type, status").
 		WillReturnRows(acceptNegRowCrossBank(20, "CLIENT", "PENDING_BUYER", 0.0))
 
-	// --- acceptCrossBank: routing info query ---
+	// --- acceptCrossBank: routing info (2 cols now — no seller_external_id) ---
 	mainMock.ExpectQuery("SELECT COALESCE.*seller_routing_number").
-		WillReturnRows(sqlmock.NewRows([]string{"seller_routing_number", "partner_negotiation_id", "seller_external_id"}).
-			AddRow(int32(999), int64(42), "ext-seller-1"))
+		WillReturnRows(sqlmock.NewRows([]string{"seller_routing_number", "partner_negotiation_id"}).
+			AddRow(int32(999), int64(42)))
 
-	// no premium → skip buyer balance / debit / 2PC
-
-	// --- INSERT contract (on tx) ---
-	mainMock.ExpectQuery("INSERT INTO otc_contracts").
-		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(1)))
-	// --- UPDATE negotiation (on tx) ---
+	// --- Commit ACCEPTED status BEFORE calling partner ---
 	mainMock.ExpectExec("UPDATE otc_negotiations SET status='ACCEPTED'").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mainMock.ExpectCommit()
+
+	// --- HTTP GET /negotiations/999/42/accept → 204 (handled by server above) ---
 
 	// --- fetchNegotiationByID ---
 	addFetchNegotiationRowsCrossBank(mainMock, clientMock, 5, 20, "CLIENT")
@@ -419,58 +416,28 @@ func TestAcceptNegotiation_CrossBank_NoPremium_Happy(t *testing.T) {
 }
 
 func TestAcceptNegotiation_CrossBank_WithPremium_Happy(t *testing.T) {
-	// Full combo server: handles partner accept (GET) AND 2PC (POST /interbank)
+	// Premium is now paid via Banka 4's inbound 2PC (CommitOtcInterbank), not here.
+	// acceptCrossBank flow is identical to NoPremium: commit ACCEPTED, call partner accept.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet {
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}
-		// 2PC /interbank requests
-		var env struct {
-			MessageType string `json:"messageType"`
-		}
-		_ = json.NewDecoder(r.Body).Decode(&env)
-		switch env.MessageType {
-		case "NEW_TX":
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]string{"vote": "YES"})
-		case "COMMIT_TX":
-			w.WriteHeader(http.StatusNoContent)
-		default:
-			w.WriteHeader(http.StatusNoContent)
-		}
+		w.WriteHeader(http.StatusNotFound)
 	}))
 	defer srv.Close()
 	setupPartnerEnv(t, srv.URL)
 
-	s, mainMock, _, clientMock, accMock, _, _ := newTestServer(t)
+	s, mainMock, _, clientMock, _, _, _ := newTestServer(t)
 
 	mainMock.ExpectBegin()
 	mainMock.ExpectQuery("SELECT seller_id, seller_type, buyer_id, buyer_type, status").
 		WillReturnRows(acceptNegRowCrossBank(20, "CLIENT", "PENDING_BUYER", 10.0)) // premium=10
 
-	// routing info
 	mainMock.ExpectQuery("SELECT COALESCE.*seller_routing_number").
-		WillReturnRows(sqlmock.NewRows([]string{"seller_routing_number", "partner_negotiation_id", "seller_external_id"}).
-			AddRow(int32(999), int64(42), "ext-seller-1"))
+		WillReturnRows(sqlmock.NewRows([]string{"seller_routing_number", "partner_negotiation_id"}).
+			AddRow(int32(999), int64(42)))
 
-	// buyer balance check (BuyerAccountId=5 → skip findAccount)
-	accMock.ExpectQuery("SELECT currency_id FROM accounts WHERE id").
-		WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(1)))
-	accMock.ExpectQuery("SELECT available_balance").
-		WillReturnRows(sqlmock.NewRows([]string{"available_balance"}).AddRow(float64(100.0)))
-	// buyer account number lookup
-	accMock.ExpectQuery("SELECT account_number FROM accounts WHERE id").
-		WillReturnRows(sqlmock.NewRows([]string{"account_number"}).AddRow("ACC-020"))
-	// debit buyer premium
-	accMock.ExpectExec("UPDATE accounts SET balance = balance - .*available_balance = available_balance -").
-		WillReturnResult(sqlmock.NewResult(1, 1))
-
-	// 2PC: NEW_TX → YES, COMMIT_TX → 204 (handled by HTTP server above)
-
-	// INSERT contract
-	mainMock.ExpectQuery("INSERT INTO otc_contracts").
-		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(1)))
 	mainMock.ExpectExec("UPDATE otc_negotiations SET status='ACCEPTED'").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mainMock.ExpectCommit()
@@ -478,12 +445,11 @@ func TestAcceptNegotiation_CrossBank_WithPremium_Happy(t *testing.T) {
 	addFetchNegotiationRowsCrossBank(mainMock, clientMock, 5, 20, "CLIENT")
 
 	resp, err := s.AcceptNegotiation(context.Background(), &pb.AcceptNegotiationRequest{
-		NegotiationId: 5, CallerId: 20, CallerType: "CLIENT", BuyerAccountId: 5,
+		NegotiationId: 5, CallerId: 20, CallerType: "CLIENT",
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "ACCEPTED", resp.Status)
 	assert.NoError(t, mainMock.ExpectationsWereMet())
-	assert.NoError(t, accMock.ExpectationsWereMet())
 }
 
 func TestAcceptNegotiation_CrossBank_MissingRoutingInfo(t *testing.T) {
@@ -496,8 +462,8 @@ func TestAcceptNegotiation_CrossBank_MissingRoutingInfo(t *testing.T) {
 		WillReturnRows(acceptNegRowCrossBank(20, "CLIENT", "PENDING_BUYER", 0.0))
 	// routing info query: seller_routing_number = 0 → error path
 	mainMock.ExpectQuery("SELECT COALESCE.*seller_routing_number").
-		WillReturnRows(sqlmock.NewRows([]string{"seller_routing_number", "partner_negotiation_id", "seller_external_id"}).
-			AddRow(int32(0), int64(0), ""))
+		WillReturnRows(sqlmock.NewRows([]string{"seller_routing_number", "partner_negotiation_id"}).
+			AddRow(int32(0), int64(0)))
 	mainMock.ExpectRollback()
 
 	_, err := s.AcceptNegotiation(context.Background(), &pb.AcceptNegotiationRequest{
@@ -520,9 +486,14 @@ func TestAcceptNegotiation_CrossBank_PartnerAcceptFails(t *testing.T) {
 	mainMock.ExpectQuery("SELECT seller_id, seller_type, buyer_id, buyer_type, status").
 		WillReturnRows(acceptNegRowCrossBank(20, "CLIENT", "PENDING_BUYER", 0.0))
 	mainMock.ExpectQuery("SELECT COALESCE.*seller_routing_number").
-		WillReturnRows(sqlmock.NewRows([]string{"seller_routing_number", "partner_negotiation_id", "seller_external_id"}).
-			AddRow(int32(999), int64(42), "ext-seller-1"))
-	mainMock.ExpectRollback()
+		WillReturnRows(sqlmock.NewRows([]string{"seller_routing_number", "partner_negotiation_id"}).
+			AddRow(int32(999), int64(42)))
+	// New flow: commit ACCEPTED first, then call partner; on failure revert to PENDING_BUYER
+	mainMock.ExpectExec("UPDATE otc_negotiations SET status='ACCEPTED'").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mainMock.ExpectCommit()
+	mainMock.ExpectExec("UPDATE otc_negotiations SET status='PENDING_BUYER'").
+		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	_, err := s.AcceptNegotiation(context.Background(), &pb.AcceptNegotiationRequest{
 		NegotiationId: 5, CallerId: 20, CallerType: "CLIENT",
@@ -531,205 +502,8 @@ func TestAcceptNegotiation_CrossBank_PartnerAcceptFails(t *testing.T) {
 	assert.Contains(t, err.Error(), "partner accept returned 403")
 }
 
-func TestAcceptNegotiation_CrossBank_InsufficientFunds(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNoContent) // partner accept OK
-	}))
-	defer srv.Close()
-	setupPartnerEnv(t, srv.URL)
-
-	s, mainMock, _, _, accMock, _, _ := newTestServer(t)
-
-	mainMock.ExpectBegin()
-	mainMock.ExpectQuery("SELECT seller_id, seller_type, buyer_id, buyer_type, status").
-		WillReturnRows(acceptNegRowCrossBank(20, "CLIENT", "PENDING_BUYER", 50.0)) // premium=50
-	mainMock.ExpectQuery("SELECT COALESCE.*seller_routing_number").
-		WillReturnRows(sqlmock.NewRows([]string{"seller_routing_number", "partner_negotiation_id", "seller_external_id"}).
-			AddRow(int32(999), int64(42), "ext-seller-1"))
-	// BuyerAccountId=5 → no findAccount query; balance check: 10 < 50 → insufficient
-	accMock.ExpectQuery("SELECT currency_id FROM accounts WHERE id").
-		WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(1)))
-	accMock.ExpectQuery("SELECT available_balance").
-		WillReturnRows(sqlmock.NewRows([]string{"available_balance"}).AddRow(float64(10.0)))
-	mainMock.ExpectRollback()
-
-	_, err := s.AcceptNegotiation(context.Background(), &pb.AcceptNegotiationRequest{
-		NegotiationId: 5, CallerId: 20, CallerType: "CLIENT", BuyerAccountId: 5,
-	})
-	assert.Equal(t, codes.InvalidArgument, status.Code(err))
-	assert.Contains(t, err.Error(), "Insufficient funds")
-}
-
-func TestAcceptNegotiation_CrossBank_2PCVoteNo(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodGet {
-			w.WriteHeader(http.StatusNoContent)
-			return
-		}
-		var env struct {
-			MessageType string `json:"messageType"`
-		}
-		_ = json.NewDecoder(r.Body).Decode(&env)
-		if env.MessageType == "NEW_TX" {
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]string{"vote": "NO"})
-		} else {
-			w.WriteHeader(http.StatusNoContent)
-		}
-	}))
-	defer srv.Close()
-	setupPartnerEnv(t, srv.URL)
-
-	s, mainMock, _, _, accMock, _, _ := newTestServer(t)
-
-	mainMock.ExpectBegin()
-	mainMock.ExpectQuery("SELECT seller_id, seller_type, buyer_id, buyer_type, status").
-		WillReturnRows(acceptNegRowCrossBank(20, "CLIENT", "PENDING_BUYER", 10.0))
-	mainMock.ExpectQuery("SELECT COALESCE.*seller_routing_number").
-		WillReturnRows(sqlmock.NewRows([]string{"seller_routing_number", "partner_negotiation_id", "seller_external_id"}).
-			AddRow(int32(999), int64(42), "ext-seller-1"))
-	// BuyerAccountId=5 → no findAccount query
-	accMock.ExpectQuery("SELECT currency_id FROM accounts WHERE id").
-		WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(1)))
-	accMock.ExpectQuery("SELECT available_balance").
-		WillReturnRows(sqlmock.NewRows([]string{"available_balance"}).AddRow(float64(100.0)))
-	accMock.ExpectQuery("SELECT account_number").
-		WillReturnRows(sqlmock.NewRows([]string{"account_number"}).AddRow("ACC-020"))
-	accMock.ExpectExec("UPDATE accounts SET balance = balance -").
-		WillReturnResult(sqlmock.NewResult(1, 1))
-	// 2PC returns NO → compensation: refund buyer
-	accMock.ExpectExec("UPDATE accounts SET balance = balance \\+").
-		WillReturnResult(sqlmock.NewResult(1, 1))
-	mainMock.ExpectRollback()
-
-	_, err := s.AcceptNegotiation(context.Background(), &pb.AcceptNegotiationRequest{
-		NegotiationId: 5, CallerId: 20, CallerType: "CLIENT", BuyerAccountId: 5,
-	})
-	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
-	assert.Contains(t, err.Error(), "partner rejected accept 2PC")
-}
-
-// ─── executeOtcAccept2PC ───────────────────────────────────────────────────
-
-func TestExecuteOtcAccept2PC_Happy(t *testing.T) {
-	srv := mock2PCServer(t, true) // partner votes YES
-	defer srv.Close()
-	setupPartnerEnv(t, srv.URL)
-
-	bank, err := otcInterbank.ResolveBankByRoutingNumber("999")
-	require.NoError(t, err)
-
-	vote, err := executeOtcAccept2PC(context.Background(), bank, otcOutgoing2PCReq{
-		sellerExtID:          "ext-seller-1",
-		partnerNegotiationID: 42,
-		stockAmount:          100,
-		buyerAccountNum:      "ACC-020",
-		totalCost:            10.0,
-		currency:             "RSD",
-	})
-	require.NoError(t, err)
-	assert.Equal(t, "YES", vote)
-}
-
-func TestExecuteOtcAccept2PC_VoteNo(t *testing.T) {
-	srv := mock2PCServer(t, false) // partner votes NO
-	defer srv.Close()
-	setupPartnerEnv(t, srv.URL)
-
-	bank, _ := otcInterbank.ResolveBankByRoutingNumber("999")
-	vote, err := executeOtcAccept2PC(context.Background(), bank, otcOutgoing2PCReq{
-		sellerExtID:          "ext-seller-1",
-		partnerNegotiationID: 42,
-		stockAmount:          100,
-		buyerAccountNum:      "ACC-020",
-		totalCost:            10.0,
-		currency:             "RSD",
-	})
-	require.NoError(t, err)
-	assert.Equal(t, "NO", vote)
-}
-
-func TestExecuteOtcAccept2PC_CommitFailsThenRollback(t *testing.T) {
-	var newTxCalled bool
-	rollbackCalled := false
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var env struct {
-			MessageType string `json:"messageType"`
-		}
-		_ = json.NewDecoder(r.Body).Decode(&env)
-		switch env.MessageType {
-		case "NEW_TX":
-			newTxCalled = true
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]string{"vote": "YES"})
-		case "COMMIT_TX":
-			w.WriteHeader(http.StatusInternalServerError) // commit fails
-		case "ROLLBACK_TX":
-			rollbackCalled = true
-			w.WriteHeader(http.StatusNoContent)
-		}
-	}))
-	defer srv.Close()
-	setupPartnerEnv(t, srv.URL)
-
-	bank, _ := otcInterbank.ResolveBankByRoutingNumber("999")
-	vote, err := executeOtcAccept2PC(context.Background(), bank, otcOutgoing2PCReq{
-		sellerExtID: "ext-1", partnerNegotiationID: 1,
-		stockAmount: 10, buyerAccountNum: "ACC-1", totalCost: 5.0, currency: "RSD",
-	})
-	assert.Equal(t, "NO", vote)
-	assert.Error(t, err)
-	assert.True(t, newTxCalled, "NEW_TX should have been called")
-	assert.True(t, rollbackCalled, "ROLLBACK_TX should have been called on commit failure")
-}
 
 // ─── executeOtcOutgoing2PC: OPTION amount sign check ──────────────────────
-
-// Verify that accept 2PC sends OPTION with positive amount (reserve)
-// while exercise 2PC sends OPTION with negative amount (consume).
-func TestOtcAccept2PC_OptionAmountIsPositive(t *testing.T) {
-	var capturedPostings []map[string]interface{}
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var env struct {
-			MessageType string `json:"messageType"`
-			Message     struct {
-				Postings []map[string]interface{} `json:"postings"`
-			} `json:"message"`
-		}
-		_ = json.NewDecoder(r.Body).Decode(&env)
-		if env.MessageType == "NEW_TX" {
-			capturedPostings = env.Message.Postings
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]string{"vote": "YES"})
-		} else {
-			w.WriteHeader(http.StatusNoContent)
-		}
-	}))
-	defer srv.Close()
-	setupPartnerEnv(t, srv.URL)
-
-	bank, _ := otcInterbank.ResolveBankByRoutingNumber("999")
-	_, _ = executeOtcAccept2PC(context.Background(), bank, otcOutgoing2PCReq{
-		sellerExtID:          "ext-1",
-		partnerNegotiationID: 42,
-		stockAmount:          100,
-		buyerAccountNum:      "ACC-1",
-		totalCost:            10.0,
-		currency:             "RSD",
-	})
-
-	require.NotEmpty(t, capturedPostings, "postings should have been sent")
-	var optionPosting map[string]interface{}
-	for _, p := range capturedPostings {
-		if p["accountType"] == "OPTION" {
-			optionPosting = p
-			break
-		}
-	}
-	require.NotNil(t, optionPosting, "OPTION posting should exist")
-	amount, _ := optionPosting["amount"].(float64)
-	assert.Greater(t, amount, float64(0), "OPTION amount must be POSITIVE for accept (reserve)")
-}
 
 func TestOtcExercise2PC_OptionAmountIsNegative(t *testing.T) {
 	var capturedPostings []map[string]interface{}
@@ -756,23 +530,33 @@ func TestOtcExercise2PC_OptionAmountIsNegative(t *testing.T) {
 	_, _ = executeOtcOutgoing2PC(context.Background(), bank, otcOutgoing2PCReq{
 		sellerExtID:          "ext-1",
 		partnerNegotiationID: 42,
+		partnerRoutingNum:    999,
 		stockAmount:          100,
 		buyerAccountNum:      "ACC-1",
+		buyerExternalID:      "20",
 		totalCost:            150.0,
 		currency:             "RSD",
+		ticker:               "AAPL",
 	})
 
 	require.NotEmpty(t, capturedPostings)
-	var optionPosting map[string]interface{}
+	// Nested format: find the OPTION posting that transfers STOCK (negative amount = consume).
+	var foundNegativeOption bool
 	for _, p := range capturedPostings {
-		if p["accountType"] == "OPTION" {
-			optionPosting = p
+		acct, _ := p["account"].(map[string]interface{})
+		if acct == nil {
+			continue
+		}
+		if acct["type"] != "OPTION" {
+			continue
+		}
+		amount, _ := p["amount"].(float64)
+		if amount < 0 {
+			foundNegativeOption = true
 			break
 		}
 	}
-	require.NotNil(t, optionPosting)
-	amount, _ := optionPosting["amount"].(float64)
-	assert.Less(t, amount, float64(0), "OPTION amount must be NEGATIVE for exercise (consume)")
+	assert.True(t, foundNegativeOption, "exercise 2PC must contain an OPTION posting with negative amount (shares consumed)")
 }
 
 // ─── api-gateway: CreateNegotiation cross-bank fields ─────────────────────


### PR DESCRIPTION
- Rewrite interbank.go with nested posting format, OTC exercise/accept detection by account/asset type, skip payment service for OTC-only 2PCs, nested-to-flat conversion for non-OTC, graceful NotFound on commit
- Update otc_interbank.go: propagate buyer-account-number via gRPC metadata, add BuyerAccountNumber/LastModifiedBy to negotiation body
- Add alias routes at /negotiations/... (protocol standard) alongside existing /otc/interbank/negotiations/... paths in main.go
- Add buyer_account_number column to otc_negotiations schema
- Fix lookupInterbankNegotiation to look up by local id first (protocol path is {sellerRn}/{sellerLocalId}), fall back to creator-key lookup
- Fix InterbankAcceptNegotiation inline query to use local id
- Add buyer-side PrepareOtcInterbank accept branch (idem_routing==partner) and buyer-side CommitOtcInterbank ACCEPT path; add seller credit after COMMIT in CommitOtcInterbank EXERCISE; trigger executeInterbankAcceptOutgoing from InterbankAcceptNegotiation; store buyer_account_number via gRPC metadata
- Add nested posting types, executeInterbankAcceptOutgoing, fix forwardNegotiationToPartner path/fields, rewrite acceptCrossBank, rewrite executeOtcOutgoing2PC with 4-posting nested exercise format