### PR TITLE
fix(interbank): fix vote response format for Bank4 and make accept CO…

### DIFF
--- a/services/api-gateway/handlers/interbank.go
+++ b/services/api-gateway/handlers/interbank.go
@@ -152,13 +152,16 @@ func handleNewTx(c *gin.Context, client pb.PaymentServiceClient, otcClient pb_ot
 			PartnerNegExternalId: partnerNegExternalID,
 		})
 		vote := "NO"
-		reason := ""
+		type voteReason struct {
+			Reason string `json:"reason"`
+		}
+		reasons := []voteReason{}
 		if otcErr == nil && otcResp != nil && otcResp.Vote == "YES" {
 			vote = "YES"
-		} else if otcResp != nil {
-			reason = otcResp.Reason
+		} else if otcResp != nil && otcResp.Reason != "" {
+			reasons = append(reasons, voteReason{Reason: otcResp.Reason})
 		}
-		c.JSON(http.StatusOK, gin.H{"vote": vote, "reasons": []string{reason}})
+		c.JSON(http.StatusOK, gin.H{"vote": vote, "reasons": reasons})
 		return
 	}
 

--- a/services/otc-service/handlers/interbank_outgoing.go
+++ b/services/otc-service/handlers/interbank_outgoing.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os"
 	"time"
@@ -148,6 +149,9 @@ func executeOtcOutgoing2PC(ctx context.Context, bank otcInterbank.BankInfo, req 
 	txID := otcIbTransactionID{RoutingNumber: ownRouting, ID: otcGenerateUUID()}
 	idemKey := otcIbIdempotenceKey{RoutingNumber: ownRouting, LocallyGeneratedKey: otcGenerateUUID()}
 
+	log.Printf("[exercise 2PC] partnerRouting=%d partnerNegID=%q ticker=%q stockAmount=%d totalCost=%.4f txID=%s",
+		req.partnerRoutingNum, req.partnerNegotiationID, req.ticker, req.stockAmount, req.totalCost, txID.ID)
+
 	newTxResp, err := otcSendInterbankRequest(ctx, bankURL, bank.APIKey, otcIbEnvelope{
 		IdempotenceKey: idemKey,
 		MessageType:    "NEW_TX",
@@ -199,6 +203,7 @@ func executeOtcOutgoing2PC(ctx context.Context, bank otcInterbank.BankInfo, req 
 	if err := json.NewDecoder(newTxResp.Body).Decode(&voteResp); err != nil {
 		return "NO", fmt.Errorf("decode vote response: %w", err)
 	}
+	log.Printf("[exercise 2PC] vote=%q reasons=%v txID=%s", voteResp.Vote, voteResp.Reasons, txID.ID)
 	if voteResp.Vote != "YES" {
 		return "NO", nil
 	}
@@ -1099,11 +1104,32 @@ func (s *OtcServer) executeInterbankAcceptBuyerSide(ctx context.Context, localNe
 		ticker, amount, strikePrice, premium, currency, settlementDate)
 
 	// COMMIT — bank4 will commit their postings (credit seller's MONAS, create authoritative seller contract).
-	_, _ = otcSendInterbankRequest(ctx, bankURL, bank.APIKey, otcIbEnvelope{
+	commitResp, commitErr := otcSendInterbankRequest(ctx, bankURL, bank.APIKey, otcIbEnvelope{
 		IdempotenceKey: otcIbIdempotenceKey{RoutingNumber: ownRouting, LocallyGeneratedKey: otcGenerateUUID()},
 		MessageType:    "COMMIT_TX",
 		Message:        otcIbCommitMessage{TransactionID: txID},
 	})
+	if commitErr != nil || (commitResp != nil && commitResp.StatusCode != http.StatusNoContent) {
+		statusCode := 0
+		if commitResp != nil {
+			statusCode = commitResp.StatusCode
+		}
+		log.Printf("[accept 2PC] COMMIT_TX failed: err=%v status=%d — rolling back local state for neg %d", commitErr, statusCode, localNegID)
+		// Undo local premium debit.
+		_, _ = s.AccountDB.ExecContext(context.Background(),
+			`UPDATE accounts SET balance = balance + $1, available_balance = available_balance + $1
+			 WHERE account_number = $2`, premiumToPay, buyerAcctNum.String)
+		// Remove the locally-created buyer contract so a retry can re-insert it.
+		_, _ = s.DB.ExecContext(context.Background(),
+			`DELETE FROM otc_contracts WHERE negotiation_id = $1`, localNegID)
+		// Best-effort rollback at bank4 so their PreparedTransaction doesn't linger.
+		_, _ = otcSendInterbankRequest(context.Background(), bankURL, bank.APIKey, otcIbEnvelope{
+			IdempotenceKey: otcIbIdempotenceKey{RoutingNumber: ownRouting, LocallyGeneratedKey: otcGenerateUUID()},
+			MessageType:    "ROLLBACK_TX",
+			Message:        otcIbCommitMessage{TransactionID: txID},
+		})
+		return fmt.Errorf("accept COMMIT_TX to bank4 failed (status %d)", statusCode)
+	}
 
 	return nil
 }


### PR DESCRIPTION
…MMIT_TX reliable

- Fix 503 when Bank4 exercises against us: handleNewTx was returning reasons as []string which Bank4 failed to unmarshal into []NoVoteReason; changed to typed struct with json tags
- Fix silent accept failure: executeInterbankAcceptBuyerSide now checks the COMMIT_TX response; on failure it rolls back the local premium debit and buyer contract, sends ROLLBACK_TX to Bank4, and returns an error instead of silently proceeding with a broken state
- Add diagnostic logging to executeOtcOutgoing2PC to surface partnerNegID, vote result, and txID for future debugging of COMMIT_TX 500 errors