### PR TITLE
fix(otc): strip time component from settlement date before inserting …

### DIFF
--- a/services/api-gateway/handlers/otc_interbank.go
+++ b/services/api-gateway/handlers/otc_interbank.go
@@ -23,12 +23,6 @@ func gatewayOwnRoutingInt() int32 {
 	return n
 }
 
-func gatewayPartnerRoutingInt() int32 {
-	var n int32
-	_, _ = fmt.Sscanf(os.Getenv("PARTNER_ROUTING_NUMBER"), "%d", &n)
-	return n
-}
-
 // validateOtcInterbankKey rejects requests whose X-Api-Key does not match OWN_INTERBANK_API_KEY.
 func validateOtcInterbankKey(c *gin.Context) bool {
 	key := os.Getenv("OWN_INTERBANK_API_KEY")
@@ -111,85 +105,32 @@ func IncomingCreateNegotiation(otcClient pb.OtcServiceClient) gin.HandlerFunc {
 			return
 		}
 
-		// Accept both nested format (stock.ticker, pricePerUnit, premium as object) and
-		// the flat format some partner banks send (ticker, pricePerStock, premium as number).
-		var raw struct {
-			Stock struct {
-				Ticker string `json:"ticker"`
-			} `json:"stock"`
-			Ticker             string         `json:"ticker"`
-			SellerID           otcPartyID     `json:"sellerId"`
-			BuyerID            *otcPartyID    `json:"buyerId"`
-			Amount             int32          `json:"amount"`
-			PricePerUnit       otcMoneyAmount `json:"pricePerUnit"`
-			PricePerStock      float64        `json:"pricePerStock"`
-			PriceCurrency      string         `json:"priceCurrency"`
-			Premium            float64        `json:"premium"`
-			PremiumCurrency    string         `json:"premiumCurrency"`
-			AccountNumber      string         `json:"accountNumber"`
-			BuyerAccountNumber string         `json:"buyerAccountNumber"`
-			SettlementDate     string         `json:"settlementDate"`
-			SellerType         string         `json:"sellerType"`
-			LastModifiedBy     *otcPartyID    `json:"lastModifiedBy"`
-		}
-		if err := c.ShouldBindJSON(&raw); err != nil {
+		var body otcNegotiationBody
+		if err := c.ShouldBindJSON(&body); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body: " + err.Error()})
 			return
-		}
-
-		// Reconcile flat vs nested fields.
-		ticker := raw.Stock.Ticker
-		if ticker == "" {
-			ticker = raw.Ticker
-		}
-		pricePerUnit := raw.PricePerUnit.Amount
-		if pricePerUnit == 0 {
-			pricePerUnit = raw.PricePerStock
-		}
-		priceCurrency := raw.PricePerUnit.Currency
-		if priceCurrency == "" {
-			priceCurrency = raw.PriceCurrency
-		}
-		// Prefer the premium currency if explicitly set; proto uses one currency for both.
-		if raw.PremiumCurrency != "" {
-			priceCurrency = raw.PremiumCurrency
-		}
-		buyerAccountNum := raw.BuyerAccountNumber
-		if buyerAccountNum == "" {
-			buyerAccountNum = raw.AccountNumber
-		}
-
-		// If the partner did not send a buyerId, they ARE the buyer — derive from env.
-		var buyerRouting int32
-		var buyerExtID string
-		if raw.BuyerID != nil {
-			buyerRouting = raw.BuyerID.RoutingNumber
-			buyerExtID = raw.BuyerID.ID
-		} else {
-			buyerRouting = gatewayPartnerRoutingInt()
-			buyerExtID = raw.SellerID.ID // partner's local seller id doubles as creator key
 		}
 
 		ctx, cancel := context.WithTimeout(c.Request.Context(), 10*time.Second)
 		defer cancel()
 
-		md := metadata.Pairs("buyer-account-number", buyerAccountNum)
+		md := metadata.Pairs("buyer-account-number", body.BuyerAccountNumber)
 		ctx = metadata.NewOutgoingContext(ctx, md)
 
 		resp, err := otcClient.CreateInterbankNegotiation(ctx, &pb.CreateInterbankNegotiationRequest{
-			Ticker:               ticker,
-			SettlementDate:       raw.SettlementDate,
-			PricePerUnit:         pricePerUnit,
-			PriceCurrency:        priceCurrency,
-			Premium:              raw.Premium,
-			BuyerRoutingNumber:   buyerRouting,
-			BuyerExternalId:      buyerExtID,
-			SellerRoutingNumber:  raw.SellerID.RoutingNumber,
-			SellerExternalId:     raw.SellerID.ID,
-			CreatorRoutingNumber: buyerRouting,
-			CreatorExternalId:    buyerExtID,
-			Amount:               raw.Amount,
-			SellerType:           raw.SellerType,
+			Ticker:               body.Stock.Ticker,
+			SettlementDate:       body.SettlementDate,
+			PricePerUnit:         body.PricePerUnit.Amount,
+			PriceCurrency:        body.PricePerUnit.Currency,
+			Premium:              body.Premium.Amount,
+			BuyerRoutingNumber:   body.BuyerID.RoutingNumber,
+			BuyerExternalId:      body.BuyerID.ID,
+			SellerRoutingNumber:  body.SellerID.RoutingNumber,
+			SellerExternalId:     body.SellerID.ID,
+			CreatorRoutingNumber: body.BuyerID.RoutingNumber,
+			CreatorExternalId:    body.BuyerID.ID,
+			Amount:               body.Amount,
+			SellerType:           body.SellerType,
 		})
 		if err != nil {
 			mapOtcInterbankError(c, err)

--- a/services/otc-service/handlers/grpc_server.go
+++ b/services/otc-service/handlers/grpc_server.go
@@ -15,6 +15,15 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+// settleDateOnly strips any time component from a date string so it is safe to
+// insert into a PostgreSQL DATE column (partner banks may send "2026-06-17T00:00:00Z").
+func settleDateOnly(s string) string {
+	if len(s) > 10 {
+		return s[:10]
+	}
+	return s
+}
+
 // retryExec retries a DB Exec up to 3 times with linear backoff.
 // Uses db.Exec (not ExecContext) so it survives a cancelled request context (e.g. during compensation).
 func retryExec(db *sql.DB, query string, args ...interface{}) {
@@ -1426,7 +1435,7 @@ func (s *OtcServer) CreateInterbankNegotiation(ctx context.Context, req *pb.Crea
 		        $10, $11, $12, $13, $14, $15, $16)
 		RETURNING id`,
 		req.Ticker, sellerID, sellerType,
-		req.Amount, req.PricePerUnit, req.SettlementDate, req.Premium, req.PriceCurrency,
+		req.Amount, req.PricePerUnit, settleDateOnly(req.SettlementDate), req.Premium, req.PriceCurrency,
 		now,
 		req.BuyerRoutingNumber, req.BuyerExternalId,
 		req.SellerRoutingNumber, req.SellerExternalId,
@@ -1459,7 +1468,7 @@ func (s *OtcServer) InterbankCounterOffer(ctx context.Context, req *pb.Interbank
 		SET amount = $1, price_per_stock = $2, settlement_date = $3, premium = $4,
 		    last_modified = $5, modified_by_id = 0, modified_by_type = 'INTERBANK', status = 'PENDING_SELLER'
 		WHERE id = $6`,
-		req.Amount, req.PricePerUnit, req.SettlementDate, req.Premium,
+		req.Amount, req.PricePerUnit, settleDateOnly(req.SettlementDate), req.Premium,
 		now, localID,
 	); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to update negotiation: %v", err)


### PR DESCRIPTION
…into DATE column

Partner banks send settlementDate as a full timestamp (e.g. "2026-06-17T00:00:00Z") which PostgreSQL rejects for DATE columns. Added settleDateOnly() helper to truncate to YYYY-MM-DD in both CreateInterbankNegotiation and InterbankCounterOffer.

Also reverts IncomingCreateNegotiation to the simple otcNegotiationBody form — the partner bank uses the standard nested OtcOffer format, not a flat one.