### PR TITLE
fix(otc-service): fall back to any seller account when currency doesn't match

### DIFF
--- a/services/otc-service/handlers/grpc_server.go
+++ b/services/otc-service/handlers/grpc_server.go
@@ -545,10 +545,22 @@ func (s *OtcServer) AcceptNegotiation(ctx context.Context, req *pb.AcceptNegotia
 		return nil, status.Error(codes.InvalidArgument, "Insufficient funds for premium")
 	}
 
-	// --- Find seller account ---
+	// --- Find seller account (prefer contract currency, fall back to any active account with conversion) ---
 	sellerAccountID, err := findAccount(ctx, s.AccountDB, portfolioUserID(sellerID, sellerType), currencyID)
+	sellerPremiumToCredit := premium
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to find seller account: %v", err)
+		var sellerCurrencyID int64
+		fbErr := s.AccountDB.QueryRowContext(ctx,
+			`SELECT id, currency_id FROM accounts WHERE owner_id = $1 AND status = 'ACTIVE' LIMIT 1`,
+			portfolioUserID(sellerID, sellerType),
+		).Scan(&sellerAccountID, &sellerCurrencyID)
+		if fbErr != nil {
+			return nil, status.Errorf(codes.Internal, "failed to find seller account: %v", err)
+		}
+		sellerPremiumToCredit, err = convertAmount(ctx, s.ExchangeDB, premium, currencyID, sellerCurrencyID)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to convert seller premium: %v", err)
+		}
 	}
 
 	// --- Deduct buyer premium (with retry compensation on failure) ---
@@ -562,7 +574,7 @@ func (s *OtcServer) AcceptNegotiation(ctx context.Context, req *pb.AcceptNegotia
 	// --- Credit seller premium ---
 	if _, err = s.AccountDB.ExecContext(ctx,
 		`UPDATE accounts SET balance = balance + $1, available_balance = available_balance + $1 WHERE id = $2`,
-		premium, sellerAccountID,
+		sellerPremiumToCredit, sellerAccountID,
 	); err != nil {
 		retryExec(s.AccountDB,
 			`UPDATE accounts SET balance = balance + $1, available_balance = available_balance + $1 WHERE id = $2`,


### PR DESCRIPTION
## Summary

- `AcceptNegotiation` was looking for a seller account matching the contract currency exactly — if the seller had no account in that currency it returned 500
- Fix: when the exact-currency lookup fails, find any active account for the seller and convert the premium to that account's currency using the exchange rate DB

## Test plan

- [ ] Accept a negotiation where the seller has no account in the contract currency — should succeed with the premium credited in the seller's existing currency
- [ ] Accept a negotiation where seller has a matching-currency account — existing path unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)