### PR TITLE
fix(interbank): use nested posting format matching partner bank protocol

### DIFF
--- a/services/otc-service/handlers/interbank_outgoing.go
+++ b/services/otc-service/handlers/interbank_outgoing.go
@@ -47,7 +47,7 @@ type ibOutAssetInner struct {
 }
 type ibOutAsset struct {
 	Type  string           `json:"type"`
-	Asset *ibOutAssetInner `json:"asset,omitempty"`
+	Asset *ibOutAssetInner `json:"body,omitempty"`
 }
 type ibOutPosting struct {
 	Account ibOutAccount `json:"account"`

--- a/services/payment-service/handlers/interbank_outgoing.go
+++ b/services/payment-service/handlers/interbank_outgoing.go
@@ -34,12 +34,24 @@ type ibIdempotenceKey struct {
 	LocallyGeneratedKey string `json:"locallyGeneratedKey"`
 }
 
+type ibPostingAccount struct {
+	Type string `json:"type"`
+	Num  string `json:"num,omitempty"`
+}
+
+type ibPostingAssetBody struct {
+	Currency string `json:"currency,omitempty"`
+}
+
+type ibPostingAsset struct {
+	Type string              `json:"type"`
+	Body *ibPostingAssetBody `json:"body,omitempty"`
+}
+
 type ibPosting struct {
-	AccountType string  `json:"accountType"`
-	AccountNum  string  `json:"accountNum"`
-	Amount      float64 `json:"amount"`
-	AssetType   string  `json:"assetType"`
-	Currency    string  `json:"currency"`
+	Account ibPostingAccount `json:"account"`
+	Amount  float64          `json:"amount"`
+	Asset   ibPostingAsset   `json:"asset"`
 }
 
 type ibNewTxMessage struct {
@@ -225,8 +237,8 @@ func executeOutgoing2PC(ctx context.Context, s *PaymentServer, req *pb.CreatePay
 		Message: ibNewTxMessage{
 			TransactionID: txID,
 			Postings: []ibPosting{
-				{AccountType: "ACCOUNT", AccountNum: req.FromAccount, Amount: -req.Amount, AssetType: "MONAS", Currency: currencyCode},
-				{AccountType: "ACCOUNT", AccountNum: req.RecipientAccount, Amount: req.Amount, AssetType: "MONAS", Currency: currencyCode},
+				{Account: ibPostingAccount{Type: "ACCOUNT", Num: req.FromAccount}, Amount: -req.Amount, Asset: ibPostingAsset{Type: "MONAS", Body: &ibPostingAssetBody{Currency: currencyCode}}},
+				{Account: ibPostingAccount{Type: "ACCOUNT", Num: req.RecipientAccount}, Amount: req.Amount, Asset: ibPostingAsset{Type: "MONAS", Body: &ibPostingAssetBody{Currency: currencyCode}}},
 			},
 			PaymentCode:    req.PaymentCode,
 			PaymentPurpose: req.Purpose,

--- a/services/payment-service/handlers/preview.go
+++ b/services/payment-service/handlers/preview.go
@@ -77,8 +77,8 @@ func (s *PaymentServer) previewCrossBank(ctx context.Context, req *pb.PreviewPay
 		Message: ibNewTxMessage{
 			TransactionID: txID,
 			Postings: []ibPosting{
-				{AccountType: "ACCOUNT", AccountNum: req.FromAccount, Amount: -req.Amount, AssetType: "MONAS", Currency: fromCurrencyCode},
-				{AccountType: "ACCOUNT", AccountNum: req.RecipientAccount, Amount: req.Amount, AssetType: "MONAS", Currency: fromCurrencyCode},
+				{Account: ibPostingAccount{Type: "ACCOUNT", Num: req.FromAccount}, Amount: -req.Amount, Asset: ibPostingAsset{Type: "MONAS", Body: &ibPostingAssetBody{Currency: fromCurrencyCode}}},
+				{Account: ibPostingAccount{Type: "ACCOUNT", Num: req.RecipientAccount}, Amount: req.Amount, Asset: ibPostingAsset{Type: "MONAS", Body: &ibPostingAssetBody{Currency: fromCurrencyCode}}},
 			},
 		},
 	})


### PR DESCRIPTION
## Summary
- Outgoing interbank postings were using flat fields (`accountType`, `accountNum`, `assetType`, `currency`) but the protocol requires nested objects
- Fixed format: `account.type`, `account.num`, `asset.type`, `asset.body.currency`
- Also renamed the inner asset JSON field from `"asset"` to `"body"` in otc-service to match the field name Banka 4 validates
- Root cause discovered by getting the raw 400 response body from Banka 4's `/interbank` endpoint

## Files changed
- `services/payment-service/handlers/interbank_outgoing.go` — new nested `ibPosting` struct + updated usages
- `services/payment-service/handlers/preview.go` — updated posting usages
- `services/otc-service/handlers/interbank_outgoing.go` — renamed `json:"asset"` → `json:"body"` in `ibOutAsset`

## Test plan
- [ ] Interbank payment to Banka 4 (routing 444) succeeds end-to-end
- [ ] Payment preview still works
- [ ] `go test ./services/payment-service/... ./services/otc-service/...` passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)