### PR TITLE
fix(otc): omit seller OPTION posting from interbank 2PC to avoid UNAC…

### DIFF
--- a/services/otc-service/handlers/interbank_outgoing.go
+++ b/services/otc-service/handlers/interbank_outgoing.go
@@ -720,11 +720,10 @@ func (s *OtcServer) executeInterbankAcceptOutgoing(ctx context.Context, localNeg
 					Amount:  premium,
 					Asset:   ibOutAsset{Type: "MONAS", Asset: &ibOutAssetInner{Currency: currency.String}},
 				},
-				{ // seller gives option right
-					Account: ibOutAccount{Type: "PERSON", ID: &ibOutPartyID{RoutingNumber: ownRouting, ID: fmt.Sprintf("%d", sellerID)}},
-					Amount:  -1,
-					Asset:   ibOutAsset{Type: "OPTION", Asset: &ibOutAssetInner{NegotiationID: &ibOutPartyID{RoutingNumber: ownRouting, ID: fmt.Sprintf("%d", localNegID)}}},
-				},
+				// posting 3 (seller gives OPTION -1 at our routing) is omitted:
+				// buyer bank validates OPTION postings only for their own routing and
+				// rejects cross-bank OPTION debits as UNACCEPTABLE_ASSET.
+				// We record the seller's OPTION obligation by creating our contract on COMMIT.
 				{ // buyer receives option right
 					Account: ibOutAccount{Type: "PERSON", ID: &ibOutPartyID{RoutingNumber: int(buyerRoutingNum.Int32), ID: buyerExtID.String}},
 					Amount:  1,


### PR DESCRIPTION
…CEPTABLE_ASSET

Bank 4 rejects OPTION postings for accounts at non-444 routing numbers. Remove posting 3 (seller gives OPTION -1 at routing 888) from the NEW_TX sent to the buyer's bank; the seller's obligation is recorded by creating our own contract on COMMIT.