### PR TITLE
fix(otc): store partner negotiation ID as TEXT to support UUID partner banks

### DIFF
--- a/services/otc-service/db/schema.sql
+++ b/services/otc-service/db/schema.sql
@@ -73,6 +73,8 @@ ALTER TABLE otc_saga ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP NOT NULL DEFA
 
 -- Migration: partner_negotiation_id = lokalni ID pregovora na partner banci (za outgoing OPTION posting)
 ALTER TABLE otc_negotiations ADD COLUMN IF NOT EXISTS partner_negotiation_id BIGINT;
+-- Migration: partner banks (e.g. Banka 4) return UUID strings, not integers
+ALTER TABLE otc_negotiations ALTER COLUMN partner_negotiation_id TYPE TEXT USING partner_negotiation_id::TEXT;
 
 -- Tabela za tracking incoming cross-bank 2PC transakcija koje uključuju OPTION postinge
 CREATE TABLE IF NOT EXISTS otc_interbank_tx (

--- a/services/otc-service/handlers/grpc_server.go
+++ b/services/otc-service/handlers/grpc_server.go
@@ -252,6 +252,9 @@ func (s *OtcServer) CreateNegotiation(ctx context.Context, req *pb.CreateNegotia
 
 	isCrossBank := req.SellerRoutingNumber != 0 &&
 		fmt.Sprintf("%d", req.SellerRoutingNumber) != os.Getenv("OWN_ROUTING_NUMBER")
+	if isCrossBank && req.Premium <= 0 {
+		return nil, status.Error(codes.InvalidArgument, "premium must be positive for cross-bank negotiations")
+	}
 
 	if isCrossBank {
 		return s.createNegotiationCrossBank(ctx, req)

--- a/services/otc-service/handlers/interbank_outgoing.go
+++ b/services/otc-service/handlers/interbank_outgoing.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"strconv"
 	"time"
 
 	otcInterbank "github.com/RAF-SI-2025/EXBanka-4-Backend/services/otc-service/interbank"
@@ -80,7 +79,7 @@ type otcIbVoteResponse struct {
 
 type otcOutgoing2PCReq struct {
 	sellerExtID          string
-	partnerNegotiationID int64
+	partnerNegotiationID string
 	partnerRoutingNum    int // seller's bank routing number
 	stockAmount          int32
 	buyerAccountNum      string
@@ -153,7 +152,7 @@ func executeOtcOutgoing2PC(ctx context.Context, bank otcInterbank.BankInfo, req 
 				{ // OPTION contract receives money (seller's bank credits seller via escrow)
 					Account: ibOutAccount{Type: "OPTION", ID: &ibOutPartyID{
 						RoutingNumber: req.partnerRoutingNum,
-						ID:            fmt.Sprintf("%d", req.partnerNegotiationID),
+						ID:            req.partnerNegotiationID,
 					}},
 					Amount: req.totalCost,
 					Asset:  ibOutAsset{Type: "MONAS", Asset: &ibOutAssetInner{Currency: req.currency}},
@@ -161,7 +160,7 @@ func executeOtcOutgoing2PC(ctx context.Context, bank otcInterbank.BankInfo, req 
 				{ // OPTION contract gives shares
 					Account: ibOutAccount{Type: "OPTION", ID: &ibOutPartyID{
 						RoutingNumber: req.partnerRoutingNum,
-						ID:            fmt.Sprintf("%d", req.partnerNegotiationID),
+						ID:            req.partnerNegotiationID,
 					}},
 					Amount: -float64(req.stockAmount),
 					Asset:  ibOutAsset{Type: "STOCK", Asset: &ibOutAssetInner{Ticker: req.ticker}},
@@ -239,17 +238,17 @@ func (s *OtcServer) exerciseCrossBank(
 
 	// Lookup routing info from the negotiation linked to this contract.
 	var sellerRoutingNum int32
-	var partnerNegotiationID int64
+	var partnerNegotiationID string
 	var sellerExtID string
 	err := s.DB.QueryRowContext(ctx, `
 		SELECT COALESCE(n.seller_routing_number, 0),
-		       COALESCE(n.partner_negotiation_id, 0),
+		       COALESCE(n.partner_negotiation_id, ''),
 		       COALESCE(n.seller_external_id, '')
 		FROM otc_negotiations n
 		JOIN otc_contracts c ON c.negotiation_id = n.id
 		WHERE c.id = $1`, req.ContractId,
 	).Scan(&sellerRoutingNum, &partnerNegotiationID, &sellerExtID)
-	if err != nil || sellerRoutingNum == 0 || partnerNegotiationID == 0 {
+	if err != nil || sellerRoutingNum == 0 || partnerNegotiationID == "" {
 		return nil, status.Error(codes.Internal,
 			"cross-bank exercise requires seller_routing_number and partner_negotiation_id (populated by outgoing negotiation flow)")
 	}
@@ -371,7 +370,7 @@ func (s *OtcServer) forwardNegotiationToPartner(
 	bank otcInterbank.BankInfo,
 	req *pb.CreateNegotiationRequest,
 	buyerAccountNum string,
-) (int64, error) {
+) (string, error) {
 	type partyID struct {
 		RoutingNumber int    `json:"routingNumber"`
 		ID            string `json:"id"`
@@ -411,30 +410,26 @@ func (s *OtcServer) forwardNegotiationToPartner(
 	data, _ := json.Marshal(b)
 	httpReq, err := http.NewRequest(http.MethodPost, bank.BankURL+"/negotiations", bytes.NewReader(data))
 	if err != nil {
-		return 0, fmt.Errorf("create request: %w", err)
+		return "", fmt.Errorf("create request: %w", err)
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("X-Api-Key", bank.APIKey)
 	resp, err := (&http.Client{Timeout: 10 * time.Second}).Do(httpReq)
 	if err != nil {
-		return 0, fmt.Errorf("http call failed: %w", err)
+		return "", fmt.Errorf("http call failed: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
-		return 0, fmt.Errorf("partner returned status %d", resp.StatusCode)
+		return "", fmt.Errorf("partner returned status %d", resp.StatusCode)
 	}
 	var result struct {
 		RoutingNumber int32  `json:"routingNumber"`
 		ID            string `json:"id"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return 0, fmt.Errorf("decode: %w", err)
+		return "", fmt.Errorf("decode: %w", err)
 	}
-	id, err := strconv.ParseInt(result.ID, 10, 64)
-	if err != nil {
-		return 0, fmt.Errorf("parse partner negotiation id: %w", err)
-	}
-	return id, nil
+	return result.ID, nil
 }
 
 // createNegotiationCrossBank handles CreateNegotiation when the seller is on a partner bank.
@@ -513,11 +508,11 @@ func (s *OtcServer) acceptCrossBank(
 	negotiationID int64,
 ) (*pb.NegotiationResponse, error) {
 	var sellerRoutingNum int32
-	var partnerNegotiationID int64
+	var partnerNegotiationID string
 	if err := s.DB.QueryRowContext(ctx,
-		`SELECT COALESCE(seller_routing_number, 0), COALESCE(partner_negotiation_id, 0)
+		`SELECT COALESCE(seller_routing_number, 0), COALESCE(partner_negotiation_id, '')
 		 FROM otc_negotiations WHERE id = $1`, negotiationID,
-	).Scan(&sellerRoutingNum, &partnerNegotiationID); err != nil || sellerRoutingNum == 0 {
+	).Scan(&sellerRoutingNum, &partnerNegotiationID); err != nil || sellerRoutingNum == 0 || partnerNegotiationID == "" {
 		return nil, status.Error(codes.Internal, "cross-bank accept: missing seller routing info")
 	}
 	bank, err := otcInterbank.ResolveBankByRoutingNumber(fmt.Sprintf("%d", sellerRoutingNum))
@@ -539,7 +534,7 @@ func (s *OtcServer) acceptCrossBank(
 
 	// Call Banka 4's accept endpoint. Banka 4 will synchronously send us a NEW_TX→COMMIT_TX
 	// via /interbank, which creates the contract and debits buyer in CommitOtcInterbank.
-	acceptURL := fmt.Sprintf("%s/negotiations/%d/%d/accept",
+	acceptURL := fmt.Sprintf("%s/negotiations/%d/%s/accept",
 		bank.BankURL, sellerRoutingNum, partnerNegotiationID)
 	acceptReq, _ := http.NewRequestWithContext(ctx, http.MethodGet, acceptURL, nil)
 	acceptReq.Header.Set("X-Api-Key", bank.APIKey)

--- a/services/otc-service/handlers/interbank_outgoing_test.go
+++ b/services/otc-service/handlers/interbank_outgoing_test.go
@@ -100,7 +100,7 @@ func TestForwardNegotiationToPartner_Happy(t *testing.T) {
 
 	partnerID, err := s.forwardNegotiationToPartner(bank, req, "")
 	require.NoError(t, err)
-	assert.Equal(t, int64(42), partnerID)
+	assert.Equal(t, "42", partnerID)
 }
 
 func TestForwardNegotiationToPartner_BadStatus(t *testing.T) {
@@ -155,12 +155,12 @@ func TestForwardNegotiationToPartner_NonNumericID(t *testing.T) {
 	s, _, _, _, _, _, _ := newTestServer(t)
 	bank, _ := otcInterbank.ResolveBankByRoutingNumber("999")
 
-	_, err := s.forwardNegotiationToPartner(bank, &pb.CreateNegotiationRequest{
+	id, err := s.forwardNegotiationToPartner(bank, &pb.CreateNegotiationRequest{
 		Ticker: "AAPL", Amount: 10, PricePerStock: 100.0,
 		SettlementDate: "2027-01-01", Currency: "RSD",
 	}, "")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "parse")
+	assert.NoError(t, err)
+	assert.Equal(t, "not-a-number", id)
 }
 
 // ─── createNegotiationCrossBank ────────────────────────────────────────────
@@ -295,7 +295,7 @@ func TestCreateNegotiation_CrossBankBranch(t *testing.T) {
 
 	resp, err := s.CreateNegotiation(context.Background(), &pb.CreateNegotiationRequest{
 		Ticker: "AAPL", Amount: 10, PricePerStock: 100.0,
-		SettlementDate: "2027-01-01", Premium: 0.0, Currency: "RSD",
+		SettlementDate: "2027-01-01", Premium: 5.0, Currency: "RSD",
 		BuyerId: 20, BuyerType: "CLIENT",
 		SellerRoutingNumber: 999, // triggers cross-bank branch
 		SellerExternalId:    "ext-seller-1",
@@ -369,7 +369,7 @@ func TestAcceptNegotiation_CrossBank_NoPremium_Happy(t *testing.T) {
 	// --- acceptCrossBank: routing info (2 cols now — no seller_external_id) ---
 	mainMock.ExpectQuery("SELECT COALESCE.*seller_routing_number").
 		WillReturnRows(sqlmock.NewRows([]string{"seller_routing_number", "partner_negotiation_id"}).
-			AddRow(int32(999), int64(42)))
+			AddRow(int32(999), "42"))
 
 	// --- Commit ACCEPTED status BEFORE calling partner ---
 	mainMock.ExpectExec("UPDATE otc_negotiations SET status='ACCEPTED'").
@@ -410,7 +410,7 @@ func TestAcceptNegotiation_CrossBank_WithPremium_Happy(t *testing.T) {
 
 	mainMock.ExpectQuery("SELECT COALESCE.*seller_routing_number").
 		WillReturnRows(sqlmock.NewRows([]string{"seller_routing_number", "partner_negotiation_id"}).
-			AddRow(int32(999), int64(42)))
+			AddRow(int32(999), "42"))
 
 	mainMock.ExpectExec("UPDATE otc_negotiations SET status='ACCEPTED'").
 		WillReturnResult(sqlmock.NewResult(1, 1))
@@ -437,7 +437,7 @@ func TestAcceptNegotiation_CrossBank_MissingRoutingInfo(t *testing.T) {
 	// routing info query: seller_routing_number = 0 → error path
 	mainMock.ExpectQuery("SELECT COALESCE.*seller_routing_number").
 		WillReturnRows(sqlmock.NewRows([]string{"seller_routing_number", "partner_negotiation_id"}).
-			AddRow(int32(0), int64(0)))
+			AddRow(int32(0), ""))
 	mainMock.ExpectRollback()
 
 	_, err := s.AcceptNegotiation(context.Background(), &pb.AcceptNegotiationRequest{
@@ -461,7 +461,7 @@ func TestAcceptNegotiation_CrossBank_PartnerAcceptFails(t *testing.T) {
 		WillReturnRows(acceptNegRowCrossBank(20, "CLIENT", "PENDING_BUYER", 0.0))
 	mainMock.ExpectQuery("SELECT COALESCE.*seller_routing_number").
 		WillReturnRows(sqlmock.NewRows([]string{"seller_routing_number", "partner_negotiation_id"}).
-			AddRow(int32(999), int64(42)))
+			AddRow(int32(999), "42"))
 	// New flow: commit ACCEPTED first, then call partner; on failure revert to PENDING_BUYER
 	mainMock.ExpectExec("UPDATE otc_negotiations SET status='ACCEPTED'").
 		WillReturnResult(sqlmock.NewResult(1, 1))
@@ -502,7 +502,7 @@ func TestOtcExercise2PC_OptionAmountIsNegative(t *testing.T) {
 	bank, _ := otcInterbank.ResolveBankByRoutingNumber("999")
 	_, _ = executeOtcOutgoing2PC(context.Background(), bank, otcOutgoing2PCReq{
 		sellerExtID:          "ext-1",
-		partnerNegotiationID: 42,
+		partnerNegotiationID: "42",
 		partnerRoutingNum:    999,
 		stockAmount:          100,
 		buyerAccountNum:      "ACC-1",


### PR DESCRIPTION
## Summary

- Banka 4's interbank-service returns UUID strings for negotiation IDs, but `partner_negotiation_id` was stored as `BIGINT` and parsed with `strconv.ParseInt` — causing every cross-bank negotiation creation to return 500
- The missing UUID also caused accept calls to hit `.../negotiations/444/0/accept` (wrong ID), returning 401
- Added validation: `premium > 0` is required for cross-bank negotiations (Banka 4's `binding:"required"` rejects `0`)

## Changes

- `db/schema.sql`: migrate `partner_negotiation_id` from `BIGINT` to `TEXT`
- `handlers/interbank_outgoing.go`: change all `int64` references to `string`, remove `strconv.ParseInt`, fix accept URL `%d` → `%s`
- `handlers/grpc_server.go`: add premium > 0 validation for cross-bank path
- `handlers/interbank_outgoing_test.go`: update tests to expect string IDs and non-zero premium

## Test plan

- [ ] `go test ./services/otc-service/...` passes (verified locally)
- [ ] `POST /otc/negotiations` for a Banka 4 stock returns 201 instead of 500
- [ ] Accepting a negotiation no longer returns 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)