### PR TITLE
fix(otc): resolve buyer account with currency fallback and use exchan…

### DIFF
--- a/services/otc-service/handlers/grpc_server.go
+++ b/services/otc-service/handlers/grpc_server.go
@@ -1790,7 +1790,7 @@ func (s *OtcServer) CommitOtcInterbank(ctx context.Context, req *pb.OtcInterbank
 				if qErr := s.AccountDB.QueryRowContext(ctx,
 					`SELECT currency_id FROM accounts WHERE account_number = $1`, buyerAcctNum,
 				).Scan(&buyerAcctCurrencyID); qErr == nil {
-					if converted, convErr := convertAmount(s.ExchangeDB, premium, ncurrencyID, buyerAcctCurrencyID); convErr == nil {
+					if converted, convErr := convertAmount(ctx, s.ExchangeDB, premium, ncurrencyID, buyerAcctCurrencyID); convErr == nil {
 						premiumToPay = converted
 					}
 				}

--- a/services/otc-service/handlers/grpc_server.go
+++ b/services/otc-service/handlers/grpc_server.go
@@ -1783,11 +1783,22 @@ func (s *OtcServer) CommitOtcInterbank(ctx context.Context, req *pb.OtcInterbank
 			).Scan(&buyerAcctNum, &buyerID, &buyerType); err != nil {
 				return nil, status.Errorf(codes.Internal, "failed to load buyer info: %v", err)
 			}
-			// Debit buyer's account for premium.
+			// Debit buyer's account for premium, converting via exchange service if currencies differ.
+			premiumToPay := premium
+			if ncurrencyID, ok := currencyIDMap[currency]; ok {
+				var buyerAcctCurrencyID int64
+				if qErr := s.AccountDB.QueryRowContext(ctx,
+					`SELECT currency_id FROM accounts WHERE account_number = $1`, buyerAcctNum,
+				).Scan(&buyerAcctCurrencyID); qErr == nil {
+					if converted, convErr := convertAmount(s.ExchangeDB, premium, ncurrencyID, buyerAcctCurrencyID); convErr == nil {
+						premiumToPay = converted
+					}
+				}
+			}
 			_, _ = s.AccountDB.ExecContext(ctx,
 				`UPDATE accounts SET balance = balance - $1, available_balance = available_balance - $1
 				 WHERE account_number = $2 AND available_balance >= $1`,
-				premium, buyerAcctNum)
+				premiumToPay, buyerAcctNum)
 			// Create buyer-side contract (seller is INTERBANK).
 			_, _ = s.DB.ExecContext(ctx, `
 				INSERT INTO otc_contracts

--- a/services/otc-service/handlers/interbank_outgoing.go
+++ b/services/otc-service/handlers/interbank_outgoing.go
@@ -449,7 +449,7 @@ func (s *OtcServer) createNegotiationCrossBank(ctx context.Context, req *pb.Crea
 	// CommitOtcInterbank uses convertAmount (exchange service) to handle currency differences.
 	currencyID := currencyIDMap[req.Currency]
 	var buyerAccountNum string
-	if acctID, acctErr := findAccount(s.AccountDB, req.BuyerId, currencyID); acctErr == nil {
+	if acctID, acctErr := findAccount(ctx, s.AccountDB, req.BuyerId, currencyID); acctErr == nil {
 		_ = s.AccountDB.QueryRowContext(ctx,
 			`SELECT account_number FROM accounts WHERE id = $1`, acctID,
 		).Scan(&buyerAccountNum)

--- a/services/otc-service/handlers/interbank_outgoing.go
+++ b/services/otc-service/handlers/interbank_outgoing.go
@@ -444,13 +444,22 @@ func (s *OtcServer) createNegotiationCrossBank(ctx context.Context, req *pb.Crea
 		return nil, status.Errorf(codes.Internal, "cannot resolve seller bank: %v", err)
 	}
 
-	// Resolve buyer's settlement account for this currency so CommitOtcInterbank can debit it.
+	// Resolve buyer's settlement account so CommitOtcInterbank can debit it.
+	// Prefer an account in the negotiation's currency; fall back to any active account.
+	// CommitOtcInterbank uses convertAmount (exchange service) to handle currency differences.
 	currencyID := currencyIDMap[req.Currency]
 	var buyerAccountNum string
-	_ = s.AccountDB.QueryRowContext(ctx,
-		`SELECT account_number FROM accounts WHERE owner_id = $1 AND currency_id = $2 AND status = 'ACTIVE' LIMIT 1`,
-		req.BuyerId, currencyID,
-	).Scan(&buyerAccountNum)
+	if acctID, acctErr := findAccount(s.AccountDB, req.BuyerId, currencyID); acctErr == nil {
+		_ = s.AccountDB.QueryRowContext(ctx,
+			`SELECT account_number FROM accounts WHERE id = $1`, acctID,
+		).Scan(&buyerAccountNum)
+	}
+	if buyerAccountNum == "" {
+		_ = s.AccountDB.QueryRowContext(ctx,
+			`SELECT account_number FROM accounts WHERE owner_id = $1 AND status = 'ACTIVE' LIMIT 1`,
+			req.BuyerId,
+		).Scan(&buyerAccountNum)
+	}
 
 	now := time.Now()
 	var id int64


### PR DESCRIPTION
…ge service for premium debit

When a client creates a cross-bank negotiation for a partner bank's stock, the buyer may not have an account in that exact currency. Previously, the account lookup silently returned empty, causing the partner bank to reject the forwarded negotiation with 400 (missing buyerAccountNumber).

- createNegotiationCrossBank: try findAccount for exact currency first, fall back to any active account so buyerAccountNumber is always populated
- CommitOtcInterbank buyer-side: use convertAmount (exchange service) to convert the premium to the buyer account's actual currency before debiting, matching the pattern used in intrabank AcceptNegotiation