### PR TITLE
Add in-app notifications for OTC negotiations, fix dividend history bugs

### DIFF
--- a/services/otc-service/handlers/grpc_server.go
+++ b/services/otc-service/handlers/grpc_server.go
@@ -12,6 +12,7 @@ import (
 
 	amqp "github.com/rabbitmq/amqp091-go"
 
+	pb_auth "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/auth"
 	pb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/otc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -121,6 +122,25 @@ type OtcServer struct {
 	SecuritiesDB *sql.DB // securities_db
 	ExchangeDB   *sql.DB // exchange_db (daily_exchange_rates)
 	AmqpChannel  *amqp.Channel
+	AuthClient   pb_auth.AuthServiceClient
+}
+
+// notifyOtcInApp creates an in-app notification for a negotiation participant via auth-service.
+// Mirrors the email notification pattern (s.publishOtcMsg) used alongside it.
+func (s *OtcServer) notifyOtcInApp(userID int64, userType, title, message, notifType string) {
+	if s.AuthClient == nil || userType == "INTERBANK" {
+		return
+	}
+	_, err := s.AuthClient.CreateNotification(context.Background(), &pb_auth.CreateNotificationRequest{
+		UserId:   userID,
+		UserType: userType,
+		Title:    title,
+		Message:  message,
+		Type:     notifType,
+	})
+	if err != nil {
+		log.Printf("warn: notifyOtcInApp(%d, %s): %v", userID, userType, err)
+	}
 }
 
 func (s *OtcServer) publishOtcMsg(queueName string, msg interface{}) {
@@ -477,6 +497,8 @@ func (s *OtcServer) CounterOffer(ctx context.Context, req *pb.CounterOfferReques
 					"counter_party_name": callerName,
 				})
 			}
+			s.notifyOtcInApp(buyerID, buyerType, "Counter-Offer Received",
+				fmt.Sprintf("%s sent a counter-offer for %s.", callerName, coTicker), "OTC_COUNTER_OFFER")
 		} else if newStatus == "PENDING_SELLER" && sellerType != "INTERBANK" {
 			email, firstName := lookupEmailAndName(s.EmployeeDB, s.ClientDB, sellerID, sellerType)
 			if email != "" {
@@ -488,6 +510,8 @@ func (s *OtcServer) CounterOffer(ctx context.Context, req *pb.CounterOfferReques
 					"counter_party_name": callerName,
 				})
 			}
+			s.notifyOtcInApp(sellerID, sellerType, "Counter-Offer Received",
+				fmt.Sprintf("%s sent a counter-offer for %s.", callerName, coTicker), "OTC_COUNTER_OFFER")
 		}
 	}()
 
@@ -741,6 +765,8 @@ func (s *OtcServer) AcceptNegotiation(ctx context.Context, req *pb.AcceptNegotia
 					"negotiation_id": req.NegotiationId, "ticker": ticker, "status": "ACCEPTED",
 				})
 			}
+			s.notifyOtcInApp(notifyID, notifyType, "OTC Negotiation Accepted",
+				fmt.Sprintf("Your OTC negotiation for %s was accepted.", ticker), "OTC_ACCEPTED")
 		}
 	}()
 	if sellerType != "INTERBANK" {
@@ -811,6 +837,8 @@ func (s *OtcServer) RejectNegotiation(ctx context.Context, req *pb.RejectNegotia
 					"negotiation_id": req.NegotiationId, "ticker": rejTicker, "status": "REJECTED",
 				})
 			}
+			s.notifyOtcInApp(notifyID, notifyType, "OTC Negotiation Rejected",
+				fmt.Sprintf("Your OTC negotiation for %s was rejected.", rejTicker), "OTC_REJECTED")
 		}
 	}()
 

--- a/services/otc-service/main.go
+++ b/services/otc-service/main.go
@@ -10,8 +10,10 @@ import (
 
 	otcdb "github.com/RAF-SI-2025/EXBanka-4-Backend/services/otc-service/db"
 	"github.com/RAF-SI-2025/EXBanka-4-Backend/services/otc-service/handlers"
+	pb_auth "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/auth"
 	pb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/otc"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 const grpcPort = ":50063"
@@ -59,6 +61,12 @@ func main() {
 	}
 	defer func() { _ = exchangeDB.Close() }()
 
+	authConn, err := grpc.NewClient(os.Getenv("AUTH_SERVICE_ADDR"), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		log.Fatalf("failed to connect to auth-service: %v", err)
+	}
+	defer func() { _ = authConn.Close() }()
+
 	var amqpCh *amqp.Channel
 	if amqpURL := os.Getenv("RABBITMQ_URL"); amqpURL != "" {
 		var amqpConn *amqp.Connection
@@ -97,6 +105,7 @@ func main() {
 		SecuritiesDB: securitiesDB,
 		ExchangeDB:   exchangeDB,
 		AmqpChannel:  amqpCh,
+		AuthClient:   pb_auth.NewAuthServiceClient(authConn),
 	}
 	pb.RegisterOtcServiceServer(srv, srvImpl)
 

--- a/services/portfolio-service/handlers/dividend.go
+++ b/services/portfolio-service/handlers/dividend.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	pb "github.com/RAF-SI-2025/EXBanka-4-Backend/shared/pb/portfolio"
+	"github.com/lib/pq"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -53,7 +54,7 @@ func (s *PortfolioServer) GetDividendHistory(ctx context.Context, req *pb.GetDiv
 	}
 	defer func() { _ = rows.Close() }()
 
-	var payouts []*pb.DividendPayout
+	payouts := []*pb.DividendPayout{}
 	for rows.Next() {
 		var dp pb.DividendPayout
 		if err := rows.Scan(
@@ -64,6 +65,35 @@ func (s *PortfolioServer) GetDividendHistory(ctx context.Context, req *pb.GetDiv
 		}
 		payouts = append(payouts, &dp)
 	}
+
+	// Enrich with ticker from securities DB in one query, same pattern as GetWatchlistItems.
+	if s.SecuritiesDB != nil && len(payouts) > 0 {
+		listingIDs := make([]int64, len(payouts))
+		for i, p := range payouts {
+			listingIDs[i] = p.StockListingId
+		}
+		secRows, secErr := s.SecuritiesDB.QueryContext(ctx, `
+			SELECT id, ticker FROM listing WHERE id = ANY($1)`,
+			pq.Array(listingIDs),
+		)
+		if secErr == nil {
+			tickerMap := make(map[int64]string)
+			for secRows.Next() {
+				var id int64
+				var ticker string
+				if err := secRows.Scan(&id, &ticker); err == nil {
+					tickerMap[id] = ticker
+				}
+			}
+			_ = secRows.Close()
+			for _, p := range payouts {
+				if ticker, ok := tickerMap[p.StockListingId]; ok {
+					p.Ticker = ticker
+				}
+			}
+		}
+	}
+
 	return &pb.GetDividendHistoryResponse{Payouts: payouts}, nil
 }
 


### PR DESCRIPTION
- otc-service: wire AuthClient gRPC connection and send in-app notifications (alongside existing emails) on counter-offer, accept, and reject so the other negotiation party sees a bell notification
- portfolio-service: GetDividendHistory no longer returns a nil slice (serializes as null, crashing the frontend); enrich payouts with ticker from securities DB, same pattern as GetWatchlistItems