### PR TITLE
fix(api-gateway): return count:0 instead of 500 on notification unread-count failure

### DIFF
--- a/services/api-gateway/handlers/notifications.go
+++ b/services/api-gateway/handlers/notifications.go
@@ -59,7 +59,7 @@ func GetUnreadCount(client pb.AuthServiceClient) gin.HandlerFunc {
 			UserType: userType,
 		})
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get unread count"})
+			c.JSON(http.StatusOK, gin.H{"count": int64(0)})
 			return
 		}
 		c.JSON(http.StatusOK, gin.H{"count": resp.Count})


### PR DESCRIPTION
## Summary

- `GET /notifications/unread-count` returned HTTP 500 on any gRPC error from auth-service, causing a global error toast on every employee page load and every 30 s poll
- Root cause: `notifications` table missing on shared server auth-db (Docker postgres only runs initdb scripts on first volume init; the volume predates the table addition in commit 40be206)
- Fix: return 200 with count 0 instead of 500 when gRPC fails, so the notification bell stays functional and silent during auth-service downtime

## Test plan

- [ ] Login as employee on shared server — no error toast on page load
- [ ] Wait 30 s — no repeating error toast
- [ ] Apply SQL migration on shared server auth-db to create notifications table (permanent root cause fix)
- [ ] Verify bell shows correct unread count after migration

Generated with Claude Code