### PR TITLE
fix(otc): fix interbank counter-offer turn detection and cross-bank e…

### DIFF
--- a/services/otc-service/handlers/grpc_server.go
+++ b/services/otc-service/handlers/grpc_server.go
@@ -934,20 +934,16 @@ func (s *OtcServer) ExerciseContract(ctx context.Context, req *pb.ExerciseContra
 		return nil, status.Error(codes.InvalidArgument, "Contract settlement date has passed")
 	}
 
-	listingID, err := listingIDForTicker(ctx, s.SecuritiesDB, ticker)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "ticker not found: %v", err)
-	}
-
 	// Cross-bank exercise: seller is on partner bank — delegate to 2PC flow.
 	// (otc_saga row is NOT created for cross-bank; 2PC has its own tracking)
+	// Resolve listing ID after the cross-bank check: the stock may be listed only at the partner bank.
 	if sellerType == "INTERBANK" {
 		resp, rerr := s.exerciseCrossBank(ctx, req, tx, sellerID, buyerID, buyerType,
 			amount, strikePrice, currency, ticker, settlementDate)
 		if rerr == nil && buyerType != "EMPLOYEE" {
 			var mktPrice float64
 			if qErr := s.SecuritiesDB.QueryRowContext(ctx,
-				`SELECT price FROM listing WHERE id = $1`, listingID).Scan(&mktPrice); qErr == nil {
+				`SELECT price FROM listing WHERE ticker = $1`, ticker).Scan(&mktPrice); qErr == nil {
 				profit := (mktPrice-strikePrice)*float64(amount) - premium
 				if profit > 0 {
 					t := time.Now()
@@ -956,6 +952,11 @@ func (s *OtcServer) ExerciseContract(ctx context.Context, req *pb.ExerciseContra
 			}
 		}
 		return resp, rerr
+	}
+
+	listingID, err := listingIDForTicker(ctx, s.SecuritiesDB, ticker)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "ticker not found: %v", err)
 	}
 
 	totalCost := strikePrice * float64(amount)
@@ -1600,10 +1601,11 @@ func (s *OtcServer) InterbankCounterOffer(ctx context.Context, req *pb.Interbank
 		return nil, status.Errorf(codes.FailedPrecondition, "negotiation is in terminal state: %s", currentStatus)
 	}
 
-	// Outbound negs have seller_routing_number set (bank4 is seller); inbound negs do not.
-	var sellerRoutingNum sql.NullInt32
-	_ = s.DB.QueryRowContext(ctx, `SELECT seller_routing_number FROM otc_negotiations WHERE id = $1`, localID).Scan(&sellerRoutingNum)
-	isOutbound := sellerRoutingNum.Valid && sellerRoutingNum.Int32 != 0
+	// Outbound: bank4 is seller (seller_type='INTERBANK'). Inbound: bank4 is buyer (buyer_type='INTERBANK').
+	// Don't use seller_routing_number — partner banks include our routing number there, making it non-zero for inbound too.
+	var sellerType string
+	_ = s.DB.QueryRowContext(ctx, `SELECT seller_type FROM otc_negotiations WHERE id = $1`, localID).Scan(&sellerType)
+	isOutbound := sellerType == "INTERBANK"
 
 	// For outbound: bank4 is seller and counter-offers on PENDING_SELLER; sets to PENDING_BUYER (our turn).
 	// For inbound: bank4 is buyer and counter-offers on PENDING_BUYER; sets to PENDING_SELLER (our turn).

--- a/services/otc-service/handlers/interbank_outgoing.go
+++ b/services/otc-service/handlers/interbank_outgoing.go
@@ -355,7 +355,17 @@ func (s *OtcServer) exerciseCrossBank(
 		totalCostToPay, buyerAccountID)
 
 	// Step 4: Add shares to buyer's portfolio.
+	// The stock may be listed only at the partner bank; upsert a placeholder listing so the portfolio entry is valid.
 	listingID, _ := listingIDForTicker(ctx, s.SecuritiesDB, ticker)
+	if listingID == 0 {
+		_ = s.SecuritiesDB.QueryRowContext(ctx, `
+			INSERT INTO listing (ticker, name, exchange_id, price, type)
+			SELECT $1, $1, id, $2, 'STOCK'
+			FROM stock_exchanges LIMIT 1
+			ON CONFLICT (ticker) DO UPDATE SET ticker = EXCLUDED.ticker
+			RETURNING id`, ticker, strikePrice,
+		).Scan(&listingID)
+	}
 	_, _ = s.PortfolioDB.ExecContext(ctx, `
 		INSERT INTO portfolio_entry (user_id, user_type, listing_id, amount, buy_price, account_id)
 		VALUES ($1, $2, $3, $4, $5, $6)
@@ -735,6 +745,7 @@ func (s *OtcServer) executeInterbankAcceptOutgoing(ctx context.Context, localNeg
 					Asset:   ibOutAsset{Type: "MONAS", Asset: &ibOutAssetInner{Currency: currency.String}},
 				},
 				{ // posting 4: buyer (bank4) receives option right — triggers bank4's commitOptionPosting to create their mirror contract
+				  // NOTE: posting 3 (seller -1 OPTION at routing 888) is intentionally omitted — bank4 rejects OPTION postings for non-444 routing numbers.
 					Account: ibOutAccount{Type: "PERSON", ID: &ibOutPartyID{RoutingNumber: int(buyerRoutingNum.Int32), ID: buyerExtID.String}},
 					Amount:  1,
 					Asset: ibOutAsset{Type: "OPTION", Asset: &ibOutAssetInner{


### PR DESCRIPTION
…xercise

- InterbankCounterOffer: detect inbound/outbound by seller_type instead of seller_routing_number; partner banks include our routing number in seller_routing_number for inbound offers, making the old check always true and causing false "not your turn" rejections on their second counter-offer
- ExerciseContract: move listingIDForTicker after the cross-bank branch so exercises on partner-bank stocks (not in our securities DB) are not blocked before reaching exerciseCrossBank
- exerciseCrossBank: upsert a placeholder listing when the ticker is absent from our securities DB so the portfolio entry gets a valid listing_id
- Document why posting 3 is omitted from executeInterbankAcceptOutgoing