### PR TITLE
fix(otc): remove over-broad idempotency check in CreateInterbankNegot…

### DIFF
--- a/services/otc-service/handlers/grpc_server.go
+++ b/services/otc-service/handlers/grpc_server.go
@@ -1415,11 +1415,6 @@ func (s *OtcServer) CreateInterbankNegotiation(ctx context.Context, req *pb.Crea
 		}
 	}
 
-	// Idempotency: return existing row if this creator key already exists
-	if existingID, _, err := s.lookupInterbankNegotiation(ctx, req.CreatorRoutingNumber, req.CreatorExternalId); err == nil {
-		return s.fetchInterbankNegotiationByID(ctx, existingID)
-	}
-
 	now := time.Now()
 	var id int64
 	err := s.DB.QueryRowContext(ctx, `


### PR DESCRIPTION
…iation

The idempotency guard keyed only on (creator_routing_number, creator_external_id), which is the buyer's identity. Every subsequent negotiation from the same partner-bank buyer hit the guard and received the same existing negotiation ID instead of a new one. This caused the partner bank to see duplicate IDs, their upsert fix then silently overwrote their local record, and the new negotiation never appeared on EXBanka's side.