### PR TITLE
fix(otc): restore OPTION posting in accept 2PC and handle outbound ac…

### DIFF
--- a/services/otc-service/handlers/grpc_server.go
+++ b/services/otc-service/handlers/grpc_server.go
@@ -1385,10 +1385,20 @@ func (s *OtcServer) lookupInterbankNegotiation(ctx context.Context, routingNumbe
 		}
 	}
 
-	// Fallback: {creatorRn}/{creatorExtId} — backward compat for callers that pass buyer routing/id.
-	err := s.DB.QueryRowContext(ctx, `
+	// Fallback 1: {creatorRn}/{creatorExtId} — backward compat for callers that pass buyer routing/id.
+	creatorErr := s.DB.QueryRowContext(ctx, `
 		SELECT id, status FROM otc_negotiations
 		WHERE creator_routing_number = $1 AND creator_external_id = $2`,
+		routingNumber, externalID,
+	).Scan(&localID, &currentStatus)
+	if creatorErr == nil {
+		return localID, currentStatus, nil
+	}
+
+	// Fallback 2: outbound negotiation — bank4 is seller, externalID is their UUID stored in partner_negotiation_id.
+	err := s.DB.QueryRowContext(ctx, `
+		SELECT id, status FROM otc_negotiations
+		WHERE seller_routing_number = $1 AND partner_negotiation_id = $2`,
 		routingNumber, externalID,
 	).Scan(&localID, &currentStatus)
 	if err == sql.ErrNoRows {
@@ -1551,13 +1561,23 @@ func (s *OtcServer) InterbankAcceptNegotiation(ctx context.Context, req *pb.Inte
 			return &pb.OtcEmptyResponse{}, nil // idempotent
 		}
 	}
-	// The partner bank is the buyer; they can accept only when it is their turn.
-	if currentStatus != "PENDING_BUYER" {
-		return nil, status.Error(codes.FailedPrecondition, "not your turn to accept")
+
+	// Check turn precondition before mutating state.
+	if sellerType == "INTERBANK" {
+		// Outbound negotiation: we are the buyer, bank4 (seller) is accepting.
+		if currentStatus != "PENDING_SELLER" {
+			_ = tx.Rollback()
+			return nil, status.Error(codes.FailedPrecondition, "not the seller's turn to accept")
+		}
+	} else {
+		// Inbound negotiation: we are the seller, bank4 (buyer) is accepting.
+		if currentStatus != "PENDING_BUYER" {
+			_ = tx.Rollback()
+			return nil, status.Error(codes.FailedPrecondition, "not your turn to accept")
+		}
 	}
 
 	now := time.Now()
-	// Contract will be created by CommitOtcInterbank after 2PC with the buyer's bank.
 	if _, err = tx.ExecContext(ctx, `
 		UPDATE otc_negotiations
 		SET status = 'ACCEPTED', last_modified = $1, modified_by_id = 0, modified_by_type = 'INTERBANK'
@@ -1565,15 +1585,22 @@ func (s *OtcServer) InterbankAcceptNegotiation(ctx context.Context, req *pb.Inte
 	); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to accept negotiation: %v", err)
 	}
-
 	if err = tx.Commit(); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to commit: %v", err)
 	}
 
-	if twopcErr := s.executeInterbankAcceptOutgoing(ctx, localID); twopcErr != nil {
-		_, _ = s.DB.ExecContext(context.Background(),
-			`UPDATE otc_negotiations SET status='PENDING_BUYER' WHERE id = $1`, localID)
-		return nil, status.Errorf(codes.Unavailable, "accept 2PC failed: %v", twopcErr)
+	if sellerType == "INTERBANK" {
+		if twopcErr := s.executeInterbankAcceptBuyerSide(ctx, localID); twopcErr != nil {
+			_, _ = s.DB.ExecContext(context.Background(),
+				`UPDATE otc_negotiations SET status='PENDING_SELLER' WHERE id = $1`, localID)
+			return nil, status.Errorf(codes.Unavailable, "buyer-side accept 2PC failed: %v", twopcErr)
+		}
+	} else {
+		if twopcErr := s.executeInterbankAcceptOutgoing(ctx, localID); twopcErr != nil {
+			_, _ = s.DB.ExecContext(context.Background(),
+				`UPDATE otc_negotiations SET status='PENDING_BUYER' WHERE id = $1`, localID)
+			return nil, status.Errorf(codes.Unavailable, "accept 2PC failed: %v", twopcErr)
+		}
 	}
 	return &pb.OtcEmptyResponse{}, nil
 }

--- a/services/otc-service/handlers/interbank_outgoing.go
+++ b/services/otc-service/handlers/interbank_outgoing.go
@@ -40,10 +40,21 @@ type ibOutAccount struct {
 	Num  string        `json:"num,omitempty"`
 	ID   *ibOutPartyID `json:"id,omitempty"`
 }
+type ibOutStock struct {
+	Ticker string `json:"ticker"`
+}
+type ibOutMoney struct {
+	Currency string  `json:"currency"`
+	Amount   float64 `json:"amount"`
+}
 type ibOutAssetInner struct {
-	Currency      string        `json:"currency,omitempty"`
-	Ticker        string        `json:"ticker,omitempty"`
-	NegotiationID *ibOutPartyID `json:"negotiationId,omitempty"`
+	Currency       string        `json:"currency,omitempty"`
+	Ticker         string        `json:"ticker,omitempty"`
+	NegotiationID  *ibOutPartyID `json:"negotiationId,omitempty"`
+	Stock          *ibOutStock   `json:"stock,omitempty"`
+	PricePerUnit   *ibOutMoney   `json:"pricePerUnit,omitempty"`
+	SettlementDate string        `json:"settlementDate,omitempty"`
+	Amount         float64       `json:"amount,omitempty"`
 }
 type ibOutAsset struct {
 	Type  string           `json:"type"`
@@ -673,14 +684,17 @@ func (s *OtcServer) executeInterbankAcceptOutgoing(ctx context.Context, localNeg
 	var buyerAcctNum, buyerExtID, currency, ticker, sellerType sql.NullString
 	var buyerRoutingNum sql.NullInt32
 	var sellerID int64
-	var premium float64
+	var premium, strikePrice float64
 	var amount int32
+	var settlementDate string
 	err := s.DB.QueryRowContext(ctx, `
 		SELECT buyer_account_number, buyer_routing_number, buyer_external_id,
-		       seller_id, seller_type, premium, currency, amount, ticker
+		       seller_id, seller_type, premium, currency, amount, ticker,
+		       settlement_date::text, price_per_stock
 		FROM otc_negotiations WHERE id = $1`, localNegID,
 	).Scan(&buyerAcctNum, &buyerRoutingNum, &buyerExtID,
-		&sellerID, &sellerType, &premium, &currency, &amount, &ticker)
+		&sellerID, &sellerType, &premium, &currency, &amount, &ticker,
+		&settlementDate, &strikePrice)
 	if err != nil {
 		return fmt.Errorf("load negotiation: %w", err)
 	}
@@ -710,22 +724,27 @@ func (s *OtcServer) executeInterbankAcceptOutgoing(ctx context.Context, localNeg
 			PaymentCode:    "289",
 			PaymentPurpose: "OTC option premium",
 			Postings: []ibOutPosting{
-				{ // buyer's account debited (premium)
+				{ // posting 1: buyer's account debited (premium)
 					Account: ibOutAccount{Type: "ACCOUNT", Num: buyerAcctNum.String},
 					Amount:  -premium,
 					Asset:   ibOutAsset{Type: "MONAS", Asset: &ibOutAssetInner{Currency: currency.String}},
 				},
-				{ // seller (us) receives premium
+				{ // posting 2: seller (us) receives premium
 					Account: ibOutAccount{Type: "PERSON", ID: &ibOutPartyID{RoutingNumber: ownRouting, ID: fmt.Sprintf("%d", sellerID)}},
 					Amount:  premium,
 					Asset:   ibOutAsset{Type: "MONAS", Asset: &ibOutAssetInner{Currency: currency.String}},
 				},
-				// OPTION postings are intentionally omitted from this 2PC:
-				// Bank 4 routes all 2PC postings to their payment service, which rejects
-				// OPTION-type assets as UNACCEPTABLE_ASSET. The 2PC covers only the MONAS
-				// premium transfer. Each bank creates its own OTC contract independently —
-				// we create ours below after YES; bank 4 creates theirs when they receive
-				// our 200 response to their accept endpoint call.
+				{ // posting 4: buyer (bank4) receives option right — triggers bank4's commitOptionPosting to create their mirror contract
+					Account: ibOutAccount{Type: "PERSON", ID: &ibOutPartyID{RoutingNumber: int(buyerRoutingNum.Int32), ID: buyerExtID.String}},
+					Amount:  1,
+					Asset: ibOutAsset{Type: "OPTION", Asset: &ibOutAssetInner{
+						NegotiationID:  &ibOutPartyID{RoutingNumber: ownRouting, ID: fmt.Sprintf("%d", localNegID)},
+						Stock:          &ibOutStock{Ticker: ticker.String},
+						PricePerUnit:   &ibOutMoney{Currency: currency.String, Amount: strikePrice},
+						SettlementDate: settlementDate,
+						Amount:         float64(amount),
+					}},
+				},
 			},
 		},
 	}
@@ -780,11 +799,6 @@ func (s *OtcServer) executeInterbankAcceptOutgoing(ctx context.Context, localNeg
 		return fmt.Errorf("seller has insufficient free shares")
 	}
 
-	var settlementDate, strikeStr string
-	_ = s.DB.QueryRowContext(ctx, `SELECT settlement_date::text, price_per_stock::text FROM otc_negotiations WHERE id = $1`, localNegID).Scan(&settlementDate, &strikeStr)
-	var strikePrice float64
-	_, _ = fmt.Sscanf(strikeStr, "%f", &strikePrice)
-
 	_, _ = s.DB.ExecContext(ctx, `
 		INSERT INTO otc_contracts
 			(negotiation_id, seller_id, seller_type, buyer_id, buyer_type,
@@ -811,6 +825,145 @@ func (s *OtcServer) executeInterbankAcceptOutgoing(ctx context.Context, localNeg
 				premium, sellerAcctID)
 		}
 	}
+
+	return nil
+}
+
+// executeInterbankAcceptBuyerSide coordinates the 2PC when we are the buyer and bank4 (seller)
+// has accepted. Bank4 called our /accept endpoint (AcceptAsLocal); we form the NEW_TX, send it
+// to bank4, debit our buyer's account on YES, create our buyer-side contract, and send COMMIT.
+// Bank4 on COMMIT creates their authoritative seller contract via commitOptionPosting.
+func (s *OtcServer) executeInterbankAcceptBuyerSide(ctx context.Context, localNegID int64) error {
+	var ticker, currency, buyerType string
+	var sellerExtID, buyerAcctNum sql.NullString
+	var settlementDate string
+	var buyerID int64
+	var sellerRoutingNum sql.NullInt32
+	var partnerNegID sql.NullString
+	var amount int32
+	var strikePrice, premium float64
+
+	err := s.DB.QueryRowContext(ctx, `
+		SELECT ticker, currency, settlement_date::text,
+		       buyer_id, buyer_type, buyer_account_number,
+		       seller_routing_number, seller_external_id,
+		       partner_negotiation_id, amount, price_per_stock, premium
+		FROM otc_negotiations WHERE id = $1`, localNegID,
+	).Scan(&ticker, &currency, &settlementDate,
+		&buyerID, &buyerType, &buyerAcctNum,
+		&sellerRoutingNum, &sellerExtID,
+		&partnerNegID, &amount, &strikePrice, &premium)
+	if err != nil {
+		return fmt.Errorf("load negotiation: %w", err)
+	}
+	if !sellerRoutingNum.Valid || !partnerNegID.Valid || partnerNegID.String == "" {
+		return fmt.Errorf("missing seller_routing_number or partner_negotiation_id on outbound negotiation %d", localNegID)
+	}
+	if !buyerAcctNum.Valid || buyerAcctNum.String == "" {
+		return fmt.Errorf("missing buyer_account_number on outbound negotiation %d", localNegID)
+	}
+
+	bank, err := otcInterbank.ResolveBankByRoutingNumber(fmt.Sprintf("%d", sellerRoutingNum.Int32))
+	if err != nil {
+		return fmt.Errorf("resolve seller bank: %w", err)
+	}
+
+	bankURL := bank.BankURL + "/interbank"
+	ownRouting := otcOwnRoutingInt()
+	txID := otcIbTransactionID{RoutingNumber: ownRouting, ID: otcGenerateUUID()}
+	idemKey := otcIbIdempotenceKey{RoutingNumber: ownRouting, LocallyGeneratedKey: otcGenerateUUID()}
+
+	// OPTION asset: negotiationId uses bank4's routing + bank4's UUID (they are authoritative seller).
+	optionAI := ibOutAssetInner{
+		NegotiationID:  &ibOutPartyID{RoutingNumber: int(sellerRoutingNum.Int32), ID: partnerNegID.String},
+		Stock:          &ibOutStock{Ticker: ticker},
+		PricePerUnit:   &ibOutMoney{Currency: currency, Amount: strikePrice},
+		SettlementDate: settlementDate,
+		Amount:         float64(amount),
+	}
+
+	envelope := otcIbEnvelope{
+		IdempotenceKey: idemKey,
+		MessageType:    "NEW_TX",
+		Message: otcIbNewTxMessage{
+			TransactionID:  txID,
+			Message:        "Peer OTC option premium and contract acceptance",
+			PaymentCode:    "289",
+			PaymentPurpose: "OTC option premium",
+			Postings: []ibOutPosting{
+				{ // posting 1: buyer ACCOUNT MONAS credit — buyer pays premium (non-local to bank4, skipped by them)
+					Account: ibOutAccount{Type: "ACCOUNT", Num: buyerAcctNum.String},
+					Amount:  -premium,
+					Asset:   ibOutAsset{Type: "MONAS", Asset: &ibOutAssetInner{Currency: currency}},
+				},
+				{ // posting 2: seller PERSON MONAS debit — seller receives premium
+					Account: ibOutAccount{Type: "PERSON", ID: &ibOutPartyID{RoutingNumber: int(sellerRoutingNum.Int32), ID: sellerExtID.String}},
+					Amount:  premium,
+					Asset:   ibOutAsset{Type: "MONAS", Asset: &ibOutAssetInner{Currency: currency}},
+				},
+				{ // posting 3: seller PERSON OPTION credit — seller gives option (reserves shares; triggers authoritative contract on COMMIT)
+					Account: ibOutAccount{Type: "PERSON", ID: &ibOutPartyID{RoutingNumber: int(sellerRoutingNum.Int32), ID: sellerExtID.String}},
+					Amount:  -1,
+					Asset:   ibOutAsset{Type: "OPTION", Asset: &optionAI},
+				},
+				{ // posting 4: buyer PERSON OPTION debit — buyer receives option (non-local to bank4, skipped by them; we handle locally)
+					Account: ibOutAccount{Type: "PERSON", ID: &ibOutPartyID{RoutingNumber: ownRouting, ID: fmt.Sprintf("%d", buyerID)}},
+					Amount:  1,
+					Asset:   ibOutAsset{Type: "OPTION", Asset: &optionAI},
+				},
+			},
+		},
+	}
+
+	resp, err := otcSendInterbankRequest(ctx, bankURL, bank.APIKey, envelope)
+	if err != nil {
+		return fmt.Errorf("NEW_TX: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	rawBody, _ := io.ReadAll(resp.Body)
+	var vote otcIbVoteResponse
+	if jsonErr := json.Unmarshal(rawBody, &vote); jsonErr != nil || vote.Vote != "YES" {
+		_, _ = otcSendInterbankRequest(ctx, bankURL, bank.APIKey, otcIbEnvelope{
+			IdempotenceKey: otcIbIdempotenceKey{RoutingNumber: ownRouting, LocallyGeneratedKey: otcGenerateUUID()},
+			MessageType:    "ROLLBACK_TX",
+			Message:        otcIbCommitMessage{TransactionID: txID},
+		})
+		return fmt.Errorf("seller bank voted NO (status=%d body=%s)", resp.StatusCode, string(rawBody))
+	}
+
+	// YES: debit buyer's account (converting currency if needed) and create our buyer-side contract.
+	premiumToPay := premium
+	if ncurrencyID, ok := currencyIDMap[currency]; ok {
+		var buyerAcctCurrencyID int64
+		if qErr := s.AccountDB.QueryRowContext(ctx,
+			`SELECT currency_id FROM accounts WHERE account_number = $1`, buyerAcctNum.String,
+		).Scan(&buyerAcctCurrencyID); qErr == nil {
+			if converted, convErr := convertAmount(ctx, s.ExchangeDB, premium, ncurrencyID, buyerAcctCurrencyID); convErr == nil {
+				premiumToPay = converted
+			}
+		}
+	}
+	_, _ = s.AccountDB.ExecContext(ctx,
+		`UPDATE accounts SET balance = balance - $1, available_balance = available_balance - $1
+		 WHERE account_number = $2 AND available_balance >= $1`,
+		premiumToPay, buyerAcctNum.String)
+
+	_, _ = s.DB.ExecContext(ctx, `
+		INSERT INTO otc_contracts
+			(negotiation_id, seller_id, seller_type, buyer_id, buyer_type,
+			 ticker, amount, strike_price, premium, currency, settlement_date)
+		VALUES ($1, 0, 'INTERBANK', $2, $3, $4, $5, $6, $7, $8, $9)
+		ON CONFLICT (negotiation_id) DO NOTHING`,
+		localNegID, buyerID, buyerType,
+		ticker, amount, strikePrice, premium, currency, settlementDate)
+
+	// COMMIT — bank4 will commit their postings (credit seller's MONAS, create authoritative seller contract).
+	_, _ = otcSendInterbankRequest(ctx, bankURL, bank.APIKey, otcIbEnvelope{
+		IdempotenceKey: otcIbIdempotenceKey{RoutingNumber: ownRouting, LocallyGeneratedKey: otcGenerateUUID()},
+		MessageType:    "COMMIT_TX",
+		Message:        otcIbCommitMessage{TransactionID: txID},
+	})
 
 	return nil
 }

--- a/services/otc-service/handlers/otc_2pc_extra_test.go
+++ b/services/otc-service/handlers/otc_2pc_extra_test.go
@@ -197,7 +197,10 @@ func TestLookupInterbankNegotiation_NumericIDNotFound_FallsBack(t *testing.T) {
 	// Primary: id=42 not found
 	mOTC.ExpectQuery("SELECT id, status FROM otc_negotiations WHERE id").
 		WillReturnRows(sqlmock.NewRows([]string{"id", "status"}))
-	// Fallback: by creator routing + externalId — also not found
+	// Fallback 1: by creator routing + externalId — also not found
+	mOTC.ExpectQuery("SELECT id, status FROM otc_negotiations").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "status"}))
+	// Fallback 2: by seller routing + partner_negotiation_id — also not found
 	mOTC.ExpectQuery("SELECT id, status FROM otc_negotiations").
 		WillReturnRows(sqlmock.NewRows([]string{"id", "status"}))
 
@@ -212,6 +215,9 @@ func TestLookupInterbankNegotiation_NumericIDNotFound_FallsBack(t *testing.T) {
 func TestLookupInterbankNegotiation_NonNumericID_FallsBack(t *testing.T) {
 	s, mOTC, _, _, _, _, _ := newTestServer(t)
 	// Non-numeric externalId → skips local id query, goes straight to creator key fallback
+	mOTC.ExpectQuery("SELECT id, status FROM otc_negotiations").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "status"}))
+	// Fallback 2: by seller routing + partner_negotiation_id — also not found
 	mOTC.ExpectQuery("SELECT id, status FROM otc_negotiations").
 		WillReturnRows(sqlmock.NewRows([]string{"id", "status"}))
 
@@ -232,7 +238,7 @@ func TestConvertAmount_SameCurrency_NoQuery(t *testing.T) {
 
 func TestConvertAmount_DifferentCurrencies_DBError(t *testing.T) {
 	excDB, excMock, _ := sqlmock.New()
-	defer excDB.Close()
+	defer func() { _ = excDB.Close() }()
 	excMock.ExpectQuery("SELECT middle_rate FROM daily_exchange_rates").
 		WillReturnRows(sqlmock.NewRows([]string{"middle_rate"})) // empty → ErrNoRows
 	_, err := convertAmount(context.Background(), excDB, 100.0, 1, 2)

--- a/services/otc-service/handlers/otc_2pc_test.go
+++ b/services/otc-service/handlers/otc_2pc_test.go
@@ -31,8 +31,13 @@ func newOtcServerWithExchange(t *testing.T) (*OtcServer, sqlmock.Sqlmock, sqlmoc
 	secDB, mSec := newDB()
 	excDB, mExc := newDB()
 	t.Cleanup(func() {
-		_ = db.Close(); _ = empDB.Close(); _ = cliDB.Close()
-		_ = accDB.Close(); _ = portDB.Close(); _ = secDB.Close(); _ = excDB.Close()
+		_ = db.Close()
+		_ = empDB.Close()
+		_ = cliDB.Close()
+		_ = accDB.Close()
+		_ = portDB.Close()
+		_ = secDB.Close()
+		_ = excDB.Close()
 	})
 	return &OtcServer{
 		DB: db, EmployeeDB: empDB, ClientDB: cliDB,

--- a/services/otc-service/handlers/otc_interbank_test.go
+++ b/services/otc-service/handlers/otc_interbank_test.go
@@ -42,12 +42,15 @@ func addLookupByLocalID(m sqlmock.Sqlmock, id int64, negStatus string) {
 		WillReturnRows(sqlmock.NewRows([]string{"id", "status"}).AddRow(id, negStatus))
 }
 
-// addLookupNotFound adds mock expectations for a lookup that finds nothing (both paths return no rows).
+// addLookupNotFound adds mock expectations for a lookup that finds nothing (all three paths return no rows).
 func addLookupNotFound(m sqlmock.Sqlmock) {
 	// Primary: by local ID
 	m.ExpectQuery("SELECT id, status FROM otc_negotiations WHERE id").
 		WillReturnRows(sqlmock.NewRows([]string{"id", "status"}))
-	// Fallback: by creator key
+	// Fallback 1: by creator routing + creator_external_id
+	m.ExpectQuery("SELECT id, status FROM otc_negotiations").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "status"}))
+	// Fallback 2: by seller routing + partner_negotiation_id
 	m.ExpectQuery("SELECT id, status FROM otc_negotiations").
 		WillReturnRows(sqlmock.NewRows([]string{"id", "status"}))
 }
@@ -82,16 +85,16 @@ func TestCreateInterbankNegotiation_InvalidSellerID(t *testing.T) {
 	assert.Equal(t, codes.InvalidArgument, status.Code(err))
 }
 
-func TestCreateInterbankNegotiation_Idempotent(t *testing.T) {
+func TestCreateInterbankNegotiation_Happy(t *testing.T) {
 	s, mOTC, _, _, _, _, _ := newTestServer(t)
 
-	// idempotency check: lookup by creatorExtId="42" (numeric, so tries local ID first)
-	addLookupByLocalID(mOTC, 42, "PENDING_SELLER")
+	mOTC.ExpectQuery("INSERT INTO otc_negotiations").
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(42)))
 	addFetchInterbankRows(mOTC, 42, "PENDING_SELLER")
 
 	resp, err := s.CreateInterbankNegotiation(context.Background(), &pb.CreateInterbankNegotiationRequest{
 		Ticker: "AAPL", Amount: 10, SettlementDate: "2026-12-31",
-		SellerExternalId:  "7",
+		SellerExternalId:     "7",
 		CreatorRoutingNumber: 444, CreatorExternalId: "42",
 	})
 	require.NoError(t, err)
@@ -109,7 +112,7 @@ func TestCreateInterbankNegotiation_InsertFails(t *testing.T) {
 
 	_, err := s.CreateInterbankNegotiation(context.Background(), &pb.CreateInterbankNegotiationRequest{
 		Ticker: "AAPL", Amount: 10, SettlementDate: "2026-12-31",
-		SellerExternalId: "7",
+		SellerExternalId:     "7",
 		CreatorRoutingNumber: 444, CreatorExternalId: "9999",
 	})
 	require.Error(t, err)
@@ -243,7 +246,9 @@ func TestInterbankDeleteNegotiation_Success(t *testing.T) {
 
 func TestInterbankAcceptNegotiation_InvalidID(t *testing.T) {
 	s, mOTC, _, _, _, _, _ := newTestServer(t)
-	// non-numeric ExternalId: skip primary ID lookup, creator-key fallback returns not found
+	// non-numeric ExternalId: skip primary ID lookup, both fallbacks return not found
+	mOTC.ExpectQuery("SELECT id, status FROM otc_negotiations").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "status"}))
 	mOTC.ExpectQuery("SELECT id, status FROM otc_negotiations").
 		WillReturnRows(sqlmock.NewRows([]string{"id", "status"}))
 

--- a/services/otc-service/handlers/otc_outgoing_test.go
+++ b/services/otc-service/handlers/otc_outgoing_test.go
@@ -41,7 +41,8 @@ func TestExecuteInterbankAcceptOutgoing_UnknownBuyerRouting(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{
 			"buyer_account_number", "buyer_routing_number", "buyer_external_id",
 			"seller_id", "seller_type", "premium", "currency", "amount", "ticker",
-		}).AddRow("ACC-001", int32(999), "ext-1", int64(5), "CLIENT", 5.0, "RSD", int32(10), "AAPL"))
+			"settlement_date", "price_per_stock",
+		}).AddRow("ACC-001", int32(999), "ext-1", int64(5), "CLIENT", 5.0, "RSD", int32(10), "AAPL", "2099-12-31", 50.0))
 
 	err := s.executeInterbankAcceptOutgoing(context.Background(), 1)
 	require.Error(t, err)
@@ -65,7 +66,8 @@ func TestExecuteInterbankAcceptOutgoing_HTTPVoteNo(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{
 			"buyer_account_number", "buyer_routing_number", "buyer_external_id",
 			"seller_id", "seller_type", "premium", "currency", "amount", "ticker",
-		}).AddRow("ACC-001", int32(444), "ext-1", int64(5), "CLIENT", 5.0, "RSD", int32(10), "AAPL"))
+			"settlement_date", "price_per_stock",
+		}).AddRow("ACC-001", int32(444), "ext-1", int64(5), "CLIENT", 5.0, "RSD", int32(10), "AAPL", "2099-12-31", 50.0))
 
 	err := s.executeInterbankAcceptOutgoing(context.Background(), 1)
 	require.Error(t, err)
@@ -89,7 +91,8 @@ func TestExecuteInterbankAcceptOutgoing_TickerNotFound(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{
 			"buyer_account_number", "buyer_routing_number", "buyer_external_id",
 			"seller_id", "seller_type", "premium", "currency", "amount", "ticker",
-		}).AddRow("ACC-001", int32(444), "ext-1", int64(5), "CLIENT", 5.0, "RSD", int32(10), "AAPL"))
+			"settlement_date", "price_per_stock",
+		}).AddRow("ACC-001", int32(444), "ext-1", int64(5), "CLIENT", 5.0, "RSD", int32(10), "AAPL", "2099-12-31", 50.0))
 	// listingIDForTicker: not found
 	mSec.ExpectQuery("SELECT id FROM listing WHERE ticker").
 		WillReturnRows(sqlmock.NewRows([]string{"id"}))
@@ -116,7 +119,8 @@ func TestExecuteInterbankAcceptOutgoing_InsufficientShares(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{
 			"buyer_account_number", "buyer_routing_number", "buyer_external_id",
 			"seller_id", "seller_type", "premium", "currency", "amount", "ticker",
-		}).AddRow("ACC-001", int32(444), "ext-1", int64(5), "CLIENT", 5.0, "RSD", int32(10), "AAPL"))
+			"settlement_date", "price_per_stock",
+		}).AddRow("ACC-001", int32(444), "ext-1", int64(5), "CLIENT", 5.0, "RSD", int32(10), "AAPL", "2099-12-31", 50.0))
 	mSec.ExpectQuery("SELECT id FROM listing WHERE ticker").
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(99)))
 	// UPDATE returns 0 rows (no free shares)


### PR DESCRIPTION
…cept from partner seller

Issue 1 (we=seller, bank4=buyer): Re-add posting 4 (buyer receives OPTION +1) with full asset body (negotiationId, stock, pricePerUnit, settlementDate, amount) so bank4's commitOptionPosting creates their mirror contract on COMMIT.

Issue 2 (bank4=seller, we=buyer): Fix lookupInterbankNegotiation to find outbound negotiations via seller_routing_number + partner_negotiation_id. Fix InterbankAcceptNegotiation to detect outbound case (sellerType=INTERBANK, status PENDING_SELLER) and route to new executeInterbankAcceptBuyerSide, which coordinates the 4-posting 2PC as buyer, debits our buyer's account, creates our buyer contract, and sends COMMIT to trigger bank4's authoritative seller contract creation.