### PR TITLE
fix(otc): fix outgoing and incoming interbank API key usage

### DIFF
--- a/services/api-gateway/handlers/otc.go
+++ b/services/api-gateway/handlers/otc.go
@@ -515,8 +515,7 @@ func SetPublicMode(portfolioClient pb_portfolio.PortfolioServiceClient) gin.Hand
 
 func GetPublicStock(client pb.OtcServiceClient) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		apiKey := os.Getenv("OWN_INTERBANK_API_KEY")
-		if apiKey == "" || c.GetHeader("X-Api-Key") != apiKey {
+		if !validateOtcInterbankKey(c) {
 			c.Status(http.StatusUnauthorized)
 			return
 		}

--- a/services/api-gateway/interbank/routing.go
+++ b/services/api-gateway/interbank/routing.go
@@ -35,7 +35,7 @@ func ResolveBankByRoutingNumber(routingNumber string) (BankInfo, error) {
 			RoutingNumber: routingNumber,
 			BankName:      os.Getenv("PARTNER_BANK_NAME"),
 			BankURL:       os.Getenv("PARTNER_BANK_URL"),
-			APIKey:        os.Getenv("PARTNER_API_KEY"),
+			APIKey:        os.Getenv("OWN_INTERBANK_API_KEY"),
 		}, nil
 	default:
 		return BankInfo{}, fmt.Errorf("unknown routing number: %s", routingNumber)

--- a/services/api-gateway/interbank/routing_test.go
+++ b/services/api-gateway/interbank/routing_test.go
@@ -37,14 +37,15 @@ func TestResolveBankByRoutingNumber_Partner(t *testing.T) {
 	t.Setenv("PARTNER_ROUTING_NUMBER", "444")
 	t.Setenv("PARTNER_BANK_NAME", "Banka 4")
 	t.Setenv("PARTNER_BANK_URL", "https://banka-4.example.com")
-	t.Setenv("PARTNER_API_KEY", "test-key")
+	t.Setenv("PARTNER_API_KEY", "their-key")
+	t.Setenv("OWN_INTERBANK_API_KEY", "our-key")
 
 	info, err := ResolveBankByRoutingNumber("444")
 	require.NoError(t, err)
 	assert.Equal(t, "444", info.RoutingNumber)
 	assert.Equal(t, "Banka 4", info.BankName)
 	assert.Equal(t, "https://banka-4.example.com", info.BankURL)
-	assert.Equal(t, "test-key", info.APIKey)
+	assert.Equal(t, "our-key", info.APIKey)
 }
 
 func TestResolveBankByRoutingNumber_Unknown(t *testing.T) {

--- a/services/otc-service/interbank/routing.go
+++ b/services/otc-service/interbank/routing.go
@@ -40,7 +40,7 @@ func ResolveBankByRoutingNumber(routingNumber string) (BankInfo, error) {
 			RoutingNumber: routingNumber,
 			BankName:      os.Getenv("PARTNER_BANK_NAME"),
 			BankURL:       os.Getenv("PARTNER_BANK_URL"),
-			APIKey:        os.Getenv("PARTNER_API_KEY"),
+			APIKey:        os.Getenv("OWN_INTERBANK_API_KEY"),
 		}, nil
 	default:
 		return BankInfo{}, fmt.Errorf("unknown routing number: %s", routingNumber)

--- a/services/otc-service/interbank/routing_test.go
+++ b/services/otc-service/interbank/routing_test.go
@@ -37,14 +37,15 @@ func TestResolveBankByRoutingNumber_Partner(t *testing.T) {
 	t.Setenv("PARTNER_ROUTING_NUMBER", "444")
 	t.Setenv("PARTNER_BANK_NAME", "Banka 4")
 	t.Setenv("PARTNER_BANK_URL", "https://banka-4.example.com")
-	t.Setenv("PARTNER_API_KEY", "test-key")
+	t.Setenv("PARTNER_API_KEY", "their-key")
+	t.Setenv("OWN_INTERBANK_API_KEY", "our-key")
 
 	info, err := ResolveBankByRoutingNumber("444")
 	require.NoError(t, err)
 	assert.Equal(t, "444", info.RoutingNumber)
 	assert.Equal(t, "Banka 4", info.BankName)
 	assert.Equal(t, "https://banka-4.example.com", info.BankURL)
-	assert.Equal(t, "test-key", info.APIKey)
+	assert.Equal(t, "our-key", info.APIKey)
 }
 
 func TestResolveBankByRoutingNumber_Unknown(t *testing.T) {


### PR DESCRIPTION
- routing.go (api-gateway + otc-service): send OWN_INTERBANK_API_KEY on all outgoing requests to partner bank; PARTNER_API_KEY is what they send to us, not what we send to them
- GetPublicStock: use validateOtcInterbankKey so partner bank can authenticate with their own key when fetching our public securities