### PR TITLE
fix(otc): fix UUID negotiation ID in 2PC accept and improve error dia…

### DIFF
--- a/services/api-gateway/handlers/interbank.go
+++ b/services/api-gateway/handlers/interbank.go
@@ -127,27 +127,31 @@ func handleNewTx(c *gin.Context, client pb.PaymentServiceClient, otcClient pb_ot
 	if exercisePosting != nil || acceptPosting != nil {
 		// OTC transaction — skip payment service entirely.
 		var negID int64
+		var partnerNegExternalID string
 		var stockAmt int32
 		var isAccept bool
 		if acceptPosting != nil {
 			if acceptPosting.Asset.Asset != nil && acceptPosting.Asset.Asset.NegotiationID != nil {
-				negID, _ = strconv.ParseInt(acceptPosting.Asset.Asset.NegotiationID.ID, 10, 64)
+				partnerNegExternalID = acceptPosting.Asset.Asset.NegotiationID.ID
+				negID, _ = strconv.ParseInt(partnerNegExternalID, 10, 64)
 			}
 			stockAmt = 1
 			isAccept = true
 		} else {
-			negID, _ = strconv.ParseInt(exercisePosting.Account.ID.ID, 10, 64)
+			partnerNegExternalID = exercisePosting.Account.ID.ID
+			negID, _ = strconv.ParseInt(partnerNegExternalID, 10, 64)
 			stockAmt = int32(math.Abs(exercisePosting.Amount))
 			isAccept = false
 		}
 		otcResp, otcErr := otcClient.PrepareOtcInterbank(ctx, &pb_otc.OtcInterbankPrepareRequest{
-			IdemRoutingNumber: fmt.Sprintf("%d", env.IdempotenceKey.RoutingNumber),
-			IdemKey:           env.IdempotenceKey.LocallyGeneratedKey,
-			TxRoutingNumber:   fmt.Sprintf("%d", msg.TransactionId.RoutingNumber),
-			TxId:              msg.TransactionId.ID,
-			NegotiationId:     negID,
-			StockAmount:       stockAmt,
-			IsAccept:          isAccept,
+			IdemRoutingNumber:    fmt.Sprintf("%d", env.IdempotenceKey.RoutingNumber),
+			IdemKey:              env.IdempotenceKey.LocallyGeneratedKey,
+			TxRoutingNumber:      fmt.Sprintf("%d", msg.TransactionId.RoutingNumber),
+			TxId:                 msg.TransactionId.ID,
+			NegotiationId:        negID,
+			StockAmount:          stockAmt,
+			IsAccept:             isAccept,
+			PartnerNegExternalId: partnerNegExternalID,
 		})
 		vote := "NO"
 		reason := ""

--- a/services/otc-service/handlers/grpc_server.go
+++ b/services/otc-service/handlers/grpc_server.go
@@ -1638,10 +1638,15 @@ func (s *OtcServer) PrepareOtcInterbank(ctx context.Context, req *pb.OtcInterban
 		partnerRouting := os.Getenv("PARTNER_ROUTING_NUMBER")
 		if req.IdemRoutingNumber == partnerRouting {
 			partnerRoutingInt, _ := strconv.ParseInt(partnerRouting, 10, 64)
+			// Use the raw string ID when available (handles UUID IDs from partner bank).
+			partnerNegLookupID := req.PartnerNegExternalId
+			if partnerNegLookupID == "" {
+				partnerNegLookupID = fmt.Sprintf("%d", req.NegotiationId)
+			}
 			var localNegID int64
 			if lookupErr := s.DB.QueryRowContext(ctx,
 				`SELECT id FROM otc_negotiations WHERE partner_negotiation_id = $1 AND seller_routing_number = $2`,
-				req.NegotiationId, partnerRoutingInt,
+				partnerNegLookupID, partnerRoutingInt,
 			).Scan(&localNegID); lookupErr == sql.ErrNoRows {
 				s.insertOtcInterbankTx(ctx, req, req.NegotiationId, "NO")
 				return &pb.OtcInterbankVoteResponse{Vote: "NO", Reason: "OPTION_NEGOTIATION_NOT_FOUND"}, nil

--- a/services/otc-service/handlers/grpc_server_test.go
+++ b/services/otc-service/handlers/grpc_server_test.go
@@ -323,7 +323,7 @@ func TestCounterOffer_Happy(t *testing.T) {
 	addFetchNegotiationRows(mainMock, empMock, clientMock, 1, 10, 20, "EMPLOYEE", "CLIENT", "PENDING_BUYER")
 	resp, err := s.CounterOffer(context.Background(), &pb.CounterOfferRequest{
 		NegotiationId: 1, CallerId: 10, CallerType: "EMPLOYEE",
-		Amount: 90, PricePerStock: 155.0, SettlementDate: "2026-06-15",
+		Amount: 90, PricePerStock: 155.0, SettlementDate: "2027-06-15",
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "PENDING_BUYER", resp.Status)
@@ -1079,7 +1079,7 @@ func TestCounterOffer_UpdateFails(t *testing.T) {
 	mainMock.ExpectRollback()
 	_, err := s.CounterOffer(context.Background(), &pb.CounterOfferRequest{
 		NegotiationId: 1, CallerId: 10, CallerType: "EMPLOYEE",
-		Amount: 90, PricePerStock: 155.0, SettlementDate: "2026-06-15",
+		Amount: 90, PricePerStock: 155.0, SettlementDate: "2027-06-15",
 	})
 	assert.Equal(t, codes.Internal, status.Code(err))
 }

--- a/services/otc-service/handlers/interbank_outgoing.go
+++ b/services/otc-service/handlers/interbank_outgoing.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"time"
@@ -739,14 +740,15 @@ func (s *OtcServer) executeInterbankAcceptOutgoing(ctx context.Context, localNeg
 	}
 	defer func() { _ = resp.Body.Close() }()
 
+	rawBody, _ := io.ReadAll(resp.Body)
 	var vote otcIbVoteResponse
-	if jsonErr := json.NewDecoder(resp.Body).Decode(&vote); jsonErr != nil || vote.Vote != "YES" {
+	if jsonErr := json.Unmarshal(rawBody, &vote); jsonErr != nil || vote.Vote != "YES" {
 		_, _ = otcSendInterbankRequest(ctx, bankURL, bank.APIKey, otcIbEnvelope{
 			IdempotenceKey: otcIbIdempotenceKey{RoutingNumber: ownRouting, LocallyGeneratedKey: otcGenerateUUID()},
 			MessageType:    "ROLLBACK_TX",
 			Message:        otcIbCommitMessage{TransactionID: txID},
 		})
-		return fmt.Errorf("buyer bank voted NO or decode error")
+		return fmt.Errorf("buyer bank voted NO (status=%d body=%s)", resp.StatusCode, string(rawBody))
 	}
 
 	// YES: reserve seller shares and create seller-side contract.

--- a/shared/pb/otc/otc.pb.go
+++ b/shared/pb/otc/otc.pb.go
@@ -1850,16 +1850,17 @@ func (x *InterbankCounterOfferRequest) GetSettlementDate() string {
 }
 
 type OtcInterbankPrepareRequest struct {
-	state             protoimpl.MessageState `protogen:"open.v1"`
-	IdemRoutingNumber string                 `protobuf:"bytes,1,opt,name=idem_routing_number,json=idemRoutingNumber,proto3" json:"idem_routing_number,omitempty"`
-	IdemKey           string                 `protobuf:"bytes,2,opt,name=idem_key,json=idemKey,proto3" json:"idem_key,omitempty"`
-	TxRoutingNumber   string                 `protobuf:"bytes,3,opt,name=tx_routing_number,json=txRoutingNumber,proto3" json:"tx_routing_number,omitempty"`
-	TxId              string                 `protobuf:"bytes,4,opt,name=tx_id,json=txId,proto3" json:"tx_id,omitempty"`
-	NegotiationId     int64                  `protobuf:"varint,5,opt,name=negotiation_id,json=negotiationId,proto3" json:"negotiation_id,omitempty"`
-	StockAmount       int32                  `protobuf:"varint,6,opt,name=stock_amount,json=stockAmount,proto3" json:"stock_amount,omitempty"`
-	IsAccept          bool                   `protobuf:"varint,7,opt,name=is_accept,json=isAccept,proto3" json:"is_accept,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	state                protoimpl.MessageState `protogen:"open.v1"`
+	IdemRoutingNumber    string                 `protobuf:"bytes,1,opt,name=idem_routing_number,json=idemRoutingNumber,proto3" json:"idem_routing_number,omitempty"`
+	IdemKey              string                 `protobuf:"bytes,2,opt,name=idem_key,json=idemKey,proto3" json:"idem_key,omitempty"`
+	TxRoutingNumber      string                 `protobuf:"bytes,3,opt,name=tx_routing_number,json=txRoutingNumber,proto3" json:"tx_routing_number,omitempty"`
+	TxId                 string                 `protobuf:"bytes,4,opt,name=tx_id,json=txId,proto3" json:"tx_id,omitempty"`
+	NegotiationId        int64                  `protobuf:"varint,5,opt,name=negotiation_id,json=negotiationId,proto3" json:"negotiation_id,omitempty"`
+	StockAmount          int32                  `protobuf:"varint,6,opt,name=stock_amount,json=stockAmount,proto3" json:"stock_amount,omitempty"`
+	IsAccept             bool                   `protobuf:"varint,7,opt,name=is_accept,json=isAccept,proto3" json:"is_accept,omitempty"`
+	PartnerNegExternalId string                 `protobuf:"bytes,8,opt,name=partner_neg_external_id,json=partnerNegExternalId,proto3" json:"partner_neg_external_id,omitempty"` // raw string neg ID from partner bank (UUID or int string)
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *OtcInterbankPrepareRequest) Reset() {
@@ -1939,6 +1940,13 @@ func (x *OtcInterbankPrepareRequest) GetIsAccept() bool {
 		return x.IsAccept
 	}
 	return false
+}
+
+func (x *OtcInterbankPrepareRequest) GetPartnerNegExternalId() string {
+	if x != nil {
+		return x.PartnerNegExternalId
+	}
+	return ""
 }
 
 type OtcInterbankVoteResponse struct {
@@ -2231,7 +2239,7 @@ const file_otc_proto_rawDesc = "" +
 	"\x0eprice_per_unit\x18\x03 \x01(\x01R\fpricePerUnit\x12\x18\n" +
 	"\apremium\x18\x04 \x01(\x01R\apremium\x12\x16\n" +
 	"\x06amount\x18\x05 \x01(\x05R\x06amount\x12'\n" +
-	"\x0fsettlement_date\x18\x06 \x01(\tR\x0esettlementDate\"\x8f\x02\n" +
+	"\x0fsettlement_date\x18\x06 \x01(\tR\x0esettlementDate\"\xc6\x02\n" +
 	"\x1aOtcInterbankPrepareRequest\x12.\n" +
 	"\x13idem_routing_number\x18\x01 \x01(\tR\x11idemRoutingNumber\x12\x19\n" +
 	"\bidem_key\x18\x02 \x01(\tR\aidemKey\x12*\n" +
@@ -2239,7 +2247,8 @@ const file_otc_proto_rawDesc = "" +
 	"\x05tx_id\x18\x04 \x01(\tR\x04txId\x12%\n" +
 	"\x0enegotiation_id\x18\x05 \x01(\x03R\rnegotiationId\x12!\n" +
 	"\fstock_amount\x18\x06 \x01(\x05R\vstockAmount\x12\x1b\n" +
-	"\tis_accept\x18\a \x01(\bR\bisAccept\"F\n" +
+	"\tis_accept\x18\a \x01(\bR\bisAccept\x125\n" +
+	"\x17partner_neg_external_id\x18\b \x01(\tR\x14partnerNegExternalId\"F\n" +
 	"\x18OtcInterbankVoteResponse\x12\x12\n" +
 	"\x04vote\x18\x01 \x01(\tR\x04vote\x12\x16\n" +
 	"\x06reason\x18\x02 \x01(\tR\x06reason\"X\n" +

--- a/shared/proto/otc.proto
+++ b/shared/proto/otc.proto
@@ -213,13 +213,14 @@ message InterbankCounterOfferRequest {
 }
 
 message OtcInterbankPrepareRequest {
-  string idem_routing_number = 1;
-  string idem_key            = 2;
-  string tx_routing_number   = 3;
-  string tx_id               = 4;
-  int64  negotiation_id      = 5;
-  int32  stock_amount        = 6;
-  bool   is_accept           = 7;
+  string idem_routing_number      = 1;
+  string idem_key                 = 2;
+  string tx_routing_number        = 3;
+  string tx_id                    = 4;
+  int64  negotiation_id           = 5;
+  int32  stock_amount             = 6;
+  bool   is_accept                = 7;
+  string partner_neg_external_id  = 8; // raw string neg ID from partner bank (UUID or int string)
 }
 
 message OtcInterbankVoteResponse {


### PR DESCRIPTION
…gnostics

- Add partner_neg_external_id string field to OtcInterbankPrepareRequest proto so the raw UUID string from partner bank is passed alongside the int64 field (which silently becomes 0 for non-integer IDs)
- Gateway handler now captures the raw NegotiationID string from OPTION postings and forwards it in PartnerNegExternalId
- PrepareOtcInterbank buyer-side path uses the string ID for partner_negotiation_id lookup (fixes vote NO on all UUID-keyed partner negotiations)
- executeInterbankAcceptOutgoing now logs HTTP status + full response body when buyer bank does not vote YES, replacing the opaque "voted NO or decode error" message
- Fix expired test settlement dates (2026-06-15 → 2027-06-15)