### PR TITLE
fix(otc): fix interbank key validation and outbound negotiation flow

### DIFF
--- a/services/api-gateway/handlers/interbank.go
+++ b/services/api-gateway/handlers/interbank.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math"
 	"net/http"
-	"os"
 	"strconv"
 
 	pb_otc "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/otc"
@@ -71,8 +70,7 @@ type commitRollbackMessage struct {
 // Authenticated via X-Api-Key header matched against OWN_INTERBANK_API_KEY env var.
 func InterbankHandler(paymentClient pb.PaymentServiceClient, otcClient pb_otc.OtcServiceClient) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		apiKey := os.Getenv("OWN_INTERBANK_API_KEY")
-		if apiKey == "" || c.GetHeader("X-Api-Key") != apiKey {
+		if !validateOtcInterbankKey(c) {
 			c.Status(http.StatusUnauthorized)
 			return
 		}

--- a/services/api-gateway/handlers/otc_interbank.go
+++ b/services/api-gateway/handlers/otc_interbank.go
@@ -23,10 +23,22 @@ func gatewayOwnRoutingInt() int32 {
 	return n
 }
 
-// validateOtcInterbankKey rejects requests whose X-Api-Key does not match OWN_INTERBANK_API_KEY.
+// validateOtcInterbankKey accepts requests whose X-Api-Key matches either the key
+// we issued to partners (OWN_INTERBANK_API_KEY) or the key the partner issued to us
+// (PARTNER_API_KEY). The latter is needed because some partners send their own key
+// rather than the key we issued them.
 func validateOtcInterbankKey(c *gin.Context) bool {
-	key := os.Getenv("OWN_INTERBANK_API_KEY")
-	return key != "" && c.GetHeader("X-Api-Key") == key
+	incoming := c.GetHeader("X-Api-Key")
+	if incoming == "" {
+		return false
+	}
+	if ownKey := os.Getenv("OWN_INTERBANK_API_KEY"); ownKey != "" && incoming == ownKey {
+		return true
+	}
+	if partnerKey := os.Getenv("PARTNER_API_KEY"); partnerKey != "" && incoming == partnerKey {
+		return true
+	}
+	return false
 }
 
 // ── JSON shapes expected/returned by the /otc/interbank/* endpoints ──────────

--- a/services/otc-service/handlers/grpc_server.go
+++ b/services/otc-service/handlers/grpc_server.go
@@ -492,8 +492,14 @@ func (s *OtcServer) CounterOffer(ctx context.Context, req *pb.CounterOfferReques
 	}()
 
 	if buyerType == "INTERBANK" {
+		// Inbound: we are seller, bank4 is buyer — notify buyer's bank of our counter.
 		if fwdErr := s.forwardSellerCounterOfferToPartner(ctx, req.NegotiationId, req.Amount, req.PricePerStock, req.Premium, req.SettlementDate); fwdErr != nil {
 			log.Printf("warn: forwardSellerCounterOfferToPartner(%d): %v", req.NegotiationId, fwdErr)
+		}
+	} else if sellerType == "INTERBANK" && isBuyer {
+		// Outbound: we are buyer, bank4 is seller — notify seller's bank of our counter.
+		if fwdErr := s.forwardBuyerCounterOfferToPartner(ctx, req.NegotiationId, req.Amount, req.PricePerStock, req.Premium, req.SettlementDate); fwdErr != nil {
+			log.Printf("warn: forwardBuyerCounterOfferToPartner(%d): %v", req.NegotiationId, fwdErr)
 		}
 	}
 
@@ -809,8 +815,14 @@ func (s *OtcServer) RejectNegotiation(ctx context.Context, req *pb.RejectNegotia
 	}()
 
 	if buyerType == "INTERBANK" {
+		// Inbound: we are seller, bank4 is buyer — notify buyer's bank of rejection.
 		if fwdErr := s.notifyPartnerRejection(ctx, req.NegotiationId); fwdErr != nil {
 			log.Printf("warn: notifyPartnerRejection(%d): %v", req.NegotiationId, fwdErr)
+		}
+	} else if sellerType == "INTERBANK" {
+		// Outbound: we are buyer, bank4 is seller — notify seller's bank of rejection.
+		if fwdErr := s.notifyOutboundRejection(ctx, req.NegotiationId); fwdErr != nil {
+			log.Printf("warn: notifyOutboundRejection(%d): %v", req.NegotiationId, fwdErr)
 		}
 	}
 
@@ -1587,9 +1599,19 @@ func (s *OtcServer) InterbankCounterOffer(ctx context.Context, req *pb.Interbank
 	if currentStatus != "PENDING_BUYER" && currentStatus != "PENDING_SELLER" {
 		return nil, status.Errorf(codes.FailedPrecondition, "negotiation is in terminal state: %s", currentStatus)
 	}
-	// The partner bank is always the buyer for incoming negotiations.
-	// Counter-offer is only allowed when it is the buyer's turn.
-	if currentStatus != "PENDING_BUYER" {
+
+	// Outbound negs have seller_routing_number set (bank4 is seller); inbound negs do not.
+	var sellerRoutingNum sql.NullInt32
+	_ = s.DB.QueryRowContext(ctx, `SELECT seller_routing_number FROM otc_negotiations WHERE id = $1`, localID).Scan(&sellerRoutingNum)
+	isOutbound := sellerRoutingNum.Valid && sellerRoutingNum.Int32 != 0
+
+	// For outbound: bank4 is seller and counter-offers on PENDING_SELLER; sets to PENDING_BUYER (our turn).
+	// For inbound: bank4 is buyer and counter-offers on PENDING_BUYER; sets to PENDING_SELLER (our turn).
+	allowedStatus, newStatus := "PENDING_BUYER", "PENDING_SELLER"
+	if isOutbound {
+		allowedStatus, newStatus = "PENDING_SELLER", "PENDING_BUYER"
+	}
+	if currentStatus != allowedStatus {
 		return nil, status.Error(codes.FailedPrecondition, "not your turn")
 	}
 
@@ -1597,10 +1619,10 @@ func (s *OtcServer) InterbankCounterOffer(ctx context.Context, req *pb.Interbank
 	if _, err = s.DB.ExecContext(ctx, `
 		UPDATE otc_negotiations
 		SET amount = $1, price_per_stock = $2, settlement_date = $3, premium = $4,
-		    last_modified = $5, modified_by_id = 0, modified_by_type = 'INTERBANK', status = 'PENDING_SELLER'
-		WHERE id = $6`,
+		    last_modified = $5, modified_by_id = 0, modified_by_type = 'INTERBANK', status = $6
+		WHERE id = $7`,
 		req.Amount, req.PricePerUnit, settleDateOnly(req.SettlementDate), req.Premium,
-		now, localID,
+		now, newStatus, localID,
 	); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to update negotiation: %v", err)
 	}

--- a/services/otc-service/handlers/interbank_outgoing.go
+++ b/services/otc-service/handlers/interbank_outgoing.go
@@ -829,6 +829,122 @@ func (s *OtcServer) executeInterbankAcceptOutgoing(ctx context.Context, localNeg
 	return nil
 }
 
+// forwardBuyerCounterOfferToPartner sends PUT /negotiations/{sellerRn}/{partnerNegID} to the seller's bank
+// (used when we are the buyer and submit a counter-offer on an outbound interbank negotiation).
+func (s *OtcServer) forwardBuyerCounterOfferToPartner(ctx context.Context, negID int64, amount int32, pricePerStock, premium float64, settlementDate string) error {
+	type partyID struct {
+		RoutingNumber int    `json:"routingNumber"`
+		ID            string `json:"id"`
+	}
+	type money struct {
+		Currency string  `json:"currency"`
+		Amount   float64 `json:"amount"`
+	}
+	type stock struct {
+		Ticker string `json:"ticker"`
+	}
+	type putBody struct {
+		Stock              stock   `json:"stock"`
+		SettlementDate     string  `json:"settlementDate"`
+		PricePerUnit       money   `json:"pricePerUnit"`
+		Premium            money   `json:"premium"`
+		BuyerID            partyID `json:"buyerId"`
+		SellerID           partyID `json:"sellerId"`
+		Amount             int32   `json:"amount"`
+		LastModifiedBy     partyID `json:"lastModifiedBy"`
+		BuyerAccountNumber string  `json:"buyerAccountNumber"`
+	}
+
+	var ticker, currency string
+	var sellerExtID, buyerAcctNum sql.NullString
+	var sellerRoutingNum sql.NullInt32
+	var partnerNegID sql.NullString
+	var buyerID int64
+	err := s.DB.QueryRowContext(ctx, `
+		SELECT ticker, currency, seller_routing_number, seller_external_id,
+		       buyer_id, buyer_account_number, partner_negotiation_id
+		FROM otc_negotiations WHERE id = $1`, negID,
+	).Scan(&ticker, &currency, &sellerRoutingNum, &sellerExtID, &buyerID, &buyerAcctNum, &partnerNegID)
+	if err != nil {
+		return fmt.Errorf("load negotiation: %w", err)
+	}
+	if !sellerRoutingNum.Valid {
+		return fmt.Errorf("no seller routing number stored for negotiation %d", negID)
+	}
+	if !partnerNegID.Valid || partnerNegID.String == "" {
+		return fmt.Errorf("no partner_negotiation_id stored for negotiation %d", negID)
+	}
+
+	bank, err := otcInterbank.ResolveBankByRoutingNumber(fmt.Sprintf("%d", sellerRoutingNum.Int32))
+	if err != nil {
+		return fmt.Errorf("resolve seller bank: %w", err)
+	}
+
+	ownRouting := otcOwnRoutingInt()
+	b := putBody{
+		Stock:              stock{Ticker: ticker},
+		SettlementDate:     settlementDate,
+		PricePerUnit:       money{Currency: currency, Amount: pricePerStock},
+		Premium:            money{Currency: currency, Amount: premium},
+		BuyerID:            partyID{RoutingNumber: ownRouting, ID: fmt.Sprintf("%d", buyerID)},
+		SellerID:           partyID{RoutingNumber: int(sellerRoutingNum.Int32), ID: sellerExtID.String},
+		Amount:             amount,
+		LastModifiedBy:     partyID{RoutingNumber: ownRouting, ID: fmt.Sprintf("%d", buyerID)},
+		BuyerAccountNumber: buyerAcctNum.String,
+	}
+	data, _ := json.Marshal(b)
+	url := fmt.Sprintf("%s/negotiations/%d/%s", bank.BankURL, sellerRoutingNum.Int32, partnerNegID.String)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewReader(data))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("X-Api-Key", bank.APIKey)
+	resp, err := (&http.Client{Timeout: 10 * time.Second}).Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("http call: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("partner returned status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// notifyOutboundRejection sends DELETE /negotiations/{sellerRn}/{partnerNegID} to the seller's bank
+// (used when we are the buyer and reject an outbound interbank negotiation).
+func (s *OtcServer) notifyOutboundRejection(ctx context.Context, negID int64) error {
+	var sellerRoutingNum sql.NullInt32
+	var partnerNegID sql.NullString
+	err := s.DB.QueryRowContext(ctx,
+		`SELECT seller_routing_number, partner_negotiation_id FROM otc_negotiations WHERE id = $1`, negID,
+	).Scan(&sellerRoutingNum, &partnerNegID)
+	if err != nil || !sellerRoutingNum.Valid || !partnerNegID.Valid || partnerNegID.String == "" {
+		return fmt.Errorf("load seller routing / partner neg id: %w", err)
+	}
+
+	bank, err := otcInterbank.ResolveBankByRoutingNumber(fmt.Sprintf("%d", sellerRoutingNum.Int32))
+	if err != nil {
+		return fmt.Errorf("resolve seller bank: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/negotiations/%d/%s", bank.BankURL, sellerRoutingNum.Int32, partnerNegID.String)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	httpReq.Header.Set("X-Api-Key", bank.APIKey)
+	resp, err := (&http.Client{Timeout: 10 * time.Second}).Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("http call: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNotFound {
+		return fmt.Errorf("partner returned status %d", resp.StatusCode)
+	}
+	return nil
+}
+
 // executeInterbankAcceptBuyerSide coordinates the 2PC when we are the buyer and bank4 (seller)
 // has accepted. Bank4 called our /accept endpoint (AcceptAsLocal); we form the NEW_TX, send it
 // to bank4, debit our buyer's account on YES, create our buyer-side contract, and send COMMIT.


### PR DESCRIPTION
- Accept both OWN_INTERBANK_API_KEY and PARTNER_API_KEY on /interbank and /otc/interbank/* endpoints so partner bank (Banka 4) can authenticate using its own key
- Fix InterbankCounterOffer turn check and status transition for outbound negotiations (we are buyer, bank4 is seller)
- Forward buyer counter-offers to partner bank on outbound negotiations
- Forward rejection to partner bank on outbound negotiations
- Add forwardBuyerCounterOfferToPartner and notifyOutboundRejection helpers