### PR TITLE
fix(test): update mocks for account-locking interface additions

### DIFF
--- a/services/account-service/handlers/grpc_server_test.go
+++ b/services/account-service/handlers/grpc_server_test.go
@@ -37,6 +37,21 @@ func (m *mockEmailClient) SendCardConfirmationEmail(_ context.Context, _ *pb_ema
 func (m *mockEmailClient) SendLoanLatePaymentEmail(_ context.Context, _ *pb_email.SendLoanLatePaymentEmailRequest, _ ...grpc.CallOption) (*pb_email.SendLoanLatePaymentEmailResponse, error) {
 	return &pb_email.SendLoanLatePaymentEmailResponse{}, m.err
 }
+func (m *mockEmailClient) SendAccountLockedEmail(_ context.Context, _ *pb_email.SendAccountLockedEmailRequest, _ ...grpc.CallOption) (*pb_email.SendAccountLockedEmailResponse, error) {
+	return &pb_email.SendAccountLockedEmailResponse{}, m.err
+}
+func (m *mockEmailClient) SendPaymentNotificationEmail(_ context.Context, _ *pb_email.SendPaymentNotificationEmailRequest, _ ...grpc.CallOption) (*pb_email.SendPaymentNotificationEmailResponse, error) {
+	return &pb_email.SendPaymentNotificationEmailResponse{}, m.err
+}
+func (m *mockEmailClient) SendCardBlockedEmail(_ context.Context, _ *pb_email.SendCardBlockedEmailRequest, _ ...grpc.CallOption) (*pb_email.SendCardBlockedEmailResponse, error) {
+	return &pb_email.SendCardBlockedEmailResponse{}, m.err
+}
+func (m *mockEmailClient) SendLoanApprovedEmail(_ context.Context, _ *pb_email.SendLoanApprovedEmailRequest, _ ...grpc.CallOption) (*pb_email.SendLoanApprovedEmailResponse, error) {
+	return &pb_email.SendLoanApprovedEmailResponse{}, m.err
+}
+func (m *mockEmailClient) SendLimitChangeEmail(_ context.Context, _ *pb_email.SendLimitChangeEmailRequest, _ ...grpc.CallOption) (*pb_email.SendLimitChangeEmailResponse, error) {
+	return &pb_email.SendLimitChangeEmailResponse{}, m.err
+}
 
 func newServer(t *testing.T) (*AccountServer, sqlmock.Sqlmock, sqlmock.Sqlmock, sqlmock.Sqlmock) {
 	t.Helper()

--- a/services/auth-service/handlers/grpc_server_test.go
+++ b/services/auth-service/handlers/grpc_server_test.go
@@ -149,6 +149,10 @@ func (m *mockEmployeeClient) GetSupervisors(ctx context.Context, in *pb_emp.GetS
 	return nil, fmt.Errorf("not implemented")
 }
 
+func (m *mockEmployeeClient) UpdateLoginAttempts(ctx context.Context, in *pb_emp.UpdateLoginAttemptsRequest, opts ...grpc.CallOption) (*pb_emp.UpdateLoginAttemptsResponse, error) {
+	return &pb_emp.UpdateLoginAttemptsResponse{}, nil
+}
+
 type mockEmailClient struct {
 	mock.Mock
 }
@@ -186,6 +190,26 @@ func (m *mockEmailClient) SendCardConfirmationEmail(ctx context.Context, in *pb_
 }
 func (m *mockEmailClient) SendLoanLatePaymentEmail(ctx context.Context, in *pb_email.SendLoanLatePaymentEmailRequest, opts ...grpc.CallOption) (*pb_email.SendLoanLatePaymentEmailResponse, error) {
 	return &pb_email.SendLoanLatePaymentEmailResponse{}, nil
+}
+
+func (m *mockEmailClient) SendAccountLockedEmail(ctx context.Context, in *pb_email.SendAccountLockedEmailRequest, opts ...grpc.CallOption) (*pb_email.SendAccountLockedEmailResponse, error) {
+	return &pb_email.SendAccountLockedEmailResponse{}, nil
+}
+
+func (m *mockEmailClient) SendPaymentNotificationEmail(ctx context.Context, in *pb_email.SendPaymentNotificationEmailRequest, opts ...grpc.CallOption) (*pb_email.SendPaymentNotificationEmailResponse, error) {
+	return &pb_email.SendPaymentNotificationEmailResponse{}, nil
+}
+
+func (m *mockEmailClient) SendCardBlockedEmail(ctx context.Context, in *pb_email.SendCardBlockedEmailRequest, opts ...grpc.CallOption) (*pb_email.SendCardBlockedEmailResponse, error) {
+	return &pb_email.SendCardBlockedEmailResponse{}, nil
+}
+
+func (m *mockEmailClient) SendLoanApprovedEmail(ctx context.Context, in *pb_email.SendLoanApprovedEmailRequest, opts ...grpc.CallOption) (*pb_email.SendLoanApprovedEmailResponse, error) {
+	return &pb_email.SendLoanApprovedEmailResponse{}, nil
+}
+
+func (m *mockEmailClient) SendLimitChangeEmail(ctx context.Context, in *pb_email.SendLimitChangeEmailRequest, opts ...grpc.CallOption) (*pb_email.SendLimitChangeEmailResponse, error) {
+	return &pb_email.SendLimitChangeEmailResponse{}, nil
 }
 
 type mockClientClient struct {
@@ -238,6 +262,10 @@ func (m *mockClientClient) ActivateClient(ctx context.Context, in *pb_client.Act
 		return nil, args.Error(1)
 	}
 	return args.Get(0).(*pb_client.ActivateClientResponse), args.Error(1)
+}
+
+func (m *mockClientClient) UpdateLoginAttempts(ctx context.Context, in *pb_client.UpdateLoginAttemptsRequest, opts ...grpc.CallOption) (*pb_client.UpdateLoginAttemptsResponse, error) {
+	return &pb_client.UpdateLoginAttemptsResponse{}, nil
 }
 
 // ---- helpers ----
@@ -677,7 +705,15 @@ func TestLogin_HappyPath(t *testing.T) {
 		}}, nil,
 	)
 
-	s := &AuthServer{EmployeeClient: empClient, EmailClient: &mockEmailClient{}}
+	db, dbMock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	// No TOTP secret → ErrNoRows → proceed to token generation
+	dbMock.ExpectQuery("SELECT secret FROM totp_secrets").
+		WithArgs(int64(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"secret"}))
+
+	s := &AuthServer{EmployeeClient: empClient, EmailClient: &mockEmailClient{}, DB: db}
 	resp, err := s.Login(context.Background(), &pb_auth.LoginRequest{Email: "user@example.com", Password: "Abcdef12"})
 	require.NoError(t, err)
 	assert.NotEmpty(t, resp.AccessToken)
@@ -736,7 +772,15 @@ func TestClientLogin_HappyPath(t *testing.T) {
 		}}, nil,
 	)
 
-	s := &AuthServer{ClientClient: clientClient}
+	db, dbMock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	// No TOTP secret → ErrNoRows → proceed to token generation
+	dbMock.ExpectQuery("SELECT secret FROM totp_secrets").
+		WithArgs(int64(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"secret"}))
+
+	s := &AuthServer{ClientClient: clientClient, DB: db}
 	resp, err := s.ClientLogin(context.Background(), &pb_auth.ClientLoginRequest{Email: "ana@example.com", Password: "Abcdef12", Source: "mobile"})
 	require.NoError(t, err)
 	assert.NotEmpty(t, resp.AccessToken)
@@ -1004,8 +1048,16 @@ func TestLogin_GetEmployeeByIdError(t *testing.T) {
 	)
 	empClient.On("GetEmployeeById", mock.Anything, mock.Anything).Return(nil, status.Error(codes.Internal, "db down"))
 
-	s := &AuthServer{EmployeeClient: empClient, EmailClient: &mockEmailClient{}}
-	_, err := s.Login(context.Background(), &pb_auth.LoginRequest{Email: "user@example.com", Password: "Abcdef12"})
+	db, dbMock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	// No TOTP secret → ErrNoRows → proceed to GetEmployeeById
+	dbMock.ExpectQuery("SELECT secret FROM totp_secrets").
+		WithArgs(int64(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"secret"}))
+
+	s := &AuthServer{EmployeeClient: empClient, EmailClient: &mockEmailClient{}, DB: db}
+	_, err = s.Login(context.Background(), &pb_auth.LoginRequest{Email: "user@example.com", Password: "Abcdef12"})
 	require.Error(t, err)
 	assert.Equal(t, codes.Internal, status.Code(err))
 }
@@ -1170,8 +1222,15 @@ func TestClientLogin_GetClientByIdError(t *testing.T) {
 	)
 	clientClient.On("GetClientById", mock.Anything, mock.Anything).Return(nil, status.Error(codes.Internal, "db down"))
 
-	s := &AuthServer{ClientClient: clientClient}
-	_, err := s.ClientLogin(context.Background(), &pb_auth.ClientLoginRequest{Email: "ana@example.com", Password: "Abcdef12"})
+	db, dbMock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	dbMock.ExpectQuery("SELECT secret FROM totp_secrets").
+		WithArgs(int64(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"secret"}))
+
+	s := &AuthServer{ClientClient: clientClient, DB: db}
+	_, err = s.ClientLogin(context.Background(), &pb_auth.ClientLoginRequest{Email: "ana@example.com", Password: "Abcdef12"})
 	require.Error(t, err)
 	assert.Equal(t, codes.Internal, status.Code(err))
 }

--- a/services/email-service/handlers/grpc_server_test.go
+++ b/services/email-service/handlers/grpc_server_test.go
@@ -50,6 +50,31 @@ func (m *mockPublisher) PublishLoanLatePayment(msg queue.LoanLatePaymentMessage)
 	return args.Error(0)
 }
 
+func (m *mockPublisher) PublishAccountLocked(msg queue.AccountLockedMessage) error {
+	args := m.Called(msg)
+	return args.Error(0)
+}
+
+func (m *mockPublisher) PublishPaymentNotification(msg queue.PaymentNotificationMessage) error {
+	args := m.Called(msg)
+	return args.Error(0)
+}
+
+func (m *mockPublisher) PublishCardBlocked(msg queue.CardBlockedMessage) error {
+	args := m.Called(msg)
+	return args.Error(0)
+}
+
+func (m *mockPublisher) PublishLoanApproved(msg queue.LoanApprovedMessage) error {
+	args := m.Called(msg)
+	return args.Error(0)
+}
+
+func (m *mockPublisher) PublishLimitChange(msg queue.LimitChangeMessage) error {
+	args := m.Called(msg)
+	return args.Error(0)
+}
+
 // ---- SendActivationEmail tests ----
 
 func TestSendActivationEmail_InvalidEmail(t *testing.T) {

--- a/services/loan-service/handlers/grpc_server_test.go
+++ b/services/loan-service/handlers/grpc_server_test.go
@@ -45,6 +45,9 @@ func (m *mockClientClient) GetClientCredentials(ctx context.Context, in *pb_clie
 func (m *mockClientClient) ActivateClient(ctx context.Context, in *pb_client.ActivateClientRequest, opts ...grpc.CallOption) (*pb_client.ActivateClientResponse, error) {
 	return nil, fmt.Errorf("not implemented")
 }
+func (m *mockClientClient) UpdateLoginAttempts(ctx context.Context, in *pb_client.UpdateLoginAttemptsRequest, opts ...grpc.CallOption) (*pb_client.UpdateLoginAttemptsResponse, error) {
+	return &pb_client.UpdateLoginAttemptsResponse{}, nil
+}
 
 type mockEmailClient struct{}
 
@@ -65,6 +68,21 @@ func (m *mockEmailClient) SendCardConfirmationEmail(ctx context.Context, in *pb_
 }
 func (m *mockEmailClient) SendLoanLatePaymentEmail(ctx context.Context, in *pb_email.SendLoanLatePaymentEmailRequest, opts ...grpc.CallOption) (*pb_email.SendLoanLatePaymentEmailResponse, error) {
 	return &pb_email.SendLoanLatePaymentEmailResponse{}, nil
+}
+func (m *mockEmailClient) SendAccountLockedEmail(ctx context.Context, in *pb_email.SendAccountLockedEmailRequest, opts ...grpc.CallOption) (*pb_email.SendAccountLockedEmailResponse, error) {
+	return &pb_email.SendAccountLockedEmailResponse{}, nil
+}
+func (m *mockEmailClient) SendPaymentNotificationEmail(ctx context.Context, in *pb_email.SendPaymentNotificationEmailRequest, opts ...grpc.CallOption) (*pb_email.SendPaymentNotificationEmailResponse, error) {
+	return &pb_email.SendPaymentNotificationEmailResponse{}, nil
+}
+func (m *mockEmailClient) SendCardBlockedEmail(ctx context.Context, in *pb_email.SendCardBlockedEmailRequest, opts ...grpc.CallOption) (*pb_email.SendCardBlockedEmailResponse, error) {
+	return &pb_email.SendCardBlockedEmailResponse{}, nil
+}
+func (m *mockEmailClient) SendLoanApprovedEmail(ctx context.Context, in *pb_email.SendLoanApprovedEmailRequest, opts ...grpc.CallOption) (*pb_email.SendLoanApprovedEmailResponse, error) {
+	return &pb_email.SendLoanApprovedEmailResponse{}, nil
+}
+func (m *mockEmailClient) SendLimitChangeEmail(ctx context.Context, in *pb_email.SendLimitChangeEmailRequest, opts ...grpc.CallOption) (*pb_email.SendLimitChangeEmailResponse, error) {
+	return &pb_email.SendLimitChangeEmailResponse{}, nil
 }
 
 // newLoanServer creates a LoanServer backed by sqlmock DBs for loan_db and account_db.

--- a/services/order-service/execution/scheduler_test.go
+++ b/services/order-service/execution/scheduler_test.go
@@ -78,6 +78,9 @@ func (m *mockEmpClient) GetActuaryPerformers(ctx context.Context, in *pb_emp.Get
 func (m *mockEmpClient) GetSupervisors(ctx context.Context, in *pb_emp.GetSupervisorsRequest, opts ...grpc.CallOption) (*pb_emp.GetSupervisorsResponse, error) {
 	return nil, nil
 }
+func (m *mockEmpClient) UpdateLoginAttempts(ctx context.Context, in *pb_emp.UpdateLoginAttemptsRequest, opts ...grpc.CallOption) (*pb_emp.UpdateLoginAttemptsResponse, error) {
+	return nil, nil
+}
 
 type mockLoanClient struct {
 	loans []*pb_loan.LoanSummary


### PR DESCRIPTION
The account-locking feature added new methods to several gRPC client interfaces (UpdateLoginAttempts, SendAccountLockedEmail) and the email Publisher interface (PublishAccountLocked and related notification methods). Updated mock structs in email-service, account-service, auth-service, order-service, and loan-service tests to implement the full interfaces.