### PR TITLE
fix(interbank): use asset json tag for inner asset body field

### DIFF
--- a/services/otc-service/handlers/interbank_outgoing.go
+++ b/services/otc-service/handlers/interbank_outgoing.go
@@ -47,7 +47,7 @@ type ibOutAssetInner struct {
 }
 type ibOutAsset struct {
 	Type  string           `json:"type"`
-	Asset *ibOutAssetInner `json:"body,omitempty"`
+	Asset *ibOutAssetInner `json:"asset,omitempty"`
 }
 type ibOutPosting struct {
 	Account ibOutAccount `json:"account"`

--- a/services/payment-service/handlers/interbank_outgoing.go
+++ b/services/payment-service/handlers/interbank_outgoing.go
@@ -45,7 +45,7 @@ type ibPostingAssetBody struct {
 
 type ibPostingAsset struct {
 	Type string              `json:"type"`
-	Body *ibPostingAssetBody `json:"body,omitempty"`
+	Body *ibPostingAssetBody `json:"asset,omitempty"`
 }
 
 type ibPosting struct {


### PR DESCRIPTION
## Summary
- Partner bank expects `json:"asset"` for the inner asset body field, not `json:"body"`
- This matches what they send in their own outgoing postings (our inbound handler already used `json:"asset"`)
- Fixes 400 validation errors: `Asset.Body required` when making cross-bank payments

## Test plan
- [ ] Make a cross-bank payment to Banka 4 and verify it completes successfully
- [ ] Verify OTC interbank transactions also work

🤖 Generated with [Claude Code](https://claude.com/claude-code)