### PR TITLE
fix(payment): correct 2PC local debit in outgoing interbank transfer

### DIFF
--- a/services/payment-service/handlers/interbank_outgoing.go
+++ b/services/payment-service/handlers/interbank_outgoing.go
@@ -299,13 +299,15 @@ func executeOutgoing2PC(ctx context.Context, s *PaymentServer, req *pb.CreatePay
 
 	// DB tx #2: apply debit now that partner committed.
 	// Use a detached context — partner has already credited the recipient so this MUST complete.
+	// Only balance is reduced here; available_balance was already reduced during reservation.
 	commitCtx, commitCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer commitCancel()
-	_, _ = s.AccountDB.ExecContext(commitCtx, `
+	if _, err := s.AccountDB.ExecContext(commitCtx, `
 		UPDATE accounts SET
-			balance           = balance - $1,
-			available_balance = available_balance + $1
-		WHERE id = $2`, req.Amount, fromID)
+			balance = balance - $1
+		WHERE id = $2`, req.Amount, fromID); err != nil {
+		return nil, status.Errorf(codes.Internal, "apply local debit after partner commit: %v", err)
+	}
 
 	// Persist payment record.
 	orderNumber := fmt.Sprintf("ORD-%d-%s", time.Now().UnixMilli(), generateUUID()[:8])


### PR DESCRIPTION
Commit step was restoring available_balance (+amount) while deducting balance (-amount), leaving available_balance > balance after a transfer. Since available_balance is already reduced during the reservation phase, only balance needs to be deducted at commit time.

Also surfaces the error instead of silently discarding it — a failed UPDATE was leaving the reservation stuck indefinitely with no trace.