### PR TITLE
feat(otc-service): implement SAGA orchestrator with fault injection a…

### DIFF
--- a/services/api-gateway/handlers/otc.go
+++ b/services/api-gateway/handlers/otc.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/RAF-SI-2025/EXBanka-4-Backend/services/api-gateway/middleware"
@@ -12,6 +13,7 @@ import (
 	pb_portfolio "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/portfolio"
 	"github.com/gin-gonic/gin"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
 
@@ -392,6 +394,21 @@ func ExerciseContract(client pb.OtcServiceClient) gin.HandlerFunc {
 		ctx, cancel := context.WithTimeout(c.Request.Context(), 30*time.Second)
 		defer cancel()
 
+		// Forward X-Saga-* fault-injection headers as gRPC metadata (test builds only).
+		if os.Getenv("OTC_SAGA_TEST_HOOKS") == "true" {
+			md := metadata.New(nil)
+			for _, h := range []string{
+				"X-Saga-Force-Fail", "X-Saga-Force-Fail-Kind",
+				"X-Saga-Compensate-Fail", "X-Saga-Compensate-Fail-Times",
+				"X-Saga-Inject-Delay",
+			} {
+				if v := c.GetHeader(h); v != "" {
+					md.Set(strings.ToLower(h), v)
+				}
+			}
+			ctx = metadata.NewOutgoingContext(ctx, md)
+		}
+
 		resp, err := client.ExerciseContract(ctx, &pb.ExerciseContractRequest{
 			ContractId:     contractID,
 			CallerId:       callerID,
@@ -405,6 +422,7 @@ func ExerciseContract(client pb.OtcServiceClient) gin.HandlerFunc {
 		c.JSON(http.StatusOK, gin.H{
 			"status":     resp.Status,
 			"executedAt": resp.ExecutedAt,
+			"sagaId":     resp.SagaId,
 		})
 	}
 }

--- a/services/otc-service/db/schema.sql
+++ b/services/otc-service/db/schema.sql
@@ -51,12 +51,25 @@ CREATE TABLE IF NOT EXISTS otc_contracts (
 
 CREATE TABLE IF NOT EXISTS otc_saga_log (
     id           BIGSERIAL PRIMARY KEY,
-    contract_id  BIGINT NOT NULL REFERENCES otc_contracts(id),
+    contract_id  BIGINT NOT NULL,
     step         INT NOT NULL,
     status       VARCHAR(20) NOT NULL,
     timestamp    TIMESTAMP NOT NULL DEFAULT NOW(),
     error_msg    TEXT
 );
+
+-- Globalni SAGA tracker: jedan red po toku, prati status (Running/Compensating/Completed/Compensated)
+CREATE TABLE IF NOT EXISTS otc_saga (
+    id           BIGSERIAL PRIMARY KEY,
+    contract_id  BIGINT NOT NULL UNIQUE,
+    status       VARCHAR(20) NOT NULL DEFAULT 'Running',
+    current_step INT NOT NULL DEFAULT 0,
+    created_at   TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at   TIMESTAMP NOT NULL DEFAULT NOW()
+);
+-- Migration za postojeće deploymente
+ALTER TABLE otc_saga ADD COLUMN IF NOT EXISTS current_step INT NOT NULL DEFAULT 0;
+ALTER TABLE otc_saga ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP NOT NULL DEFAULT NOW();
 
 -- Migration: partner_negotiation_id = lokalni ID pregovora na partner banci (za outgoing OPTION posting)
 ALTER TABLE otc_negotiations ADD COLUMN IF NOT EXISTS partner_negotiation_id BIGINT;

--- a/services/otc-service/handlers/grpc_server.go
+++ b/services/otc-service/handlers/grpc_server.go
@@ -26,6 +26,57 @@ func retryExec(db *sql.DB, query string, args ...interface{}) {
 	}
 }
 
+// sagaFaultHook checks X-Saga-* gRPC metadata and injects failures or delays.
+// Only active when OTC_SAGA_TEST_HOOKS=true. Returns non-nil error if the phase should fail.
+// compensateFailCounts tracks how many times each compensator has failed (for -Times: N).
+func sagaFaultHook(ctx context.Context, phase string, compensateFailCounts map[string]int) error {
+	if os.Getenv("OTC_SAGA_TEST_HOOKS") != "true" {
+		return nil
+	}
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return nil
+	}
+
+	// X-Saga-Inject-Delay: Fi:Nms
+	if vals := md.Get("x-saga-inject-delay"); len(vals) > 0 {
+		// format: "F3:5000"
+		var delayPhase string
+		var delayMs int
+		if n, _ := fmt.Sscanf(vals[0], "%5s:%d", &delayPhase, &delayMs); n == 2 && delayPhase == phase {
+			time.Sleep(time.Duration(delayMs) * time.Millisecond)
+		}
+	}
+
+	// X-Saga-Force-Fail: Fi  (fail kind defaults to "before", meaning fail without side effects)
+	if vals := md.Get("x-saga-force-fail"); len(vals) > 0 && vals[0] == phase {
+		kind := "before"
+		if kv := md.Get("x-saga-force-fail-kind"); len(kv) > 0 {
+			kind = kv[0]
+		}
+		// "before" = caller checks this before executing the step → return error immediately
+		// "after"  = caller checks this after executing the step → side effects already applied
+		_ = kind
+		return fmt.Errorf("fault injected for phase %s", phase)
+	}
+
+	// X-Saga-Compensate-Fail: Ci  +  X-Saga-Compensate-Fail-Times: N
+	if vals := md.Get("x-saga-compensate-fail"); len(vals) > 0 && vals[0] == phase {
+		maxFails := 1
+		if tv := md.Get("x-saga-compensate-fail-times"); len(tv) > 0 {
+			if n, err := strconv.Atoi(tv[0]); err == nil {
+				maxFails = n
+			}
+		}
+		if compensateFailCounts[phase] < maxFails {
+			compensateFailCounts[phase]++
+			return fmt.Errorf("compensate fault injected for %s (attempt %d)", phase, compensateFailCounts[phase])
+		}
+	}
+
+	return nil
+}
+
 func (s *OtcServer) insertOtcInterbankTx(ctx context.Context, req *pb.OtcInterbankPrepareRequest, negID int64, vote string) {
 	txType := "EXERCISE"
 	if req.IsAccept {
@@ -650,16 +701,17 @@ func (s *OtcServer) calcContractProfit(ticker string, strikePrice float64, amoun
 }
 
 func (s *OtcServer) ExerciseContract(ctx context.Context, req *pb.ExerciseContractRequest) (*pb.ExerciseContractResponse, error) {
-	// Idempotency: if this contract was already successfully exercised, return immediately.
-	var lastStep int
-	var lastStepStatus string
+	// Idempotency: if saga for this contract already completed, return immediately.
+	var existingSagaID int64
+	var existingSagaStatus string
 	if idErr := s.DB.QueryRowContext(ctx,
-		`SELECT step, status FROM otc_saga_log WHERE contract_id=$1 ORDER BY step DESC, id DESC LIMIT 1`,
+		`SELECT id, status FROM otc_saga WHERE contract_id=$1`,
 		req.ContractId,
-	).Scan(&lastStep, &lastStepStatus); idErr == nil && lastStep == 5 && lastStepStatus == "SUCCESS" {
+	).Scan(&existingSagaID, &existingSagaStatus); idErr == nil && existingSagaStatus == "Completed" {
 		return &pb.ExerciseContractResponse{
 			Status:     "EXERCISED",
 			ExecutedAt: time.Now().Format(time.RFC3339),
+			SagaId:     existingSagaID,
 		}, nil
 	}
 
@@ -703,6 +755,7 @@ func (s *OtcServer) ExerciseContract(ctx context.Context, req *pb.ExerciseContra
 	}
 
 	// Cross-bank exercise: seller is on partner bank — delegate to 2PC flow.
+	// (otc_saga row is NOT created for cross-bank; 2PC has its own tracking)
 	if sellerType == "INTERBANK" {
 		resp, rerr := s.exerciseCrossBank(ctx, req, tx, sellerID, buyerID, buyerType,
 			amount, strikePrice, currency, ticker, settlementDate)
@@ -742,9 +795,16 @@ func (s *OtcServer) ExerciseContract(ctx context.Context, req *pb.ExerciseContra
 		return nil, status.Errorf(codes.Internal, "currency conversion failed: %v", err)
 	}
 
-	// sagaLog writes a saga step record. It uses a fresh 5-second background context so
-	// it never blocks the calling goroutine (and therefore never prevents defer tx.Rollback()
-	// from running) even when the request context has already been cancelled.
+	// INSERT global saga tracker row (Running, step=0).
+	// sagaID stays 0 on failure (e.g. mock error in tests) — sagaStatus becomes a no-op.
+	var sagaID int64
+	_ = s.DB.QueryRowContext(ctx,
+		`INSERT INTO otc_saga (contract_id, status, current_step) VALUES ($1, 'Running', 0) RETURNING id`,
+		req.ContractId,
+	).Scan(&sagaID)
+
+	// sagaLog writes a per-step record. Uses a fresh background context so it survives
+	// a cancelled request context (e.g. during compensation after client disconnect).
 	sagaLog := func(step int, stepStatus, errMsg string) {
 		logCtx, logCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer logCancel()
@@ -754,10 +814,31 @@ func (s *OtcServer) ExerciseContract(ctx context.Context, req *pb.ExerciseContra
 		)
 	}
 
+	// sagaStatus updates the global saga tracker. No-op if sagaID is 0 (e.g. in unit tests).
+	sagaStatus := func(newStatus string, step int) {
+		if sagaID == 0 {
+			return
+		}
+		logCtx, logCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer logCancel()
+		_, _ = s.DB.ExecContext(logCtx,
+			`UPDATE otc_saga SET status=$1, current_step=$2, updated_at=NOW() WHERE id=$3`,
+			newStatus, step, sagaID,
+		)
+	}
+
+	// compensateFailCounts tracks X-Saga-Compensate-Fail-Times retries per compensator.
+	compensateFailCounts := make(map[string]int)
+
 	sellerPortfolioID := portfolioUserID(sellerID, sellerType)
 
-	// Step 1: Reserve buyer funds (deduct available_balance).
-	// Also checks balance >= totalCostToPay to ensure consistency between the two balance fields.
+	// ── Step 1: Reserve buyer funds ──────────────────────────────────────────────
+	if hookErr := sagaFaultHook(ctx, "F1", compensateFailCounts); hookErr != nil {
+		sagaLog(1, "FAILED", hookErr.Error())
+		sagaStatus("Compensating", 1)
+		sagaStatus("Compensated", 1)
+		return nil, status.Errorf(codes.Internal, "F1 fault injected: %v", hookErr)
+	}
 	result, err := s.AccountDB.ExecContext(ctx,
 		`UPDATE accounts SET available_balance = available_balance - $1
 		 WHERE id = $2 AND available_balance >= $1 AND balance >= $1`,
@@ -765,23 +846,42 @@ func (s *OtcServer) ExerciseContract(ctx context.Context, req *pb.ExerciseContra
 	)
 	if err != nil {
 		sagaLog(1, "FAILED", err.Error())
+		sagaStatus("Compensating", 1)
+		sagaStatus("Compensated", 1)
 		return nil, status.Errorf(codes.Internal, "step 1 failed: %v", err)
 	}
 	if rows, _ := result.RowsAffected(); rows == 0 {
 		sagaLog(1, "FAILED", fmt.Sprintf("insufficient funds: need %.2f", totalCostToPay))
+		sagaStatus("Compensating", 1)
+		sagaStatus("Compensated", 1)
 		return nil, status.Error(codes.InvalidArgument, "Insufficient funds")
 	}
 	sagaLog(1, "SUCCESS", "")
+	sagaStatus("Running", 1)
 
 	comp1 := func() {
-		retryExec(s.AccountDB,
-			`UPDATE accounts SET available_balance = available_balance + $1 WHERE id = $2`,
-			totalCostToPay, buyerAccountID)
-		sagaLog(1, "COMPENSATED", "")
+		for {
+			if hookErr := sagaFaultHook(ctx, "C1", compensateFailCounts); hookErr != nil {
+				sagaLog(1, "COMP_FAILED", hookErr.Error())
+				time.Sleep(200 * time.Millisecond)
+				continue
+			}
+			retryExec(s.AccountDB,
+				`UPDATE accounts SET available_balance = available_balance + $1 WHERE id = $2`,
+				totalCostToPay, buyerAccountID)
+			sagaLog(1, "COMPENSATED", "")
+			break
+		}
 	}
 
-	// Step 2: Reserve seller securities (actual write, not just read).
-	// Uses UPDATE with a conditional WHERE to atomically check-and-reserve free shares.
+	// ── Step 2: Reserve seller securities ────────────────────────────────────────
+	if hookErr := sagaFaultHook(ctx, "F2", compensateFailCounts); hookErr != nil {
+		sagaLog(2, "FAILED", hookErr.Error())
+		sagaStatus("Compensating", 2)
+		comp1()
+		sagaStatus("Compensated", 2)
+		return nil, status.Errorf(codes.Internal, "F2 fault injected: %v", hookErr)
+	}
 	result2, err := s.PortfolioDB.ExecContext(ctx, `
 		UPDATE portfolio_entry
 		SET reserved_amount = reserved_amount + $1
@@ -791,39 +891,64 @@ func (s *OtcServer) ExerciseContract(ctx context.Context, req *pb.ExerciseContra
 	)
 	if err != nil {
 		sagaLog(2, "FAILED", err.Error())
+		sagaStatus("Compensating", 2)
 		comp1()
+		sagaStatus("Compensated", 2)
 		return nil, status.Errorf(codes.Internal, "step 2 failed: %v", err)
 	}
 	if rows, _ := result2.RowsAffected(); rows == 0 {
 		sagaLog(2, "FAILED", "seller insufficient free holdings")
+		sagaStatus("Compensating", 2)
 		comp1()
+		sagaStatus("Compensated", 2)
 		return nil, status.Error(codes.InvalidArgument, "Seller does not have enough free shares")
 	}
 	sagaLog(2, "SUCCESS", "")
+	sagaStatus("Running", 2)
 
 	comp2 := func() {
-		retryExec(s.PortfolioDB,
-			`UPDATE portfolio_entry SET reserved_amount = GREATEST(0, reserved_amount - $1)
-			 WHERE user_id = $2 AND user_type = $3 AND listing_id = $4`,
-			amount, sellerPortfolioID, sellerType, listingID)
-		sagaLog(2, "COMPENSATED", "")
+		for {
+			if hookErr := sagaFaultHook(ctx, "C2", compensateFailCounts); hookErr != nil {
+				sagaLog(2, "COMP_FAILED", hookErr.Error())
+				time.Sleep(200 * time.Millisecond)
+				continue
+			}
+			retryExec(s.PortfolioDB,
+				`UPDATE portfolio_entry SET reserved_amount = GREATEST(0, reserved_amount - $1)
+				 WHERE user_id = $2 AND user_type = $3 AND listing_id = $4`,
+				amount, sellerPortfolioID, sellerType, listingID)
+			sagaLog(2, "COMPENSATED", "")
+			break
+		}
 	}
 
-	// Step 3: Transfer funds (debit buyer balance, credit seller balance).
+	// ── Step 3: Transfer funds ────────────────────────────────────────────────────
 	sellerAccountID, err := findAccount(s.AccountDB, portfolioUserID(sellerID, sellerType), currencyID)
 	if err != nil {
 		sagaLog(3, "FAILED", err.Error())
+		sagaStatus("Compensating", 3)
 		comp2()
 		comp1()
+		sagaStatus("Compensated", 3)
 		return nil, status.Errorf(codes.Internal, "step 3 failed finding seller account: %v", err)
+	}
+	if hookErr := sagaFaultHook(ctx, "F3", compensateFailCounts); hookErr != nil {
+		sagaLog(3, "FAILED", hookErr.Error())
+		sagaStatus("Compensating", 3)
+		comp2()
+		comp1()
+		sagaStatus("Compensated", 3)
+		return nil, status.Errorf(codes.Internal, "F3 fault injected: %v", hookErr)
 	}
 	if _, err = s.AccountDB.ExecContext(ctx,
 		`UPDATE accounts SET balance = balance - $1 WHERE id = $2`,
 		totalCostToPay, buyerAccountID,
 	); err != nil {
 		sagaLog(3, "FAILED", err.Error())
+		sagaStatus("Compensating", 3)
 		comp2()
 		comp1()
+		sagaStatus("Compensated", 3)
 		return nil, status.Errorf(codes.Internal, "step 3 failed debit buyer: %v", err)
 	}
 	if _, err = s.AccountDB.ExecContext(ctx,
@@ -832,20 +957,39 @@ func (s *OtcServer) ExerciseContract(ctx context.Context, req *pb.ExerciseContra
 	); err != nil {
 		retryExec(s.AccountDB, `UPDATE accounts SET balance = balance + $1 WHERE id = $2`, totalCostToPay, buyerAccountID)
 		sagaLog(3, "FAILED", err.Error())
+		sagaStatus("Compensating", 3)
 		comp2()
 		comp1()
+		sagaStatus("Compensated", 3)
 		return nil, status.Errorf(codes.Internal, "step 3 failed credit seller: %v", err)
 	}
 	sagaLog(3, "SUCCESS", "")
+	sagaStatus("Running", 3)
 
 	comp3 := func() {
-		retryExec(s.AccountDB, `UPDATE accounts SET balance = balance + $1 WHERE id = $2`, totalCostToPay, buyerAccountID)
-		retryExec(s.AccountDB, `UPDATE accounts SET balance = balance - $1, available_balance = available_balance - $1 WHERE id = $2`, totalCost, sellerAccountID)
-		sagaLog(3, "COMPENSATED", "")
+		for {
+			if hookErr := sagaFaultHook(ctx, "C3", compensateFailCounts); hookErr != nil {
+				sagaLog(3, "COMP_FAILED", hookErr.Error())
+				time.Sleep(200 * time.Millisecond)
+				continue
+			}
+			retryExec(s.AccountDB, `UPDATE accounts SET balance = balance + $1 WHERE id = $2`, totalCostToPay, buyerAccountID)
+			retryExec(s.AccountDB, `UPDATE accounts SET balance = balance - $1, available_balance = available_balance - $1 WHERE id = $2`, totalCost, sellerAccountID)
+			sagaLog(3, "COMPENSATED", "")
+			break
+		}
 	}
 
-	// Step 4: Transfer ownership.
-	// Clears reserved_amount alongside amount so the saga reservation is released as shares move.
+	// ── Step 4: Transfer ownership ────────────────────────────────────────────────
+	if hookErr := sagaFaultHook(ctx, "F4", compensateFailCounts); hookErr != nil {
+		sagaLog(4, "FAILED", hookErr.Error())
+		sagaStatus("Compensating", 4)
+		comp3()
+		comp2()
+		comp1()
+		sagaStatus("Compensated", 4)
+		return nil, status.Errorf(codes.Internal, "F4 fault injected: %v", hookErr)
+	}
 	if _, err = s.PortfolioDB.ExecContext(ctx, `
 		UPDATE portfolio_entry
 		SET amount          = amount - $1,
@@ -856,9 +1000,11 @@ func (s *OtcServer) ExerciseContract(ctx context.Context, req *pb.ExerciseContra
 		amount, sellerPortfolioID, sellerType, listingID,
 	); err != nil {
 		sagaLog(4, "FAILED", err.Error())
+		sagaStatus("Compensating", 4)
 		comp3()
 		comp2()
 		comp1()
+		sagaStatus("Compensated", 4)
 		return nil, status.Errorf(codes.Internal, "step 4 failed deduct seller portfolio: %v", err)
 	}
 	_, _ = s.PortfolioDB.ExecContext(ctx, `
@@ -880,27 +1026,60 @@ func (s *OtcServer) ExerciseContract(ctx context.Context, req *pb.ExerciseContra
 			 WHERE user_id = $2 AND user_type = $3 AND listing_id = $4`,
 			amount, sellerPortfolioID, sellerType, listingID,
 		)
-		sagaLog(4, "COMPENSATED", "")
+		sagaStatus("Compensating", 4)
 		comp3()
 		comp2()
 		comp1()
+		sagaStatus("Compensated", 4)
 		return nil, status.Errorf(codes.Internal, "step 4 failed upsert buyer portfolio: %v", err)
 	}
 	sagaLog(4, "SUCCESS", "")
+	sagaStatus("Running", 4)
 
 	comp4 := func() {
-		retryExec(s.PortfolioDB, `
-			UPDATE portfolio_entry SET amount = amount + $1, reserved_amount = reserved_amount + $1, public_amount = public_amount + $1, last_modified = NOW()
-			WHERE user_id=$2 AND user_type=$3 AND listing_id=$4`,
-			amount, sellerPortfolioID, sellerType, listingID)
-		retryExec(s.PortfolioDB, `
-			UPDATE portfolio_entry SET amount = amount - $1, last_modified = NOW()
-			WHERE user_id=$2 AND user_type=$3 AND listing_id=$4`,
-			amount, buyerPortfolioID, buyerType, listingID)
-		sagaLog(4, "COMPENSATED", "")
+		for {
+			if hookErr := sagaFaultHook(ctx, "C4", compensateFailCounts); hookErr != nil {
+				sagaLog(4, "COMP_FAILED", hookErr.Error())
+				time.Sleep(200 * time.Millisecond)
+				continue
+			}
+			// Restore seller portfolio. F4 may have deleted the row (amount hit 0),
+			// so UPSERT handles both the re-insert and the increment cases.
+			retryExec(s.PortfolioDB, `
+				INSERT INTO portfolio_entry
+					(user_id, user_type, listing_id, amount, buy_price, account_id, reserved_amount)
+				VALUES ($2, $3, $4, $1, 0, $5, $1)
+				ON CONFLICT (user_id, user_type, listing_id) DO UPDATE
+				SET amount          = portfolio_entry.amount + EXCLUDED.amount,
+				    reserved_amount = portfolio_entry.reserved_amount + EXCLUDED.reserved_amount,
+				    last_modified   = NOW()`,
+				amount, sellerPortfolioID, sellerType, listingID, sellerAccountID)
+			// Remove buyer shares acquired in F4, clean up row if empty.
+			retryExec(s.PortfolioDB, `
+				UPDATE portfolio_entry SET amount = amount - $1, last_modified = NOW()
+				WHERE user_id=$2 AND user_type=$3 AND listing_id=$4`,
+				amount, buyerPortfolioID, buyerType, listingID)
+			_, _ = s.PortfolioDB.Exec(`
+				DELETE FROM portfolio_entry
+				WHERE user_id=$1 AND user_type=$2 AND listing_id=$3 AND amount <= 0`,
+				buyerPortfolioID, buyerType, listingID)
+			sagaLog(4, "COMPENSATED", "")
+			break
+		}
 	}
 
-	// Step 5: Double-check final state, then atomically mark contract EXERCISED.
+	// ── Step 5: Verify and mark contract EXERCISED ────────────────────────────────
+	if hookErr := sagaFaultHook(ctx, "F5", compensateFailCounts); hookErr != nil {
+		sagaLog(5, "FAILED", hookErr.Error())
+		sagaStatus("Compensating", 5)
+		comp4()
+		comp3()
+		comp2()
+		comp1()
+		sagaStatus("Compensated", 5)
+		return nil, status.Errorf(codes.Internal, "F5 fault injected: %v", hookErr)
+	}
+
 	var buyerHolding int64
 	checkErr := s.PortfolioDB.QueryRowContext(ctx, `
 		SELECT COALESCE(amount, 0) FROM portfolio_entry
@@ -909,10 +1088,12 @@ func (s *OtcServer) ExerciseContract(ctx context.Context, req *pb.ExerciseContra
 	).Scan(&buyerHolding)
 	if checkErr != nil || buyerHolding < int64(amount) {
 		sagaLog(5, "FAILED", "double check failed: buyer portfolio inconsistent")
+		sagaStatus("Compensating", 5)
 		comp4()
 		comp3()
 		comp2()
 		comp1()
+		sagaStatus("Compensated", 5)
 		return nil, status.Error(codes.Internal, "step 5 double check failed, saga rolled back")
 	}
 
@@ -921,21 +1102,26 @@ func (s *OtcServer) ExerciseContract(ctx context.Context, req *pb.ExerciseContra
 		`UPDATE otc_contracts SET status = 'EXERCISED' WHERE id = $1`, req.ContractId,
 	); err != nil {
 		sagaLog(5, "FAILED", err.Error())
+		sagaStatus("Compensating", 5)
 		comp4()
 		comp3()
 		comp2()
 		comp1()
+		sagaStatus("Compensated", 5)
 		return nil, status.Errorf(codes.Internal, "step 5 failed: %v", err)
 	}
 	if err = tx.Commit(); err != nil {
 		sagaLog(5, "FAILED", "commit failed: "+err.Error())
+		sagaStatus("Compensating", 5)
 		comp4()
 		comp3()
 		comp2()
 		comp1()
+		sagaStatus("Compensated", 5)
 		return nil, status.Errorf(codes.Internal, "step 5 commit failed: %v", err)
 	}
 	sagaLog(5, "SUCCESS", "")
+	sagaStatus("Completed", 5)
 
 	if buyerType != "EMPLOYEE" {
 		var mktPrice float64
@@ -951,6 +1137,7 @@ func (s *OtcServer) ExerciseContract(ctx context.Context, req *pb.ExerciseContra
 	return &pb.ExerciseContractResponse{
 		Status:     "EXERCISED",
 		ExecutedAt: now.Format(time.RFC3339),
+		SagaId:     sagaID,
 	}, nil
 }
 

--- a/services/otc-service/handlers/grpc_server_coverage_gaps_test.go
+++ b/services/otc-service/handlers/grpc_server_coverage_gaps_test.go
@@ -196,8 +196,8 @@ func TestRejectNegotiation_CommitFails(t *testing.T) {
 
 func TestExerciseContract_IdempotentAlreadyExercised(t *testing.T) {
 	s, mainMock, _, _, _, _, _ := newTestServer(t)
-	mainMock.ExpectQuery("SELECT step, status FROM otc_saga_log").
-		WillReturnRows(sqlmock.NewRows([]string{"step", "status"}).AddRow(5, "SUCCESS"))
+	mainMock.ExpectQuery("SELECT id, status FROM otc_saga").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "status"}).AddRow(int64(1), "Completed"))
 	resp, err := s.ExerciseContract(context.Background(), &pb.ExerciseContractRequest{
 		ContractId: 1, CallerId: 20, CallerType: "CLIENT",
 	})
@@ -208,8 +208,8 @@ func TestExerciseContract_IdempotentAlreadyExercised(t *testing.T) {
 
 func TestExerciseContract_BeginTxFails(t *testing.T) {
 	s, mainMock, _, _, _, _, _ := newTestServer(t)
-	mainMock.ExpectQuery("SELECT step, status FROM otc_saga_log").
-		WillReturnRows(sqlmock.NewRows([]string{"step", "status"}))
+	mainMock.ExpectQuery("SELECT id, status FROM otc_saga").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "status"}))
 	mainMock.ExpectBegin().WillReturnError(sql.ErrConnDone)
 	_, err := s.ExerciseContract(context.Background(), &pb.ExerciseContractRequest{
 		ContractId: 1, CallerId: 20, CallerType: "CLIENT",
@@ -222,11 +222,12 @@ func TestExerciseContract_BeginTxFails(t *testing.T) {
 // Seller=10 (CLIENT), buyer=20 (CLIENT), 5 shares at 100 USD each. buyerAccountId=100, sellerAccountId=200.
 func exerciseStep1to4(t *testing.T, mainMock, mAcc, mPort, mSec sqlmock.Sqlmock, future time.Time) {
 	t.Helper()
-	mainMock.ExpectQuery("SELECT step, status FROM otc_saga_log").WillReturnRows(sqlmock.NewRows([]string{"step", "status"}))
+	mainMock.ExpectQuery("SELECT id, status FROM otc_saga").WillReturnRows(sqlmock.NewRows([]string{"id", "status"}))
 	mainMock.ExpectBegin()
 	mainMock.ExpectQuery("SELECT .* FROM otc_contracts WHERE id").WillReturnRows(contractRow(10, 20, future))
 	mSec.ExpectQuery("SELECT id FROM listing").WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(42)))
 	mAcc.ExpectQuery("SELECT currency_id FROM accounts WHERE id").WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(4)))
+	mainMock.ExpectQuery("INSERT INTO otc_saga").WillReturnError(fmt.Errorf("mock"))
 	// Step 1
 	mAcc.ExpectExec("UPDATE accounts SET available_balance = available_balance - ").WillReturnResult(sqlmock.NewResult(0, 1))
 	mainMock.ExpectExec("INSERT INTO otc_saga_log").WillReturnResult(sqlmock.NewResult(1, 1))
@@ -247,9 +248,10 @@ func exerciseStep1to4(t *testing.T, mainMock, mAcc, mPort, mSec sqlmock.Sqlmock,
 
 // comp4to1 sets up sqlmock expectations for full compensation (comp4 → comp3 → comp2 → comp1).
 func comp4to1(mainMock, mAcc, mPort sqlmock.Sqlmock) {
-	// comp4: restore seller + remove buyer shares
+	// comp4: UPSERT restore seller + remove buyer shares + delete if empty
+	mPort.ExpectExec("INSERT INTO portfolio_entry").WillReturnResult(sqlmock.NewResult(0, 1))
 	mPort.ExpectExec("UPDATE portfolio_entry").WillReturnResult(sqlmock.NewResult(0, 1))
-	mPort.ExpectExec("UPDATE portfolio_entry").WillReturnResult(sqlmock.NewResult(0, 1))
+	mPort.ExpectExec("DELETE FROM portfolio_entry").WillReturnResult(sqlmock.NewResult(0, 0))
 	mainMock.ExpectExec("INSERT INTO otc_saga_log").WillReturnResult(sqlmock.NewResult(1, 1))
 	// comp3: restore buyer balance + restore seller balance
 	mAcc.ExpectExec("UPDATE accounts SET balance").WillReturnResult(sqlmock.NewResult(0, 1))

--- a/services/otc-service/handlers/grpc_server_test.go
+++ b/services/otc-service/handlers/grpc_server_test.go
@@ -647,8 +647,8 @@ func TestListContracts_WithStatusFilter(t *testing.T) {
 
 func TestExerciseContract_NotFound(t *testing.T) {
 	s, mainMock, _, _, _, _, _ := newTestServer(t)
-	mainMock.ExpectQuery("SELECT step, status FROM otc_saga_log").
-		WillReturnRows(sqlmock.NewRows([]string{"step", "status"}))
+	mainMock.ExpectQuery("SELECT id, status FROM otc_saga").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "status"}))
 	mainMock.ExpectBegin()
 	mainMock.ExpectQuery("SELECT .* FROM otc_contracts WHERE id").
 		WillReturnError(sql.ErrNoRows)
@@ -662,8 +662,8 @@ func TestExerciseContract_NotFound(t *testing.T) {
 func TestExerciseContract_NotBuyer(t *testing.T) {
 	s, mainMock, _, _, _, _, _ := newTestServer(t)
 	future := time.Now().Add(48 * time.Hour)
-	mainMock.ExpectQuery("SELECT step, status FROM otc_saga_log").
-		WillReturnRows(sqlmock.NewRows([]string{"step", "status"}))
+	mainMock.ExpectQuery("SELECT id, status FROM otc_saga").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "status"}))
 	mainMock.ExpectBegin()
 	mainMock.ExpectQuery("SELECT .* FROM otc_contracts WHERE id").
 		WillReturnRows(contractRow(10, 20, future))
@@ -677,8 +677,8 @@ func TestExerciseContract_NotBuyer(t *testing.T) {
 func TestExerciseContract_NotActive(t *testing.T) {
 	s, mainMock, _, _, _, _, _ := newTestServer(t)
 	future := time.Now().Add(48 * time.Hour)
-	mainMock.ExpectQuery("SELECT step, status FROM otc_saga_log").
-		WillReturnRows(sqlmock.NewRows([]string{"step", "status"}))
+	mainMock.ExpectQuery("SELECT id, status FROM otc_saga").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "status"}))
 	mainMock.ExpectBegin()
 	mainMock.ExpectQuery("SELECT .* FROM otc_contracts WHERE id").
 		WillReturnRows(sqlmock.NewRows([]string{
@@ -696,8 +696,8 @@ func TestExerciseContract_NotActive(t *testing.T) {
 func TestExerciseContract_InsufficientFunds(t *testing.T) {
 	s, mainMock, _, _, mAcc, _, mSec := newTestServer(t)
 	future := time.Now().Add(48 * time.Hour)
-	mainMock.ExpectQuery("SELECT step, status FROM otc_saga_log").
-		WillReturnRows(sqlmock.NewRows([]string{"step", "status"}))
+	mainMock.ExpectQuery("SELECT id, status FROM otc_saga").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "status"}))
 	mainMock.ExpectBegin()
 	mainMock.ExpectQuery("SELECT .* FROM otc_contracts WHERE id").
 		WillReturnRows(contractRow(10, 20, future))
@@ -706,6 +706,7 @@ func TestExerciseContract_InsufficientFunds(t *testing.T) {
 	// Step 1: atomic UPDATE returns 0 rows (insufficient funds)
 	mAcc.ExpectQuery("SELECT currency_id FROM accounts WHERE id").
 		WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(4)))
+	mainMock.ExpectQuery("INSERT INTO otc_saga").WillReturnError(fmt.Errorf("mock"))
 	mAcc.ExpectExec("UPDATE accounts SET available_balance = available_balance - ").
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mainMock.ExpectExec("INSERT INTO otc_saga_log"). // step 1 FAILED
@@ -722,8 +723,8 @@ func TestExerciseContract_InsufficientFunds(t *testing.T) {
 func TestExerciseContract_SellerNoShares(t *testing.T) {
 	s, mainMock, _, _, mAcc, mPort, mSec := newTestServer(t)
 	future := time.Now().Add(48 * time.Hour)
-	mainMock.ExpectQuery("SELECT step, status FROM otc_saga_log").
-		WillReturnRows(sqlmock.NewRows([]string{"step", "status"}))
+	mainMock.ExpectQuery("SELECT id, status FROM otc_saga").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "status"}))
 	mainMock.ExpectBegin()
 	mainMock.ExpectQuery("SELECT .* FROM otc_contracts WHERE id").
 		WillReturnRows(contractRow(10, 20, future))
@@ -732,6 +733,7 @@ func TestExerciseContract_SellerNoShares(t *testing.T) {
 	// Step 1: atomic UPDATE returns 1 row (success)
 	mAcc.ExpectQuery("SELECT currency_id FROM accounts WHERE id").
 		WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(4)))
+	mainMock.ExpectQuery("INSERT INTO otc_saga").WillReturnError(fmt.Errorf("mock"))
 	mAcc.ExpectExec("UPDATE accounts SET available_balance = available_balance - ").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mainMock.ExpectExec("INSERT INTO otc_saga_log"). // step 1 SUCCESS
@@ -761,8 +763,8 @@ func TestExerciseContract_SellerNoShares(t *testing.T) {
 func TestExerciseContract_HappyPath(t *testing.T) {
 	s, mainMock, _, _, mAcc, mPort, mSec := newTestServer(t)
 	future := time.Now().Add(48 * time.Hour)
-	mainMock.ExpectQuery("SELECT step, status FROM otc_saga_log").
-		WillReturnRows(sqlmock.NewRows([]string{"step", "status"}))
+	mainMock.ExpectQuery("SELECT id, status FROM otc_saga").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "status"}))
 	mainMock.ExpectBegin()
 	mainMock.ExpectQuery("SELECT .* FROM otc_contracts WHERE id").
 		WillReturnRows(contractRow(10, 20, future))
@@ -772,6 +774,7 @@ func TestExerciseContract_HappyPath(t *testing.T) {
 	// Step 1: atomic UPDATE returns 1 row (success)
 	mAcc.ExpectQuery("SELECT currency_id FROM accounts WHERE id").
 		WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(4)))
+	mainMock.ExpectQuery("INSERT INTO otc_saga").WillReturnError(fmt.Errorf("mock"))
 	mAcc.ExpectExec("UPDATE accounts SET available_balance = available_balance - ").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mainMock.ExpectExec("INSERT INTO otc_saga_log").
@@ -827,8 +830,8 @@ func TestExerciseContract_PublicAmountDecrement(t *testing.T) {
 	// Verifies that Step 4 seller UPDATE includes public_amount correction.
 	s, mainMock, _, _, mAcc, mPort, mSec := newTestServer(t)
 	future := time.Now().Add(48 * time.Hour)
-	mainMock.ExpectQuery("SELECT step, status FROM otc_saga_log").
-		WillReturnRows(sqlmock.NewRows([]string{"step", "status"}))
+	mainMock.ExpectQuery("SELECT id, status FROM otc_saga").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "status"}))
 	mainMock.ExpectBegin()
 	mainMock.ExpectQuery("SELECT .* FROM otc_contracts WHERE id").
 		WillReturnRows(contractRow(10, 20, future))
@@ -838,6 +841,7 @@ func TestExerciseContract_PublicAmountDecrement(t *testing.T) {
 	// Step 1: atomic UPDATE
 	mAcc.ExpectQuery("SELECT currency_id FROM accounts WHERE id").
 		WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(4)))
+	mainMock.ExpectQuery("INSERT INTO otc_saga").WillReturnError(fmt.Errorf("mock"))
 	mAcc.ExpectExec("UPDATE accounts SET available_balance = available_balance - ").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mainMock.ExpectExec("INSERT INTO otc_saga_log").WillReturnResult(sqlmock.NewResult(1, 1))
@@ -882,8 +886,8 @@ func TestExerciseContract_CompensationRetry(t *testing.T) {
 	// Verifies that comp1 retries when the first DB exec fails.
 	s, mainMock, _, _, mAcc, mPort, mSec := newTestServer(t)
 	future := time.Now().Add(48 * time.Hour)
-	mainMock.ExpectQuery("SELECT step, status FROM otc_saga_log").
-		WillReturnRows(sqlmock.NewRows([]string{"step", "status"}))
+	mainMock.ExpectQuery("SELECT id, status FROM otc_saga").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "status"}))
 	mainMock.ExpectBegin()
 	mainMock.ExpectQuery("SELECT .* FROM otc_contracts WHERE id").
 		WillReturnRows(contractRow(10, 20, future))
@@ -893,6 +897,7 @@ func TestExerciseContract_CompensationRetry(t *testing.T) {
 	// Step 1: atomic UPDATE succeeds (1 row)
 	mAcc.ExpectQuery("SELECT currency_id FROM accounts WHERE id").
 		WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(4)))
+	mainMock.ExpectQuery("INSERT INTO otc_saga").WillReturnError(fmt.Errorf("mock"))
 	mAcc.ExpectExec("UPDATE accounts SET available_balance = available_balance - ").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mainMock.ExpectExec("INSERT INTO otc_saga_log").WillReturnResult(sqlmock.NewResult(1, 1)) // step 1 SUCCESS
@@ -1402,8 +1407,8 @@ func TestAcceptNegotiation_UpdateNegotiationFails(t *testing.T) {
 
 func TestExerciseContract_InternalError(t *testing.T) {
 	s, mainMock, _, _, _, _, _ := newTestServer(t)
-	mainMock.ExpectQuery("SELECT step, status FROM otc_saga_log").
-		WillReturnRows(sqlmock.NewRows([]string{"step", "status"}))
+	mainMock.ExpectQuery("SELECT id, status FROM otc_saga").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "status"}))
 	mainMock.ExpectBegin()
 	mainMock.ExpectQuery("SELECT .* FROM otc_contracts WHERE id").
 		WillReturnError(fmt.Errorf("connection reset"))
@@ -1418,8 +1423,8 @@ func TestExerciseContract_SettlementDatePassed(t *testing.T) {
 	s, mainMock, _, _, _, _, _ := newTestServer(t)
 	// settlement date is 2 days in the past (beyond 24h grace)
 	past := time.Now().Add(-48 * time.Hour)
-	mainMock.ExpectQuery("SELECT step, status FROM otc_saga_log").
-		WillReturnRows(sqlmock.NewRows([]string{"step", "status"}))
+	mainMock.ExpectQuery("SELECT id, status FROM otc_saga").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "status"}))
 	mainMock.ExpectBegin()
 	mainMock.ExpectQuery("SELECT .* FROM otc_contracts WHERE id").
 		WillReturnRows(contractRow(10, 20, past))
@@ -1434,8 +1439,8 @@ func TestExerciseContract_SettlementDatePassed(t *testing.T) {
 func TestExerciseContract_UnsupportedCurrency(t *testing.T) {
 	s, mainMock, _, _, _, _, mSec := newTestServer(t)
 	future := time.Now().Add(48 * time.Hour)
-	mainMock.ExpectQuery("SELECT step, status FROM otc_saga_log").
-		WillReturnRows(sqlmock.NewRows([]string{"step", "status"}))
+	mainMock.ExpectQuery("SELECT id, status FROM otc_saga").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "status"}))
 	mainMock.ExpectBegin()
 	mainMock.ExpectQuery("SELECT .* FROM otc_contracts WHERE id").
 		WillReturnRows(sqlmock.NewRows([]string{
@@ -1456,8 +1461,8 @@ func TestExerciseContract_UnsupportedCurrency(t *testing.T) {
 func TestExerciseContract_ListingIDNotFound(t *testing.T) {
 	s, mainMock, _, _, _, _, mSec := newTestServer(t)
 	future := time.Now().Add(48 * time.Hour)
-	mainMock.ExpectQuery("SELECT step, status FROM otc_saga_log").
-		WillReturnRows(sqlmock.NewRows([]string{"step", "status"}))
+	mainMock.ExpectQuery("SELECT id, status FROM otc_saga").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "status"}))
 	mainMock.ExpectBegin()
 	mainMock.ExpectQuery("SELECT .* FROM otc_contracts WHERE id").
 		WillReturnRows(contractRow(10, 20, future))
@@ -1475,8 +1480,8 @@ func TestExerciseContract_ListingIDNotFound(t *testing.T) {
 func TestExerciseContract_FindBuyerAccountFails(t *testing.T) {
 	s, mainMock, _, _, mAcc, _, mSec := newTestServer(t)
 	future := time.Now().Add(48 * time.Hour)
-	mainMock.ExpectQuery("SELECT step, status FROM otc_saga_log").
-		WillReturnRows(sqlmock.NewRows([]string{"step", "status"}))
+	mainMock.ExpectQuery("SELECT id, status FROM otc_saga").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "status"}))
 	mainMock.ExpectBegin()
 	mainMock.ExpectQuery("SELECT .* FROM otc_contracts WHERE id").
 		WillReturnRows(contractRow(10, 20, future))
@@ -1496,8 +1501,8 @@ func TestExerciseContract_FindBuyerAccountFails(t *testing.T) {
 func TestExerciseContract_Step1UpdateFails(t *testing.T) {
 	s, mainMock, _, _, mAcc, _, mSec := newTestServer(t)
 	future := time.Now().Add(48 * time.Hour)
-	mainMock.ExpectQuery("SELECT step, status FROM otc_saga_log").
-		WillReturnRows(sqlmock.NewRows([]string{"step", "status"}))
+	mainMock.ExpectQuery("SELECT id, status FROM otc_saga").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "status"}))
 	mainMock.ExpectBegin()
 	mainMock.ExpectQuery("SELECT .* FROM otc_contracts WHERE id").
 		WillReturnRows(contractRow(10, 20, future))
@@ -1506,6 +1511,7 @@ func TestExerciseContract_Step1UpdateFails(t *testing.T) {
 	// Step 1: atomic UPDATE returns error
 	mAcc.ExpectQuery("SELECT currency_id FROM accounts WHERE id").
 		WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(4)))
+	mainMock.ExpectQuery("INSERT INTO otc_saga").WillReturnError(fmt.Errorf("mock"))
 	mAcc.ExpectExec("UPDATE accounts SET available_balance = available_balance - ").
 		WillReturnError(fmt.Errorf("db error"))
 	mainMock.ExpectExec("INSERT INTO otc_saga_log"). // step 1 FAILED
@@ -1521,8 +1527,8 @@ func TestExerciseContract_Step1UpdateFails(t *testing.T) {
 func TestExerciseContract_Step2InternalError(t *testing.T) {
 	s, mainMock, _, _, mAcc, mPort, mSec := newTestServer(t)
 	future := time.Now().Add(48 * time.Hour)
-	mainMock.ExpectQuery("SELECT step, status FROM otc_saga_log").
-		WillReturnRows(sqlmock.NewRows([]string{"step", "status"}))
+	mainMock.ExpectQuery("SELECT id, status FROM otc_saga").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "status"}))
 	mainMock.ExpectBegin()
 	mainMock.ExpectQuery("SELECT .* FROM otc_contracts WHERE id").
 		WillReturnRows(contractRow(10, 20, future))
@@ -1531,6 +1537,7 @@ func TestExerciseContract_Step2InternalError(t *testing.T) {
 	// Step 1: atomic UPDATE succeeds (1 row)
 	mAcc.ExpectQuery("SELECT currency_id FROM accounts WHERE id").
 		WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(4)))
+	mainMock.ExpectQuery("INSERT INTO otc_saga").WillReturnError(fmt.Errorf("mock"))
 	mAcc.ExpectExec("UPDATE accounts SET available_balance = available_balance - ").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mainMock.ExpectExec("INSERT INTO otc_saga_log").WillReturnResult(sqlmock.NewResult(1, 1))
@@ -1553,8 +1560,8 @@ func TestExerciseContract_Step2InternalError(t *testing.T) {
 func TestExerciseContract_Step3SellerAccountNotFound(t *testing.T) {
 	s, mainMock, _, _, mAcc, mPort, mSec := newTestServer(t)
 	future := time.Now().Add(48 * time.Hour)
-	mainMock.ExpectQuery("SELECT step, status FROM otc_saga_log").
-		WillReturnRows(sqlmock.NewRows([]string{"step", "status"}))
+	mainMock.ExpectQuery("SELECT id, status FROM otc_saga").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "status"}))
 	mainMock.ExpectBegin()
 	mainMock.ExpectQuery("SELECT .* FROM otc_contracts WHERE id").
 		WillReturnRows(contractRow(10, 20, future))
@@ -1563,6 +1570,7 @@ func TestExerciseContract_Step3SellerAccountNotFound(t *testing.T) {
 	// Step 1: atomic UPDATE succeeds
 	mAcc.ExpectQuery("SELECT currency_id FROM accounts WHERE id").
 		WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(4)))
+	mainMock.ExpectQuery("INSERT INTO otc_saga").WillReturnError(fmt.Errorf("mock"))
 	mAcc.ExpectExec("UPDATE accounts SET available_balance = available_balance - ").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mainMock.ExpectExec("INSERT INTO otc_saga_log").WillReturnResult(sqlmock.NewResult(1, 1))
@@ -1593,8 +1601,8 @@ func TestExerciseContract_Step3SellerAccountNotFound(t *testing.T) {
 func TestExerciseContract_Step3DebitBuyerFails(t *testing.T) {
 	s, mainMock, _, _, mAcc, mPort, mSec := newTestServer(t)
 	future := time.Now().Add(48 * time.Hour)
-	mainMock.ExpectQuery("SELECT step, status FROM otc_saga_log").
-		WillReturnRows(sqlmock.NewRows([]string{"step", "status"}))
+	mainMock.ExpectQuery("SELECT id, status FROM otc_saga").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "status"}))
 	mainMock.ExpectBegin()
 	mainMock.ExpectQuery("SELECT .* FROM otc_contracts WHERE id").
 		WillReturnRows(contractRow(10, 20, future))
@@ -1603,6 +1611,7 @@ func TestExerciseContract_Step3DebitBuyerFails(t *testing.T) {
 	// Step 1: atomic UPDATE succeeds
 	mAcc.ExpectQuery("SELECT currency_id FROM accounts WHERE id").
 		WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(4)))
+	mainMock.ExpectQuery("INSERT INTO otc_saga").WillReturnError(fmt.Errorf("mock"))
 	mAcc.ExpectExec("UPDATE accounts SET available_balance = available_balance - ").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mainMock.ExpectExec("INSERT INTO otc_saga_log").WillReturnResult(sqlmock.NewResult(1, 1))
@@ -1634,8 +1643,8 @@ func TestExerciseContract_Step3DebitBuyerFails(t *testing.T) {
 func TestExerciseContract_Step3CreditSellerFails(t *testing.T) {
 	s, mainMock, _, _, mAcc, mPort, mSec := newTestServer(t)
 	future := time.Now().Add(48 * time.Hour)
-	mainMock.ExpectQuery("SELECT step, status FROM otc_saga_log").
-		WillReturnRows(sqlmock.NewRows([]string{"step", "status"}))
+	mainMock.ExpectQuery("SELECT id, status FROM otc_saga").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "status"}))
 	mainMock.ExpectBegin()
 	mainMock.ExpectQuery("SELECT .* FROM otc_contracts WHERE id").
 		WillReturnRows(contractRow(10, 20, future))
@@ -1644,6 +1653,7 @@ func TestExerciseContract_Step3CreditSellerFails(t *testing.T) {
 	// Step 1: atomic UPDATE succeeds
 	mAcc.ExpectQuery("SELECT currency_id FROM accounts WHERE id").
 		WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(4)))
+	mainMock.ExpectQuery("INSERT INTO otc_saga").WillReturnError(fmt.Errorf("mock"))
 	mAcc.ExpectExec("UPDATE accounts SET available_balance = available_balance - ").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mainMock.ExpectExec("INSERT INTO otc_saga_log").WillReturnResult(sqlmock.NewResult(1, 1))
@@ -1680,8 +1690,8 @@ func TestExerciseContract_Step3CreditSellerFails(t *testing.T) {
 func TestExerciseContract_Step4SellerUpdateFails(t *testing.T) {
 	s, mainMock, _, _, mAcc, mPort, mSec := newTestServer(t)
 	future := time.Now().Add(48 * time.Hour)
-	mainMock.ExpectQuery("SELECT step, status FROM otc_saga_log").
-		WillReturnRows(sqlmock.NewRows([]string{"step", "status"}))
+	mainMock.ExpectQuery("SELECT id, status FROM otc_saga").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "status"}))
 	mainMock.ExpectBegin()
 	mainMock.ExpectQuery("SELECT .* FROM otc_contracts WHERE id").
 		WillReturnRows(contractRow(10, 20, future))
@@ -1690,6 +1700,7 @@ func TestExerciseContract_Step4SellerUpdateFails(t *testing.T) {
 	// Step 1: atomic UPDATE succeeds
 	mAcc.ExpectQuery("SELECT currency_id FROM accounts WHERE id").
 		WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(4)))
+	mainMock.ExpectQuery("INSERT INTO otc_saga").WillReturnError(fmt.Errorf("mock"))
 	mAcc.ExpectExec("UPDATE accounts SET available_balance = available_balance - ").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mainMock.ExpectExec("INSERT INTO otc_saga_log").WillReturnResult(sqlmock.NewResult(1, 1))
@@ -1729,8 +1740,8 @@ func TestExerciseContract_Step4SellerUpdateFails(t *testing.T) {
 func TestExerciseContract_Step4BuyerUpsertFails(t *testing.T) {
 	s, mainMock, _, _, mAcc, mPort, mSec := newTestServer(t)
 	future := time.Now().Add(48 * time.Hour)
-	mainMock.ExpectQuery("SELECT step, status FROM otc_saga_log").
-		WillReturnRows(sqlmock.NewRows([]string{"step", "status"}))
+	mainMock.ExpectQuery("SELECT id, status FROM otc_saga").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "status"}))
 	mainMock.ExpectBegin()
 	mainMock.ExpectQuery("SELECT .* FROM otc_contracts WHERE id").
 		WillReturnRows(contractRow(10, 20, future))
@@ -1739,6 +1750,7 @@ func TestExerciseContract_Step4BuyerUpsertFails(t *testing.T) {
 	// Step 1: atomic UPDATE succeeds
 	mAcc.ExpectQuery("SELECT currency_id FROM accounts WHERE id").
 		WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(4)))
+	mainMock.ExpectQuery("INSERT INTO otc_saga").WillReturnError(fmt.Errorf("mock"))
 	mAcc.ExpectExec("UPDATE accounts SET available_balance = available_balance - ").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mainMock.ExpectExec("INSERT INTO otc_saga_log").WillReturnResult(sqlmock.NewResult(1, 1))
@@ -1782,8 +1794,8 @@ func TestExerciseContract_Step4BuyerUpsertFails(t *testing.T) {
 func TestExerciseContract_Step5UpdateContractFails(t *testing.T) {
 	s, mainMock, _, _, mAcc, mPort, mSec := newTestServer(t)
 	future := time.Now().Add(48 * time.Hour)
-	mainMock.ExpectQuery("SELECT step, status FROM otc_saga_log").
-		WillReturnRows(sqlmock.NewRows([]string{"step", "status"}))
+	mainMock.ExpectQuery("SELECT id, status FROM otc_saga").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "status"}))
 	mainMock.ExpectBegin()
 	mainMock.ExpectQuery("SELECT .* FROM otc_contracts WHERE id").
 		WillReturnRows(contractRow(10, 20, future))
@@ -1792,6 +1804,7 @@ func TestExerciseContract_Step5UpdateContractFails(t *testing.T) {
 	// Step 1: atomic UPDATE succeeds
 	mAcc.ExpectQuery("SELECT currency_id FROM accounts WHERE id").
 		WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(4)))
+	mainMock.ExpectQuery("INSERT INTO otc_saga").WillReturnError(fmt.Errorf("mock"))
 	mAcc.ExpectExec("UPDATE accounts SET available_balance = available_balance - ").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mainMock.ExpectExec("INSERT INTO otc_saga_log").WillReturnResult(sqlmock.NewResult(1, 1))
@@ -1844,8 +1857,8 @@ func TestExerciseContract_EmployeeSeller(t *testing.T) {
 	// EMPLOYEE seller → portfolioUserID returns 0 (bank shared portfolio)
 	s, mainMock, _, _, mAcc, mPort, mSec := newTestServer(t)
 	future := time.Now().Add(48 * time.Hour)
-	mainMock.ExpectQuery("SELECT step, status FROM otc_saga_log").
-		WillReturnRows(sqlmock.NewRows([]string{"step", "status"}))
+	mainMock.ExpectQuery("SELECT id, status FROM otc_saga").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "status"}))
 	mainMock.ExpectBegin()
 	mainMock.ExpectQuery("SELECT .* FROM otc_contracts WHERE id").
 		WillReturnRows(sqlmock.NewRows([]string{
@@ -1858,6 +1871,7 @@ func TestExerciseContract_EmployeeSeller(t *testing.T) {
 	// Step 1: atomic UPDATE succeeds
 	mAcc.ExpectQuery("SELECT currency_id FROM accounts WHERE id").
 		WillReturnRows(sqlmock.NewRows([]string{"currency_id"}).AddRow(int64(4)))
+	mainMock.ExpectQuery("INSERT INTO otc_saga").WillReturnError(fmt.Errorf("mock"))
 	mAcc.ExpectExec("UPDATE accounts SET available_balance = available_balance - ").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mainMock.ExpectExec("INSERT INTO otc_saga_log").WillReturnResult(sqlmock.NewResult(1, 1))

--- a/services/otc-service/handlers/saga_integration_test.go
+++ b/services/otc-service/handlers/saga_integration_test.go
@@ -1,0 +1,647 @@
+package handlers_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-4-Backend/services/otc-service/handlers"
+	pb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/otc"
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+)
+
+// skipUnlessIntegration skips the test unless OTC_INTEGRATION_TEST=true.
+func skipUnlessIntegration(t *testing.T) {
+	t.Helper()
+	if os.Getenv("OTC_INTEGRATION_TEST") != "true" {
+		t.Skip("set OTC_INTEGRATION_TEST=true to run SAGA integration tests")
+	}
+}
+
+// ── Database connection helpers ────────────────────────────────────────────────
+
+func mustConnect(t *testing.T, envKey, fallback string) *sql.DB {
+	t.Helper()
+	dsn := os.Getenv(envKey)
+	if dsn == "" {
+		dsn = fallback
+	}
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err, "connect %s", envKey)
+	require.NoError(t, db.Ping(), "ping %s", envKey)
+	return db
+}
+
+func newTestServer(t *testing.T) *handlers.OtcServer {
+	t.Helper()
+	return &handlers.OtcServer{
+		DB:           mustConnect(t, "OTC_DB_URL", "postgres://otc_user:otc_pass@localhost:5444/otc_db?sslmode=disable"),
+		AccountDB:    mustConnect(t, "ACCOUNT_DB_URL", "postgres://account_user:account_pass@localhost:5436/account_db?sslmode=disable"),
+		PortfolioDB:  mustConnect(t, "PORTFOLIO_DB_URL", "postgres://portfolio_user:portfolio_pass@localhost:5443/portfolio_db?sslmode=disable"),
+		SecuritiesDB: mustConnect(t, "SECURITIES_DB_URL", "postgres://securities_user:securities_pass@localhost:5441/securities_db?sslmode=disable"),
+		ExchangeDB:   mustConnect(t, "EXCHANGE_DB_URL", "postgres://exchange_user:exchange_pass@localhost:5438/exchange_db?sslmode=disable"),
+		EmployeeDB:   mustConnect(t, "EMPLOYEE_DB_URL", "postgres://employee_user:employee_pass@localhost:5433/employee_db?sslmode=disable"),
+		ClientDB:     mustConnect(t, "CLIENT_DB_URL", "postgres://client_user:client_pass@localhost:5435/client_db?sslmode=disable"),
+	}
+}
+
+// ── Seed helpers ───────────────────────────────────────────────────────────────
+
+const (
+	testBuyerID  int64 = 9901
+	testSellerID int64 = 9902
+	testTicker         = "SAGA_TEST"
+	testCurrency       = "USD"
+	// currency_id=4 for USD (from currencyIDMap seed)
+	testCurrencyID int64 = 4
+)
+
+func truncateAll(t *testing.T, s *handlers.OtcServer) {
+	t.Helper()
+	_, _ = s.DB.Exec(`DELETE FROM otc_saga_log WHERE contract_id IN (SELECT id FROM otc_contracts WHERE ticker=$1)`, testTicker)
+	_, _ = s.DB.Exec(`DELETE FROM otc_saga WHERE contract_id IN (SELECT id FROM otc_contracts WHERE ticker=$1)`, testTicker)
+	_, _ = s.DB.Exec(`DELETE FROM otc_contracts WHERE ticker=$1`, testTicker)
+	_, _ = s.DB.Exec(`DELETE FROM otc_negotiations WHERE ticker=$1`, testTicker)
+	_, _ = s.AccountDB.Exec(`DELETE FROM accounts WHERE owner_id IN ($1,$2)`, testBuyerID, testSellerID)
+	_, _ = s.PortfolioDB.Exec(`DELETE FROM portfolio_entry WHERE user_id IN ($1,$2)`, testBuyerID, testSellerID)
+	_ = ensureListing(t, s)
+}
+
+func ensureListing(t *testing.T, s *handlers.OtcServer) int64 {
+	t.Helper()
+	var id int64
+	err := s.SecuritiesDB.QueryRow(`SELECT id FROM listing WHERE ticker=$1`, testTicker).Scan(&id)
+	if err == nil {
+		return id
+	}
+	require.Equal(t, sql.ErrNoRows, err, "ensure listing: unexpected error looking up ticker")
+
+	// Ensure a test stock exchange exists.
+	var exchID int64
+	err = s.SecuritiesDB.QueryRow(
+		`INSERT INTO stock_exchanges (name, acronym, mic_code, polity, currency, timezone)
+		 VALUES ('SAGA Test Exchange','SAGA','SAGX','Test','USD','UTC')
+		 ON CONFLICT (mic_code) DO UPDATE SET name=EXCLUDED.name RETURNING id`,
+	).Scan(&exchID)
+	require.NoError(t, err, "ensure stock exchange")
+
+	err = s.SecuritiesDB.QueryRow(
+		`INSERT INTO listing (ticker, name, exchange_id, last_refresh, price, ask, bid, volume, change, type)
+		 VALUES ($1,'SAGA Test',$2,NOW(),100,101,99,1000,0,'STOCK') RETURNING id`,
+		testTicker, exchID,
+	).Scan(&id)
+	require.NoError(t, err, "ensure listing")
+	return id
+}
+
+func seedNegotiation(t *testing.T, s *handlers.OtcServer, qty int, strikeUSD float64, settlementOffset time.Duration) int64 {
+	t.Helper()
+	settlementDate := time.Now().Add(settlementOffset).Format("2006-01-02")
+	var negID int64
+	err := s.DB.QueryRow(`
+		INSERT INTO otc_negotiations
+			(ticker, seller_id, seller_type, buyer_id, buyer_type, amount, price_per_stock, settlement_date, premium, currency, status)
+		VALUES ($1,$2,'CLIENT',$3,'CLIENT',$4,$5,$6,0,$7,'ACCEPTED') RETURNING id`,
+		testTicker, testSellerID, testBuyerID, qty, strikeUSD, settlementDate, testCurrency,
+	).Scan(&negID)
+	require.NoError(t, err, "seed negotiation")
+	return negID
+}
+
+func seedContract(t *testing.T, s *handlers.OtcServer, qty int, strikeUSD float64, settlementOffset time.Duration) int64 {
+	t.Helper()
+	negID := seedNegotiation(t, s, qty, strikeUSD, settlementOffset)
+	var contractID int64
+	err := s.DB.QueryRow(`
+		INSERT INTO otc_contracts (negotiation_id, seller_id, seller_type, buyer_id, buyer_type, ticker, amount, strike_price, premium, currency, settlement_date, status)
+		VALUES ($1,$2,'CLIENT',$3,'CLIENT',$4,$5,$6,0,$7,$8,'ACTIVE') RETURNING id`,
+		negID, testSellerID, testBuyerID, testTicker, qty, strikeUSD, testCurrency,
+		time.Now().Add(settlementOffset).Format("2006-01-02"),
+	).Scan(&contractID)
+	require.NoError(t, err, "seed contract")
+	return contractID
+}
+
+func seedContractWithStatus(t *testing.T, s *handlers.OtcServer, contractStatus string) int64 {
+	t.Helper()
+	negID := seedNegotiation(t, s, 10, 300, 24*time.Hour)
+	var contractID int64
+	err := s.DB.QueryRow(`
+		INSERT INTO otc_contracts (negotiation_id, seller_id, seller_type, buyer_id, buyer_type, ticker, amount, strike_price, premium, currency, settlement_date, status)
+		VALUES ($1,$2,'CLIENT',$3,'CLIENT',$4,10,300,0,'USD',NOW()+INTERVAL '1 day',$5) RETURNING id`,
+		negID, testSellerID, testBuyerID, testTicker, contractStatus,
+	).Scan(&contractID)
+	require.NoError(t, err)
+	return contractID
+}
+
+func seedBuyerAccount(t *testing.T, s *handlers.OtcServer, balanceUSD float64) int64 {
+	t.Helper()
+	var id int64
+	err := s.AccountDB.QueryRow(`
+		INSERT INTO accounts (account_number, account_name, owner_id, employee_id, currency_id, account_type, status, balance, available_balance)
+		VALUES ($1,'SAGA Buyer',$2,1,$3,'CURRENT','ACTIVE',$4,$4) RETURNING id`,
+		fmt.Sprintf("SAGA-BUYER-%d", time.Now().UnixNano()), testBuyerID, testCurrencyID, balanceUSD,
+	).Scan(&id)
+	require.NoError(t, err, "seed buyer account")
+	return id
+}
+
+func seedSellerAccount(t *testing.T, s *handlers.OtcServer) int64 {
+	t.Helper()
+	var id int64
+	err := s.AccountDB.QueryRow(`
+		INSERT INTO accounts (account_number, account_name, owner_id, employee_id, currency_id, account_type, status, balance, available_balance)
+		VALUES ($1,'SAGA Seller',$2,1,$3,'CURRENT','ACTIVE',0,0) RETURNING id`,
+		fmt.Sprintf("SAGA-SELLER-%d", time.Now().UnixNano()), testSellerID, testCurrencyID,
+	).Scan(&id)
+	require.NoError(t, err, "seed seller account")
+	return id
+}
+
+func seedSellerPortfolio(t *testing.T, s *handlers.OtcServer, accountID int64, qty int) {
+	t.Helper()
+	listingID := ensureListing(t, s)
+	_, err := s.PortfolioDB.Exec(`
+		INSERT INTO portfolio_entry (user_id, user_type, listing_id, amount, buy_price, account_id, reserved_amount)
+		VALUES ($1,'CLIENT',$2,$3,100,$4,0)
+		ON CONFLICT (user_id, user_type, listing_id) DO UPDATE SET amount=$3, reserved_amount=0`,
+		testSellerID, listingID, qty, accountID,
+	)
+	require.NoError(t, err, "seed seller portfolio")
+}
+
+// ── Poll / assert helpers ──────────────────────────────────────────────────────
+
+func pollSagaStatus(t *testing.T, db *sql.DB, contractID int64, timeout time.Duration) string {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		var st string
+		err := db.QueryRow(`SELECT status FROM otc_saga WHERE contract_id=$1`, contractID).Scan(&st)
+		if err == nil && (st == "Completed" || st == "Compensated") {
+			return st
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	var st string
+	_ = db.QueryRow(`SELECT status FROM otc_saga WHERE contract_id=$1`, contractID).Scan(&st)
+	t.Fatalf("saga for contract %d did not reach terminal status within %v (last: %q)", contractID, timeout, st)
+	return ""
+}
+
+type sagaRow struct {
+	Status      string
+	CurrentStep int
+}
+
+func getSaga(t *testing.T, db *sql.DB, contractID int64) sagaRow {
+	t.Helper()
+	var r sagaRow
+	err := db.QueryRow(`SELECT status, current_step FROM otc_saga WHERE contract_id=$1`, contractID).
+		Scan(&r.Status, &r.CurrentStep)
+	require.NoError(t, err, "getSaga")
+	return r
+}
+
+type logEntry struct {
+	Step   int
+	Status string
+}
+
+func getSagaLog(t *testing.T, db *sql.DB, contractID int64) []logEntry {
+	t.Helper()
+	rows, err := db.Query(`SELECT step, status FROM otc_saga_log WHERE contract_id=$1 ORDER BY id`, contractID)
+	require.NoError(t, err)
+	defer rows.Close()
+	var entries []logEntry
+	for rows.Next() {
+		var e logEntry
+		require.NoError(t, rows.Scan(&e.Step, &e.Status))
+		entries = append(entries, e)
+	}
+	return entries
+}
+
+func getAccountBalance(t *testing.T, db *sql.DB, ownerID int64) (balance, available float64) {
+	t.Helper()
+	err := db.QueryRow(
+		`SELECT COALESCE(balance,0), COALESCE(available_balance,0) FROM accounts WHERE owner_id=$1 AND currency_id=$2 LIMIT 1`,
+		ownerID, testCurrencyID,
+	).Scan(&balance, &available)
+	require.NoError(t, err, "getAccountBalance for owner %d", ownerID)
+	return
+}
+
+func getPortfolioAmount(t *testing.T, db *sql.DB, userID int64, listingID int64) (amount, reserved int) {
+	t.Helper()
+	err := db.QueryRow(
+		`SELECT COALESCE(amount,0), COALESCE(reserved_amount,0) FROM portfolio_entry WHERE user_id=$1 AND listing_id=$2`,
+		userID, listingID,
+	).Scan(&amount, &reserved)
+	if err == sql.ErrNoRows {
+		return 0, 0
+	}
+	require.NoError(t, err)
+	return
+}
+
+func getContractStatus(t *testing.T, db *sql.DB, contractID int64) string {
+	t.Helper()
+	var st string
+	require.NoError(t, db.QueryRow(`SELECT status FROM otc_contracts WHERE id=$1`, contractID).Scan(&st))
+	return st
+}
+
+// assertInvariants checks I1 (money conserved), I2 (shares conserved), I3 (no reserved leftovers).
+func assertInvariants(t *testing.T, s *handlers.OtcServer, buyerBalanceBefore, sellerBalanceBefore float64, listingID int64, sellerSharesBefore int) {
+	t.Helper()
+	buyerBal, buyerAvail := getAccountBalance(t, s.AccountDB, testBuyerID)
+	sellerBal, sellerAvail := getAccountBalance(t, s.AccountDB, testSellerID)
+
+	// I1: total money (buyer + seller) conserved
+	assert.InDelta(t,
+		buyerBalanceBefore+sellerBalanceBefore,
+		buyerBal+sellerBal,
+		0.01,
+		"I1: total money not conserved (buyer %.2f + seller %.2f = %.2f, expected %.2f)",
+		buyerBal, sellerBal, buyerBal+sellerBal, buyerBalanceBefore+sellerBalanceBefore,
+	)
+	// I1 sub: available == balance for both (no locked amounts remaining — I3 for money)
+	assert.InDelta(t, buyerBal, buyerAvail, 0.01, "I3: buyer has reserved money (balance != available)")
+	assert.InDelta(t, sellerBal, sellerAvail, 0.01, "I3: seller has reserved money (balance != available)")
+
+	// I2: total shares conserved
+	buyerAmt, buyerReserved := getPortfolioAmount(t, s.PortfolioDB, testBuyerID, listingID)
+	sellerAmt, sellerReserved := getPortfolioAmount(t, s.PortfolioDB, testSellerID, listingID)
+	assert.Equal(t, sellerSharesBefore, buyerAmt+sellerAmt, "I2: total shares not conserved")
+
+	// I3: no reserved leftovers
+	assert.Equal(t, 0, buyerReserved, "I3: buyer has reserved_amount > 0")
+	assert.Equal(t, 0, sellerReserved, "I3: seller has reserved_amount > 0")
+}
+
+// ctxWithMeta builds a context carrying gRPC incoming metadata (for fault injection).
+func ctxWithMeta(kv ...string) context.Context {
+	md := metadata.Pairs(kv...)
+	return metadata.NewIncomingContext(context.Background(), md)
+}
+
+// ── SG-01: Happy path ──────────────────────────────────────────────────────────
+
+func TestSG01_HappyPath(t *testing.T) {
+	skipUnlessIntegration(t)
+	s := newTestServer(t)
+	truncateAll(t, s)
+	listingID := ensureListing(t, s)
+
+	contractID := seedContract(t, s, 10, 300, 24*time.Hour)
+	seedBuyerAccount(t, s, 5000)
+	sellerAccID := seedSellerAccount(t, s)
+	seedSellerPortfolio(t, s, sellerAccID, 10)
+
+	buyerBalBefore, _ := getAccountBalance(t, s.AccountDB, testBuyerID)
+	sellerBalBefore, _ := getAccountBalance(t, s.AccountDB, testSellerID)
+	sellerAmt, _ := getPortfolioAmount(t, s.PortfolioDB, testSellerID, listingID)
+
+	resp, err := s.ExerciseContract(context.Background(), &pb.ExerciseContractRequest{
+		ContractId: contractID,
+		CallerId:   testBuyerID,
+		CallerType: "CLIENT",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "EXERCISED", resp.Status)
+	assert.NotZero(t, resp.SagaId)
+
+	saga := getSaga(t, s.DB, contractID)
+	assert.Equal(t, "Completed", saga.Status)
+	assert.Equal(t, 5, saga.CurrentStep)
+
+	logEntries := getSagaLog(t, s.DB, contractID)
+	require.Len(t, logEntries, 5, "expected 5 log entries for happy path")
+	for i, e := range logEntries {
+		assert.Equal(t, i+1, e.Step, "log step order")
+		assert.Equal(t, "SUCCESS", e.Status)
+	}
+
+	assert.Equal(t, "EXERCISED", getContractStatus(t, s.DB, contractID))
+
+	buyerBal, _ := getAccountBalance(t, s.AccountDB, testBuyerID)
+	sellerBal, _ := getAccountBalance(t, s.AccountDB, testSellerID)
+	assert.InDelta(t, buyerBalBefore-3000, buyerBal, 0.01, "buyer should have 2000 USD")
+	assert.InDelta(t, sellerBalBefore+3000, sellerBal, 0.01, "seller should have 3000 USD")
+
+	buyerHolding, _ := getPortfolioAmount(t, s.PortfolioDB, testBuyerID, listingID)
+	assert.Equal(t, 10, buyerHolding, "buyer should own 10 shares")
+
+	assertInvariants(t, s, buyerBalBefore, sellerBalBefore, listingID, sellerAmt)
+}
+
+// ── SG-02: Pre-saga validation ─────────────────────────────────────────────────
+
+func TestSG02a_CallerNotBuyer(t *testing.T) {
+	skipUnlessIntegration(t)
+	s := newTestServer(t)
+	truncateAll(t, s)
+	contractID := seedContract(t, s, 10, 300, 24*time.Hour)
+
+	_, err := s.ExerciseContract(context.Background(), &pb.ExerciseContractRequest{
+		ContractId: contractID,
+		CallerId:   testBuyerID + 999,
+		CallerType: "CLIENT",
+	})
+	require.Error(t, err)
+
+	// No saga row should be created.
+	var count int
+	s.DB.QueryRow(`SELECT COUNT(*) FROM otc_saga WHERE contract_id=$1`, contractID).Scan(&count)
+	assert.Equal(t, 0, count, "no saga row should exist for pre-saga rejection")
+}
+
+func TestSG02b_ContractNotFound(t *testing.T) {
+	skipUnlessIntegration(t)
+	s := newTestServer(t)
+	truncateAll(t, s)
+
+	_, err := s.ExerciseContract(context.Background(), &pb.ExerciseContractRequest{
+		ContractId: 999999999,
+		CallerId:   testBuyerID,
+		CallerType: "CLIENT",
+	})
+	require.Error(t, err)
+}
+
+func TestSG02c_ContractAlreadyExercised(t *testing.T) {
+	skipUnlessIntegration(t)
+	s := newTestServer(t)
+	truncateAll(t, s)
+	contractID := seedContractWithStatus(t, s, "EXERCISED")
+
+	_, err := s.ExerciseContract(context.Background(), &pb.ExerciseContractRequest{
+		ContractId: contractID,
+		CallerId:   testBuyerID,
+		CallerType: "CLIENT",
+	})
+	require.Error(t, err)
+
+	var count int
+	s.DB.QueryRow(`SELECT COUNT(*) FROM otc_saga WHERE contract_id=$1`, contractID).Scan(&count)
+	assert.Equal(t, 0, count, "no saga row for pre-validation failure")
+}
+
+func TestSG02d_SettlementDatePassed(t *testing.T) {
+	skipUnlessIntegration(t)
+	s := newTestServer(t)
+	truncateAll(t, s)
+	// settlement date 2 days in the past
+	contractID := seedContract(t, s, 10, 300, -48*time.Hour)
+
+	_, err := s.ExerciseContract(context.Background(), &pb.ExerciseContractRequest{
+		ContractId: contractID,
+		CallerId:   testBuyerID,
+		CallerType: "CLIENT",
+	})
+	require.Error(t, err)
+}
+
+// ── SG-03: F1 failure (insufficient funds) ─────────────────────────────────────
+
+func TestSG03_InsufficientFunds(t *testing.T) {
+	skipUnlessIntegration(t)
+	s := newTestServer(t)
+	truncateAll(t, s)
+	listingID := ensureListing(t, s)
+
+	contractID := seedContract(t, s, 10, 300, 24*time.Hour) // needs 3000 USD
+	seedBuyerAccount(t, s, 500)                              // only 500 USD
+	sellerAccID := seedSellerAccount(t, s)
+	seedSellerPortfolio(t, s, sellerAccID, 10)
+
+	buyerBalBefore, _ := getAccountBalance(t, s.AccountDB, testBuyerID)
+	sellerAmt, _ := getPortfolioAmount(t, s.PortfolioDB, testSellerID, listingID)
+
+	_, err := s.ExerciseContract(context.Background(), &pb.ExerciseContractRequest{
+		ContractId: contractID,
+		CallerId:   testBuyerID,
+		CallerType: "CLIENT",
+	})
+	require.Error(t, err)
+
+	saga := getSaga(t, s.DB, contractID)
+	assert.Equal(t, "Compensated", saga.Status)
+	assert.Equal(t, 1, saga.CurrentStep)
+
+	logEntries := getSagaLog(t, s.DB, contractID)
+	require.Len(t, logEntries, 1, "only F1 log entry expected")
+	assert.Equal(t, 1, logEntries[0].Step)
+	assert.Equal(t, "FAILED", logEntries[0].Status)
+
+	// No side effects.
+	buyerBal, _ := getAccountBalance(t, s.AccountDB, testBuyerID)
+	assert.InDelta(t, buyerBalBefore, buyerBal, 0.01, "buyer balance must be unchanged")
+
+	_, _ = sellerAmt, listingID // invariants checked implicitly via unchanged balances
+}
+
+// ── SG-04: F2 failure (insufficient shares) ────────────────────────────────────
+
+func TestSG04_InsufficientShares(t *testing.T) {
+	skipUnlessIntegration(t)
+	s := newTestServer(t)
+	truncateAll(t, s)
+	listingID := ensureListing(t, s)
+
+	contractID := seedContract(t, s, 10, 300, 24*time.Hour) // needs 10 shares
+	seedBuyerAccount(t, s, 5000)
+	sellerAccID := seedSellerAccount(t, s)
+	seedSellerPortfolio(t, s, sellerAccID, 3) // only 3 shares
+
+	buyerBalBefore, _ := getAccountBalance(t, s.AccountDB, testBuyerID)
+	sellerAmt, _ := getPortfolioAmount(t, s.PortfolioDB, testSellerID, listingID)
+
+	_, err := s.ExerciseContract(context.Background(), &pb.ExerciseContractRequest{
+		ContractId: contractID,
+		CallerId:   testBuyerID,
+		CallerType: "CLIENT",
+	})
+	require.Error(t, err)
+
+	saga := getSaga(t, s.DB, contractID)
+	assert.Equal(t, "Compensated", saga.Status)
+	assert.Equal(t, 2, saga.CurrentStep)
+
+	logEntries := getSagaLog(t, s.DB, contractID)
+	require.GreaterOrEqual(t, len(logEntries), 3, "expected at least F1 ok, F2 fail, C1 compensated")
+	assert.Equal(t, 1, logEntries[0].Step)
+	assert.Equal(t, "SUCCESS", logEntries[0].Status)
+	assert.Equal(t, 2, logEntries[1].Step)
+	assert.Equal(t, "FAILED", logEntries[1].Status)
+	// C1 should have fired
+	c1Entry := logEntries[len(logEntries)-1]
+	assert.Equal(t, 1, c1Entry.Step)
+	assert.Equal(t, "COMPENSATED", c1Entry.Status)
+
+	// Buyer balance unchanged (F1 reserved, C1 released).
+	buyerBal, _ := getAccountBalance(t, s.AccountDB, testBuyerID)
+	assert.InDelta(t, buyerBalBefore, buyerBal, 0.01, "buyer balance unchanged after F2 failure")
+
+	_ = sellerAmt
+}
+
+// ── SG-05: F3 force-fail ────────────────────────────────────────────────────────
+
+func TestSG05_F3ForceFail(t *testing.T) {
+	skipUnlessIntegration(t)
+	s := newTestServer(t)
+	truncateAll(t, s)
+	listingID := ensureListing(t, s)
+
+	contractID := seedContract(t, s, 10, 300, 24*time.Hour)
+	seedBuyerAccount(t, s, 5000)
+	sellerAccID := seedSellerAccount(t, s)
+	seedSellerPortfolio(t, s, sellerAccID, 10)
+
+	buyerBalBefore, _ := getAccountBalance(t, s.AccountDB, testBuyerID)
+	sellerBalBefore, _ := getAccountBalance(t, s.AccountDB, testSellerID)
+	sellerAmt, _ := getPortfolioAmount(t, s.PortfolioDB, testSellerID, listingID)
+
+	ctx := ctxWithMeta("x-saga-force-fail", "F3")
+	_, err := s.ExerciseContract(ctx, &pb.ExerciseContractRequest{
+		ContractId: contractID,
+		CallerId:   testBuyerID,
+		CallerType: "CLIENT",
+	})
+	require.Error(t, err)
+
+	saga := getSaga(t, s.DB, contractID)
+	assert.Equal(t, "Compensated", saga.Status)
+	assert.Equal(t, 3, saga.CurrentStep)
+
+	logEntries := getSagaLog(t, s.DB, contractID)
+	// Expected: F1 ok, F2 ok, F3 fail, C2 compensated, C1 compensated
+	assert.GreaterOrEqual(t, len(logEntries), 5)
+
+	assertInvariants(t, s, buyerBalBefore, sellerBalBefore, listingID, sellerAmt)
+	assert.Equal(t, "ACTIVE", getContractStatus(t, s.DB, contractID), "I6: contract must stay ACTIVE")
+}
+
+// ── SG-06: F4 force-fail ────────────────────────────────────────────────────────
+
+func TestSG06_F4ForceFail(t *testing.T) {
+	skipUnlessIntegration(t)
+	s := newTestServer(t)
+	truncateAll(t, s)
+	listingID := ensureListing(t, s)
+
+	contractID := seedContract(t, s, 10, 300, 24*time.Hour)
+	seedBuyerAccount(t, s, 5000)
+	sellerAccID := seedSellerAccount(t, s)
+	seedSellerPortfolio(t, s, sellerAccID, 10)
+
+	buyerBalBefore, _ := getAccountBalance(t, s.AccountDB, testBuyerID)
+	sellerBalBefore, _ := getAccountBalance(t, s.AccountDB, testSellerID)
+	sellerAmt, _ := getPortfolioAmount(t, s.PortfolioDB, testSellerID, listingID)
+
+	ctx := ctxWithMeta("x-saga-force-fail", "F4")
+	_, err := s.ExerciseContract(ctx, &pb.ExerciseContractRequest{
+		ContractId: contractID,
+		CallerId:   testBuyerID,
+		CallerType: "CLIENT",
+	})
+	require.Error(t, err)
+
+	saga := getSaga(t, s.DB, contractID)
+	assert.Equal(t, "Compensated", saga.Status)
+	assert.Equal(t, 4, saga.CurrentStep)
+
+	assertInvariants(t, s, buyerBalBefore, sellerBalBefore, listingID, sellerAmt)
+	assert.Equal(t, "ACTIVE", getContractStatus(t, s.DB, contractID))
+}
+
+// ── SG-07: F5 force-fail ────────────────────────────────────────────────────────
+
+func TestSG07_F5ForceFail(t *testing.T) {
+	skipUnlessIntegration(t)
+	s := newTestServer(t)
+	truncateAll(t, s)
+	listingID := ensureListing(t, s)
+
+	contractID := seedContract(t, s, 10, 300, 24*time.Hour)
+	seedBuyerAccount(t, s, 5000)
+	sellerAccID := seedSellerAccount(t, s)
+	seedSellerPortfolio(t, s, sellerAccID, 10)
+
+	buyerBalBefore, _ := getAccountBalance(t, s.AccountDB, testBuyerID)
+	sellerBalBefore, _ := getAccountBalance(t, s.AccountDB, testSellerID)
+	sellerAmt, _ := getPortfolioAmount(t, s.PortfolioDB, testSellerID, listingID)
+
+	ctx := ctxWithMeta("x-saga-force-fail", "F5")
+	_, err := s.ExerciseContract(ctx, &pb.ExerciseContractRequest{
+		ContractId: contractID,
+		CallerId:   testBuyerID,
+		CallerType: "CLIENT",
+	})
+	require.Error(t, err)
+
+	saga := getSaga(t, s.DB, contractID)
+	assert.Equal(t, "Compensated", saga.Status)
+	assert.Equal(t, 5, saga.CurrentStep)
+
+	logEntries := getSagaLog(t, s.DB, contractID)
+	// F1-F4 ok, F5 fail, C4 comp, C3 comp, C2 comp, C1 comp = 9 entries
+	assert.GreaterOrEqual(t, len(logEntries), 9)
+
+	assertInvariants(t, s, buyerBalBefore, sellerBalBefore, listingID, sellerAmt)
+	assert.Equal(t, "ACTIVE", getContractStatus(t, s.DB, contractID))
+}
+
+// ── SG-08: Compensator fails once, then succeeds ───────────────────────────────
+
+func TestSG08_CompensatorFailsOnceThenSucceeds(t *testing.T) {
+	skipUnlessIntegration(t)
+	s := newTestServer(t)
+	truncateAll(t, s)
+	listingID := ensureListing(t, s)
+
+	contractID := seedContract(t, s, 10, 300, 24*time.Hour)
+	seedBuyerAccount(t, s, 5000)
+	sellerAccID := seedSellerAccount(t, s)
+	seedSellerPortfolio(t, s, sellerAccID, 10)
+
+	buyerBalBefore, _ := getAccountBalance(t, s.AccountDB, testBuyerID)
+	sellerBalBefore, _ := getAccountBalance(t, s.AccountDB, testSellerID)
+	sellerAmt, _ := getPortfolioAmount(t, s.PortfolioDB, testSellerID, listingID)
+
+	ctx := ctxWithMeta(
+		"x-saga-force-fail", "F3",
+		"x-saga-compensate-fail", "C2",
+		"x-saga-compensate-fail-times", "1",
+	)
+	_, err := s.ExerciseContract(ctx, &pb.ExerciseContractRequest{
+		ContractId: contractID,
+		CallerId:   testBuyerID,
+		CallerType: "CLIENT",
+	})
+	require.Error(t, err)
+
+	saga := getSaga(t, s.DB, contractID)
+	assert.Equal(t, "Compensated", saga.Status)
+
+	logEntries := getSagaLog(t, s.DB, contractID)
+	// Count C2 compensator entries only (COMP_FAILED + COMPENSATED, not the forward SUCCESS).
+	c2Count := 0
+	for _, e := range logEntries {
+		if e.Step == 2 && e.Status != "SUCCESS" {
+			c2Count++
+		}
+	}
+	assert.Equal(t, 2, c2Count, "C2 should appear twice in log (1 COMP_FAILED + 1 COMPENSATED)")
+
+	assertInvariants(t, s, buyerBalBefore, sellerBalBefore, listingID, sellerAmt)
+}

--- a/services/otc-service/handlers/saga_integration_test.go
+++ b/services/otc-service/handlers/saga_integration_test.go
@@ -179,23 +179,6 @@ func seedSellerPortfolio(t *testing.T, s *handlers.OtcServer, accountID int64, q
 
 // ── Poll / assert helpers ──────────────────────────────────────────────────────
 
-func pollSagaStatus(t *testing.T, db *sql.DB, contractID int64, timeout time.Duration) string {
-	t.Helper()
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		var st string
-		err := db.QueryRow(`SELECT status FROM otc_saga WHERE contract_id=$1`, contractID).Scan(&st)
-		if err == nil && (st == "Completed" || st == "Compensated") {
-			return st
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-	var st string
-	_ = db.QueryRow(`SELECT status FROM otc_saga WHERE contract_id=$1`, contractID).Scan(&st)
-	t.Fatalf("saga for contract %d did not reach terminal status within %v (last: %q)", contractID, timeout, st)
-	return ""
-}
-
 type sagaRow struct {
 	Status      string
 	CurrentStep int
@@ -219,7 +202,7 @@ func getSagaLog(t *testing.T, db *sql.DB, contractID int64) []logEntry {
 	t.Helper()
 	rows, err := db.Query(`SELECT step, status FROM otc_saga_log WHERE contract_id=$1 ORDER BY id`, contractID)
 	require.NoError(t, err)
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	var entries []logEntry
 	for rows.Next() {
 		var e logEntry
@@ -360,7 +343,7 @@ func TestSG02a_CallerNotBuyer(t *testing.T) {
 
 	// No saga row should be created.
 	var count int
-	s.DB.QueryRow(`SELECT COUNT(*) FROM otc_saga WHERE contract_id=$1`, contractID).Scan(&count)
+	_ = s.DB.QueryRow(`SELECT COUNT(*) FROM otc_saga WHERE contract_id=$1`, contractID).Scan(&count)
 	assert.Equal(t, 0, count, "no saga row should exist for pre-saga rejection")
 }
 
@@ -391,7 +374,7 @@ func TestSG02c_ContractAlreadyExercised(t *testing.T) {
 	require.Error(t, err)
 
 	var count int
-	s.DB.QueryRow(`SELECT COUNT(*) FROM otc_saga WHERE contract_id=$1`, contractID).Scan(&count)
+	_ = s.DB.QueryRow(`SELECT COUNT(*) FROM otc_saga WHERE contract_id=$1`, contractID).Scan(&count)
 	assert.Equal(t, 0, count, "no saga row for pre-validation failure")
 }
 
@@ -419,7 +402,7 @@ func TestSG03_InsufficientFunds(t *testing.T) {
 	listingID := ensureListing(t, s)
 
 	contractID := seedContract(t, s, 10, 300, 24*time.Hour) // needs 3000 USD
-	seedBuyerAccount(t, s, 500)                              // only 500 USD
+	seedBuyerAccount(t, s, 500)                             // only 500 USD
 	sellerAccID := seedSellerAccount(t, s)
 	seedSellerPortfolio(t, s, sellerAccID, 10)
 

--- a/services/otc-service/handlers/saga_recovery.go
+++ b/services/otc-service/handlers/saga_recovery.go
@@ -1,0 +1,181 @@
+package handlers
+
+import (
+	"context"
+	"database/sql"
+	"log"
+	"time"
+)
+
+// RecoverInFlightSagas is called at service startup. It finds any SAGA that was left in
+// Running or Compensating state (e.g. because the service was killed mid-flight) and
+// compensates all completed forward steps.
+func (s *OtcServer) RecoverInFlightSagas() {
+	type sagaRow struct {
+		id, contractID int64
+		currentStep    int
+		sagaStatus     string
+	}
+
+	rows, err := s.DB.Query(
+		`SELECT id, contract_id, current_step, status FROM otc_saga WHERE status IN ('Running', 'Compensating')`)
+	if err != nil {
+		log.Printf("RecoverInFlightSagas: query error: %v", err)
+		return
+	}
+	defer rows.Close()
+
+	var sagas []sagaRow
+	for rows.Next() {
+		var r sagaRow
+		if err := rows.Scan(&r.id, &r.contractID, &r.currentStep, &r.sagaStatus); err == nil {
+			sagas = append(sagas, r)
+		}
+	}
+	rows.Close()
+
+	for _, saga := range sagas {
+		log.Printf("RecoverInFlightSagas: recovering saga %d (contract %d, step %d, status %s)",
+			saga.id, saga.contractID, saga.currentStep, saga.sagaStatus)
+		go s.recoverSaga(saga.id, saga.contractID)
+	}
+}
+
+// recoverSaga compensates all completed forward steps for the given contract.
+func (s *OtcServer) recoverSaga(sagaID, contractID int64) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	// Mark as Compensating so the recovery is idempotent.
+	_, _ = s.DB.ExecContext(ctx,
+		`UPDATE otc_saga SET status='Compensating', updated_at=NOW() WHERE id=$1 AND status IN ('Running','Compensating')`,
+		sagaID)
+
+	// Determine which forward steps completed by reading the log.
+	successRows, err := s.DB.QueryContext(ctx,
+		`SELECT DISTINCT step FROM otc_saga_log WHERE contract_id=$1 AND status='SUCCESS' ORDER BY step DESC`,
+		contractID)
+	if err != nil {
+		log.Printf("recoverSaga %d: failed to read log: %v", sagaID, err)
+		return
+	}
+	var completedSteps []int
+	for successRows.Next() {
+		var step int
+		if err := successRows.Scan(&step); err == nil {
+			completedSteps = append(completedSteps, step)
+		}
+	}
+	successRows.Close()
+
+	if len(completedSteps) == 0 {
+		// Nothing completed, just mark as Compensated.
+		_, _ = s.DB.ExecContext(ctx,
+			`UPDATE otc_saga SET status='Compensated', updated_at=NOW() WHERE id=$1`, sagaID)
+		return
+	}
+
+	// Load contract details needed to build compensation operations.
+	var sellerID, buyerID int64
+	var sellerType, buyerType, ticker, currency string
+	var amount int32
+	var strikePrice float64
+	err = s.DB.QueryRowContext(ctx,
+		`SELECT seller_id, seller_type, buyer_id, buyer_type, ticker, amount, strike_price, currency
+		 FROM otc_contracts WHERE id=$1`, contractID,
+	).Scan(&sellerID, &sellerType, &buyerID, &buyerType, &ticker, &amount, &strikePrice, &currency)
+	if err != nil {
+		log.Printf("recoverSaga %d: failed to load contract: %v", sagaID, err)
+		return
+	}
+
+	currencyID, ok := currencyIDMap[currency]
+	if !ok {
+		log.Printf("recoverSaga %d: unknown currency %s", sagaID, currency)
+		return
+	}
+
+	buyerAccountID, err := findAccount(s.AccountDB, portfolioUserID(buyerID, buyerType), currencyID)
+	if err != nil {
+		log.Printf("recoverSaga %d: cannot find buyer account: %v", sagaID, err)
+		return
+	}
+
+	buyerCurrencyID, err := getAccountCurrencyID(s.AccountDB, buyerAccountID)
+	if err != nil {
+		log.Printf("recoverSaga %d: cannot get buyer currency: %v", sagaID, err)
+		return
+	}
+
+	totalCostToPay, err := convertAmount(s.ExchangeDB, strikePrice*float64(amount), currencyID, buyerCurrencyID)
+	if err != nil {
+		log.Printf("recoverSaga %d: currency conversion failed: %v", sagaID, err)
+		return
+	}
+
+	sellerAccountID, err := findAccount(s.AccountDB, portfolioUserID(sellerID, sellerType), currencyID)
+	if err != nil {
+		log.Printf("recoverSaga %d: cannot find seller account: %v", sagaID, err)
+		return
+	}
+
+	listingID, err := listingIDForTicker(s.SecuritiesDB, ticker)
+	if err != nil {
+		log.Printf("recoverSaga %d: cannot find listing for ticker %s: %v", sagaID, ticker, err)
+		return
+	}
+
+	sellerPortfolioID := portfolioUserID(sellerID, sellerType)
+	buyerPortfolioID := portfolioUserID(buyerID, buyerType)
+
+	sagaLogRecovery := func(step int, stepStatus, errMsg string) {
+		logCtx, logCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer logCancel()
+		_, _ = s.DB.ExecContext(logCtx,
+			`INSERT INTO otc_saga_log (contract_id, step, status, error_msg) VALUES ($1, $2, $3, $4)`,
+			contractID, step, stepStatus, sql.NullString{String: errMsg, Valid: errMsg != ""},
+		)
+	}
+
+	// Run compensators in reverse order for all completed forward steps.
+	// completedSteps is already in DESC order.
+	highestStep := completedSteps[0]
+
+	if highestStep >= 4 {
+		retryExec(s.PortfolioDB, `
+			UPDATE portfolio_entry SET amount=amount+$1, reserved_amount=reserved_amount+$1, public_amount=public_amount+$1, last_modified=NOW()
+			WHERE user_id=$2 AND user_type=$3 AND listing_id=$4`,
+			amount, sellerPortfolioID, sellerType, listingID)
+		retryExec(s.PortfolioDB, `
+			UPDATE portfolio_entry SET amount=amount-$1, last_modified=NOW()
+			WHERE user_id=$2 AND user_type=$3 AND listing_id=$4`,
+			amount, buyerPortfolioID, buyerType, listingID)
+		sagaLogRecovery(4, "COMPENSATED", "recovery")
+	}
+
+	if highestStep >= 3 {
+		retryExec(s.AccountDB, `UPDATE accounts SET balance=balance+$1 WHERE id=$2`, totalCostToPay, buyerAccountID)
+		retryExec(s.AccountDB, `UPDATE accounts SET balance=balance-$1, available_balance=available_balance-$1 WHERE id=$2`,
+			strikePrice*float64(amount), sellerAccountID)
+		sagaLogRecovery(3, "COMPENSATED", "recovery")
+	}
+
+	if highestStep >= 2 {
+		retryExec(s.PortfolioDB,
+			`UPDATE portfolio_entry SET reserved_amount=GREATEST(0, reserved_amount-$1)
+			 WHERE user_id=$2 AND user_type=$3 AND listing_id=$4`,
+			amount, sellerPortfolioID, sellerType, listingID)
+		sagaLogRecovery(2, "COMPENSATED", "recovery")
+	}
+
+	if highestStep >= 1 {
+		retryExec(s.AccountDB,
+			`UPDATE accounts SET available_balance=available_balance+$1 WHERE id=$2`,
+			totalCostToPay, buyerAccountID)
+		sagaLogRecovery(1, "COMPENSATED", "recovery")
+	}
+
+	_, _ = s.DB.ExecContext(ctx,
+		`UPDATE otc_saga SET status='Compensated', updated_at=NOW() WHERE id=$1`, sagaID)
+	log.Printf("recoverSaga %d: recovery complete (compensated up to step %d)", sagaID, highestStep)
+}

--- a/services/otc-service/handlers/saga_recovery.go
+++ b/services/otc-service/handlers/saga_recovery.go
@@ -23,7 +23,7 @@ func (s *OtcServer) RecoverInFlightSagas() {
 		log.Printf("RecoverInFlightSagas: query error: %v", err)
 		return
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var sagas []sagaRow
 	for rows.Next() {
@@ -32,7 +32,7 @@ func (s *OtcServer) RecoverInFlightSagas() {
 			sagas = append(sagas, r)
 		}
 	}
-	rows.Close()
+	_ = rows.Close()
 
 	for _, saga := range sagas {
 		log.Printf("RecoverInFlightSagas: recovering saga %d (contract %d, step %d, status %s)",
@@ -66,7 +66,7 @@ func (s *OtcServer) recoverSaga(sagaID, contractID int64) {
 			completedSteps = append(completedSteps, step)
 		}
 	}
-	successRows.Close()
+	_ = successRows.Close()
 
 	if len(completedSteps) == 0 {
 		// Nothing completed, just mark as Compensated.

--- a/services/otc-service/main.go
+++ b/services/otc-service/main.go
@@ -74,6 +74,9 @@ func main() {
 	}
 	pb.RegisterOtcServiceServer(srv, srvImpl)
 
+	// Recover any SAGA flows that were interrupted by a previous crash.
+	go srvImpl.RecoverInFlightSagas()
+
 	// Hourly contract expiration with tax loss recording.
 	// Runs immediately on startup so stale contracts are cleaned up at boot.
 	go func() {

--- a/services/securities-service/scheduler/price_simulation.go
+++ b/services/securities-service/scheduler/price_simulation.go
@@ -67,8 +67,8 @@ func simulatePrices(db *sql.DB) error {
 			continue
 		}
 
-		// Random factor in [-0.005, +0.015] (biased toward gains in test mode, avg +0.5%/min)
-		factor := 1 + (rand.Float64()*0.02 - 0.005)
+		// Random factor in [-0.01, +0.01] (symmetric ±1%)
+		factor := 1 + (rand.Float64()*0.02 - 0.01)
 		newPrice := l.price * factor
 
 		// Preserve ask/bid spread ratio; fall back to a fixed 0.1% spread if price was zero.

--- a/shared/pb/otc/otc.pb.go
+++ b/shared/pb/otc/otc.pb.go
@@ -1121,6 +1121,7 @@ type ExerciseContractResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Status        string                 `protobuf:"bytes,1,opt,name=status,proto3" json:"status,omitempty"`
 	ExecutedAt    string                 `protobuf:"bytes,2,opt,name=executed_at,json=executedAt,proto3" json:"executed_at,omitempty"`
+	SagaId        int64                  `protobuf:"varint,3,opt,name=saga_id,json=sagaId,proto3" json:"saga_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1167,6 +1168,13 @@ func (x *ExerciseContractResponse) GetExecutedAt() string {
 		return x.ExecutedAt
 	}
 	return ""
+}
+
+func (x *ExerciseContractResponse) GetSagaId() int64 {
+	if x != nil {
+		return x.SagaId
+	}
+	return 0
 }
 
 type GetMarketRequest struct {
@@ -2150,11 +2158,12 @@ const file_otc_proto_rawDesc = "" +
 	"\tcaller_id\x18\x02 \x01(\x03R\bcallerId\x12\x1f\n" +
 	"\vcaller_type\x18\x03 \x01(\tR\n" +
 	"callerType\x12(\n" +
-	"\x10buyer_account_id\x18\x04 \x01(\x03R\x0ebuyerAccountId\"S\n" +
+	"\x10buyer_account_id\x18\x04 \x01(\x03R\x0ebuyerAccountId\"l\n" +
 	"\x18ExerciseContractResponse\x12\x16\n" +
 	"\x06status\x18\x01 \x01(\tR\x06status\x12\x1f\n" +
 	"\vexecuted_at\x18\x02 \x01(\tR\n" +
-	"executedAt\"P\n" +
+	"executedAt\x12\x17\n" +
+	"\asaga_id\x18\x03 \x01(\x03R\x06sagaId\"P\n" +
 	"\x10GetMarketRequest\x12\x1b\n" +
 	"\tcaller_id\x18\x01 \x01(\x03R\bcallerId\x12\x1f\n" +
 	"\vcaller_type\x18\x02 \x01(\tR\n" +

--- a/shared/proto/otc.proto
+++ b/shared/proto/otc.proto
@@ -138,6 +138,7 @@ message ExerciseContractRequest {
 message ExerciseContractResponse {
   string status      = 1;
   string executed_at = 2;
+  int64  saga_id     = 3;
 }
 
 message GetMarketRequest {


### PR DESCRIPTION
…nd recovery

- Add global otc_saga tracker table (Running/Compensating/Completed/Compensated)
- Add saga_id to ExerciseContractResponse proto and HTTP response
- Add OTC_SAGA_TEST_HOOKS fault injection via gRPC metadata (X-Saga-Force-Fail etc.)
- Fix FK deadlock: remove REFERENCES constraints from otc_saga and otc_saga_log
- Fix comp4: use UPSERT to restore seller portfolio row deleted by F4
- Add RecoverInFlightSagas() crash recovery on startup
- Add saga integration tests SG-01 to SG-08 (happy path, validation, compensation, fault injection)
- Fix unit test mock expectations to match actual execution order
- Fix price simulation: symmetric ±1% factor (was biased +0.5%/min)
- Forward X-Saga-* headers as gRPC metadata in api-gateway