### PR TITLE
fix(otc-service): fall back to any seller account in exercise saga step 3

### DIFF
--- a/services/otc-service/handlers/grpc_server.go
+++ b/services/otc-service/handlers/grpc_server.go
@@ -959,13 +959,31 @@ func (s *OtcServer) ExerciseContract(ctx context.Context, req *pb.ExerciseContra
 
 	// ── Step 3: Transfer funds ────────────────────────────────────────────────────
 	sellerAccountID, err := findAccount(ctx, s.AccountDB, portfolioUserID(sellerID, sellerType), currencyID)
+	sellerTotalCostToReceive := totalCost
 	if err != nil {
-		sagaLog(3, "FAILED", err.Error())
-		sagaStatus("Compensating", 3)
-		comp2()
-		comp1()
-		sagaStatus("Compensated", 3)
-		return nil, status.Errorf(codes.Internal, "step 3 failed finding seller account: %v", err)
+		// No account in contract currency — fall back to any active account with conversion.
+		var sellerCurrencyID int64
+		fbErr := s.AccountDB.QueryRowContext(ctx,
+			`SELECT id, currency_id FROM accounts WHERE owner_id = $1 AND status = 'ACTIVE' LIMIT 1`,
+			portfolioUserID(sellerID, sellerType),
+		).Scan(&sellerAccountID, &sellerCurrencyID)
+		if fbErr != nil {
+			sagaLog(3, "FAILED", err.Error())
+			sagaStatus("Compensating", 3)
+			comp2()
+			comp1()
+			sagaStatus("Compensated", 3)
+			return nil, status.Errorf(codes.Internal, "step 3 failed finding seller account: %v", err)
+		}
+		sellerTotalCostToReceive, err = convertAmount(ctx, s.ExchangeDB, totalCost, currencyID, sellerCurrencyID)
+		if err != nil {
+			sagaLog(3, "FAILED", err.Error())
+			sagaStatus("Compensating", 3)
+			comp2()
+			comp1()
+			sagaStatus("Compensated", 3)
+			return nil, status.Errorf(codes.Internal, "step 3 failed converting seller amount: %v", err)
+		}
 	}
 	if hookErr := sagaFaultHook(ctx, "F3", compensateFailCounts); hookErr != nil {
 		sagaLog(3, "FAILED", hookErr.Error())
@@ -988,7 +1006,7 @@ func (s *OtcServer) ExerciseContract(ctx context.Context, req *pb.ExerciseContra
 	}
 	if _, err = s.AccountDB.ExecContext(ctx,
 		`UPDATE accounts SET balance = balance + $1, available_balance = available_balance + $1 WHERE id = $2`,
-		totalCost, sellerAccountID,
+		sellerTotalCostToReceive, sellerAccountID,
 	); err != nil {
 		retryExec(s.AccountDB, `UPDATE accounts SET balance = balance + $1 WHERE id = $2`, totalCostToPay, buyerAccountID)
 		sagaLog(3, "FAILED", err.Error())
@@ -1009,7 +1027,7 @@ func (s *OtcServer) ExerciseContract(ctx context.Context, req *pb.ExerciseContra
 				continue
 			}
 			retryExec(s.AccountDB, `UPDATE accounts SET balance = balance + $1 WHERE id = $2`, totalCostToPay, buyerAccountID)
-			retryExec(s.AccountDB, `UPDATE accounts SET balance = balance - $1, available_balance = available_balance - $1 WHERE id = $2`, totalCost, sellerAccountID)
+			retryExec(s.AccountDB, `UPDATE accounts SET balance = balance - $1, available_balance = available_balance - $1 WHERE id = $2`, sellerTotalCostToReceive, sellerAccountID)
 			sagaLog(3, "COMPENSATED", "")
 			break
 		}


### PR DESCRIPTION
## Summary

- Same root cause as PR #282: seller has no account in the contract currency (e.g. USD contract, seller only has EUR)
- Exercise saga step 3 was calling `findAccount` with the contract `currencyID` — if no match, it returned 500 and compensated
- Fix: fall back to any active seller account and convert `totalCost` to that currency; `comp3` also uses the converted amount for the reversal

## Test plan

- [ ] Exercise OTC contract where seller has no account in the contract currency — should succeed with payment credited in seller's existing currency
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)