### PR TITLE
Replace personal test email with generic dunja@banka.rs in client seed

### DIFF
--- a/services/client-service/db/schema.sql
+++ b/services/client-service/db/schema.sql
@@ -17,8 +17,8 @@ CREATE TABLE clients (
 
 -- Seed test client used by Cypress e2e tests (password: taraDunjic123)
 INSERT INTO clients (first_name, last_name, jmbg, date_of_birth, gender, email, phone_number, address, username, password, active)
-SELECT 'Tara', 'Dunjic', '2809002785018', '2002-09-28', 'F', 'ddimitrijevi822rn@raf.rs', '+381601234567', 'Bulevar oslobodjenja 1, Beograd', 'ddimitrijevi822rn', '$2a$10$KZiA1q9EmV1PlRI0/m7i7e8a2GgitlGORbgHEbb9Y9ZUNYpxyfY.u', true
-WHERE NOT EXISTS (SELECT 1 FROM clients WHERE email = 'ddimitrijevi822rn@raf.rs');
+SELECT 'Tara', 'Dunjic', '2809002785018', '2002-09-28', 'F', 'dunja@banka.rs', '+381601234567', 'Bulevar oslobodjenja 1, Beograd', 'dunja', '$2a$10$KZiA1q9EmV1PlRI0/m7i7e8a2GgitlGORbgHEbb9Y9ZUNYpxyfY.u', true
+WHERE NOT EXISTS (SELECT 1 FROM clients WHERE email = 'dunja@banka.rs');
 
 -- Seed second test client for OTC testing (password: markoMarkovic123)
 INSERT INTO clients (first_name, last_name, jmbg, date_of_birth, gender, email, phone_number, address, username, password, active)


### PR DESCRIPTION
Avoids using a real person's email address as the hardcoded seed client credential.