### PR TITLE
fix(otc-service): route seller-side interbank accept through 2PC

### DIFF
--- a/services/otc-service/handlers/grpc_server.go
+++ b/services/otc-service/handlers/grpc_server.go
@@ -491,6 +491,29 @@ func (s *OtcServer) AcceptNegotiation(ctx context.Context, req *pb.AcceptNegotia
 		return nil, status.Error(codes.InvalidArgument, "Seller does not have enough free shares")
 	}
 
+	// Cross-bank: we are the seller, buyer is on a partner bank.
+	// Commit ACCEPTED then run 2PC (NEW_TX) with the buyer's bank.
+	if buyerType == "INTERBANK" && isSeller {
+		now := time.Now()
+		if _, err = tx.ExecContext(ctx,
+			`UPDATE otc_negotiations
+			 SET status = 'ACCEPTED', last_modified = $1, modified_by_id = $2, modified_by_type = $3
+			 WHERE id = $4`,
+			now, req.CallerId, req.CallerType, req.NegotiationId,
+		); err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to accept negotiation: %v", err)
+		}
+		if err = tx.Commit(); err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to commit: %v", err)
+		}
+		if twopcErr := s.executeInterbankAcceptOutgoing(ctx, req.NegotiationId); twopcErr != nil {
+			_, _ = s.DB.ExecContext(context.Background(),
+				`UPDATE otc_negotiations SET status='PENDING_SELLER' WHERE id = $1`, req.NegotiationId)
+			return nil, status.Errorf(codes.Unavailable, "accept 2PC failed: %v", twopcErr)
+		}
+		return s.fetchNegotiationByID(ctx, req.NegotiationId)
+	}
+
 	// --- Buyer balance check ---
 	currencyID, ok := currencyIDMap[currency]
 	if !ok {


### PR DESCRIPTION
## Summary

- `AcceptNegotiation` only had a cross-bank branch for `sellerType == "INTERBANK" && isBuyer` (our user is buyer, partner is seller)
- When `buyerType == "INTERBANK" && isSeller` (our user is seller, partner bank is buyer), the handler was falling through to the local path — never calling the partner bank at all
- Fix: after the seller capacity check, detect this case and commit ACCEPTED then call `executeInterbankAcceptOutgoing` to run the 4-posting 2PC (premium + option transfer) with the buyer's bank

Also applied DB migrations directly to the cluster (cross-bank columns on `otc_negotiations` and the `otc_saga` table were missing from the live DB):
- `buyer_routing_number`, `buyer_external_id`, `seller_routing_number`, `seller_external_id`, `creator_routing_number`, `creator_external_id`, `partner_negotiation_id`, `buyer_account_number` added to `otc_negotiations`
- `otc_saga` table created

## Test plan

- [ ] Our seller accepts a negotiation where the buyer is from Banka 4 — should trigger the 2PC and return the updated negotiation
- [ ] CI passes for `otc-service`

🤖 Generated with [Claude Code](https://claude.com/claude-code)